### PR TITLE
Add GECKO mappings as xrefs to main OWL files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,28 +231,32 @@ MAP_TSV := mappings/index.tsv \
            mappings/koges-mapping.tsv \
            mappings/gcs-mapping.tsv \
            mappings/genomics-england-mapping.tsv \
+           mappings/maelstrom-mapping.tsv \
            mappings/saprin-mapping.tsv \
            mappings/vukuzazi-mapping.tsv
 
-mappings/index.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/index.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ Index > $@
 
-mappings/properties.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/properties.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ Properties > $@
 
-mappings/koges-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/koges-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ KoGES > $@
 
-mappings/gcs-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/gcs-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ GCS > $@
 
-mappings/genomics-england-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/genomics-england-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ GenomicsEngland > $@
 
-mappings/saprin-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/maelstrom-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
+	python3 $^ Maelstrom > $@
+
+mappings/saprin-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ SAPRIN > $@
 
-mappings/vukuzazi-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+mappings/vukuzazi-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx
 	python3 $^ Vukuzazi > $@
 
 # GECKO plus OBO terms
@@ -274,6 +278,7 @@ build/gecko-full.owl: build/gecko.owl build/mapping/index.owl | build/robot.jar
 XREFS := build/koges-xrefs.tsv \
          build/gcs-xrefs.tsv \
          build/genomics-england-xrefs.tsv \
+         build/maelstrom-xrefs.tsv \
          build/saprin-xrefs.tsv \
          build/vukuzazi-xrefs.tsv
 
@@ -287,6 +292,7 @@ build/%-xrefs.tsv: src/create_xref_template.py mappings/%-mapping.tsv mappings/i
 MAPPINGS := build/mapping/koges-gecko.ttl \
             build/mapping/gcs-gecko.ttl \
             build/mapping/genomics-england-gecko.ttl \
+            build/mapping/maelstrom-gecko.ttl \
             build/mapping/saprin-gecko.ttl \
             build/mapping/vukuzazi-gecko.ttl
 

--- a/data/maelstrom.yml
+++ b/data/maelstrom.yml
@@ -401,7 +401,7 @@
 - "name": "Reproduction"
   "title":
     "en": "Birth, pregnancy and reproductive health history"
-    "fr": " Naissance, grossesse et antécédents de santé reproductive"
+    "fr": "Naissance, grossesse et antécédents de santé reproductive"
   "description":
     "en": "Information about birth and current or past reproductive health history\
       \ of mothers and fathers."
@@ -519,7 +519,7 @@
     "terms": []
   - "name": "Life_dev"
     "title":
-      "en": "Life course development (under development)"
+      "en": "Life course development"
       "fr": "Développement au cours de la vie"
     "description":
       "en": "Information about child development (e.g. motor, social, emotional and\
@@ -1689,8 +1689,8 @@
     "terms": []
   - "name": "Beliefs_values"
     "title":
-      "en": "Beliefs and values (under development)"
-      "fr": "Croyances et valeurs (en développement)"
+      "en": "Beliefs and values"
+      "fr": "Croyances et valeurs"
     "description":
       "en": "Information about concepts that an individual hold to be true or important,\
         \ which determine attitudes and opinions (e.g. social views, faith, sense\
@@ -1703,9 +1703,8 @@
     "terms": []
   - "name": "Other_life_events"
     "title":
-      "en": "Other life events, plans and beliefs (under development)"
-      "fr": "Autres informations en lien avec les événements de vie, plans et croyances\
-        \ (en développement)"
+      "en": "Other life events, plans and beliefs"
+      "fr": "Autres informations en lien avec les événements de vie, plans et croyances"
     "description":
       "en": "Information about other events, plans and personal beliefs."
       "fr": "Informations au sujet d’autres événements, plans et croyances personnelles."

--- a/mappings/gcs-mapping.tsv
+++ b/mappings/gcs-mapping.tsv
@@ -1,1001 +1,1001 @@
-Field Label	Class Type	GECKO Label	Definition	Comment																			
-LABEL	CLASS_TYPE	C % SPLIT=|																					
-Identity		GCS	Identity and contact information																				
-Demographic Info	equivalent	demographic data	Demographic characteristics: sex, age, ethnicity, marital status, education																				
-Family members	subclass	family and household structure	Characteristics of relatives in the household																				
-Residence	equivalent	residence	The residential area (urban/rural), structure of the house, and duration of residing in the house																				
-Water and fuel source		GCS	Water source, heat and fuel system, and cooking method																				
-Job	equivalent	occupation	The names of all jobs the participant has had and the duration of work																				
-Food preservation and cooking		GCS	Food preservation, frying, boiling, BBQ, steaming, ‚Ä¶																				
-Properties		GCS	Transferable and non-transferable belongings and wealth score (Multiple Correspondence Analysis)																				
-Medical History	equivalent	clinical history	Suffering from any disease at the baseline of cohort																				
-Chief complaints		GCS	The complaints of participants from their physical or mental sufferings																				
-Cancer History	equivalent	clinical history of cancer	History of cancer, site, and age diagnosed in the participant or any of his/her relatives																				
-Smoking	equivalent	tobacco	Ever or current smoker, age of use, type, number per day and days per week																				
-Opium use	equivalent	opiate use history	Ever or current user, age and route of use, type, time per day and days per week																				
-Alcohol use	equivalent	alcohol	Ever or current user, age of use, type, quantity per episode and episodes per month																				
-Drug history (1)	equivalent	recreational drug use history	The main created categories of drugs consumed by participants																				
-Drug History (2)	equivalent	recreational drug use history	The exact name, duration, dose, and frequency of drugs consumed																				
-Oral health	equivalent	oral health history	Decayed, filled, and missing teeth along with the age of the participant in each of these occasions																				
-Tea		GCS	Tea temperature, type of tea, and type of habit for drinking the tea																				
-Physical activity	equivalent	physical activity	The duration and intensity of physical activities during working and leasure times of the day, and Metabolic Equivalent Task (MET)																				
-Animal contact		GCS	The age of the participant in contact with animals, the duration and intensity of animal contact, and the type of animal																				
-Anthropometric measurements	equivalent	anthropometry	Physically measured height, weight, waist circumference, hip circumference and data of pictogram																				
-Blood pressure measurements	equivalent	blood pressure	Both systolic and diastolic blood pressure measured in sitting position twice from each arm																				
-Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result	Units of food categories consumed per day																				
-Lab markers		GCS	Biochemical markers																				
-PID			The Unique Id for eatch participant																				
-FirstName			The first name of participant.																				
-LastName			The last name of participant.																				
-Province	subclass	residence	Specifies the participant Province of Residence																				
-District	subclass	residence	Specifies the participant District of Residence																				
-City	subclass	residence	Specifies the participant City of Residence																				
-Subdistrict	subclass	residence	Specifies the participant Subdistrict of Residence																				
-Village	subclass	residence	Specifies the participant Village of Residence																				
-Street	subclass	residence	Specifies the participant Street of Residence																				
-Alley	subclass	residence	Specifies the participant Alley of Residence																				
-CV name	subclass	residence	Specifies the names of cities or villages in one variable																				
-City_Village	subclass	residence	Specifies residence in cities or villages																				
-HouseNumber	subclass	residence	Specifies the participant's House Number of Residence																				
-ZipCode	subclass	residence	Specifies the participant's Zip Code of Residence																				
-HomePhone			Specifies the participants Home Phone																				
-AreaCode			Specifies the participant's home Phone Area Code																				
-CellPhone			Specifies the participant's Cell phone number																				
-HealthCenter			participant related to this health center(the participant covered by this health center)																				
-FamilyMemPhone			Specifies the phone number of one of participant's family members																				
-FamilyMemAreaCode			Specifies the area code of the phone number of one of participant's family members																				
-FamilyMemName			Specifies the name of one family member of the participant																				
-FriendName			Specifies the name of one of friends of the participant																				
-FriendProvince			Specifies the province in which the friend of the participant resides																				
-FriendDistrict			Specifies the district in which the friend of the participant resides																				
-FriendCity			Specifies the city in which the friend of the participant resides																				
-FriendSubdistrict			Specifies the subdistrict in which the friend of the participant resides																				
-FriendVillage			Specifies the village in which the friend of the participant resides																				
-FriendStreet			Specifies the street in which the friend of the participant resides																				
-FriendAlley			Specifies the alley in which the friend of the participant resides																				
-FriendHouseNumber			Specifies the house number in which the friend of the participant resides																				
-FriendZipCode			Specifies the zip code in which the friend of the participant resides																				
-FriendHomePhone			Specifies the phone number of the participant's friend																				
-FriendAreaCode			Specifies the area code of the phone number of participant's friend																				
-FriendCellPhone			Specifies the cell phone number of participant's friend																				
-PlaceOfInterview			Specifies the participant interview place																				
-InterviewPDate_Y			participant year of Interview date in Shamsi format																				
-InterviewPDate_M			participant month of Interview date in Shamsi format																				
-InterviewPDate_D			participant Day of Interview date in Shamsi format																				
-Gender	equivalent	gender	Specifies the participant Gender																				
-BdatePDate_Y	subclass	age/birthdate	Year of participant Birth date in Shamsi format																				
-BdatePDate_M	subclass	age/birthdate	Month of participant Birth date in Shamsi format																				
-BdatePDate_D	subclass	age/birthdate	Day of participant Birth date in Shamsi format																				
-Age_self	subclass	age/birthdate	Specifies the self-report participant age in inteview time																				
-Age_new	subclass	age/birthdate	Age calculated from birth date and interview date																				
-Ethnicity	equivalent	ethnicity/race	Specifies the participant Ethnicity																				
-ethnicity_new	subclass	ethnicity/race	Specifies ethnicity by Turkmen or Non-turkmen																				
-MaritalStatus	equivalent	marital status value	Specifies the participant marital status																				
-marital_new	subclass	marital status value	Specifies marital status into married or non-married																				
-Education	equivalent	education	Specifies the participant Education Level																				
-FamilyInHousehold	subclass	family and household structure	Specifies the number of participant family living in the household																				
-BrothersN	subclass	family and household structure	Specifies participant No. of Brothers																				
-StepbrothersN	subclass	family and household structure	Specifies participant No. of Step brothers																				
-SistersN	subclass	family and household structure	Specifies participant No. of Sisters																				
-Stepsisters	subclass	family and household structure	Specifies participant No. of Step sisters																				
-Sons	subclass	family and household structure	Specifies participant No. of Sons																				
-Daughters	subclass	family and household structure	Specifies participant No. of Daughters																				
-TwinYesNo	subclass	family and household structure	Specifies whether the participant has twin brother or sister																				
-TwinAlive	subclass	family and household structure	Specifies whether the twin of the participant is alive																				
-ResDuration_1	subclass	residence	Specifies the participant first residence history Duration																				
-ResCitVill_1	subclass	residence	Specifies the participant first residence history in Village or City																				
-ResDistrict_1	subclass	residence	Specifies the participant first residence history District																				
-ResCitVillname_1	subclass	residence	Specifies the participant first residence history City or village name																				
-ResHouseType_1	subclass	residence	Specifies the participant first residence history House Type																				
-ResDuration_2	subclass	residence	Specifies the participant second residence history Duration																				
-ResCitVill_2	subclass	residence	Specifies the participant second residence history in Village or City																				
-ResDistrict_2	subclass	residence	Specifies the participant second residence history District																				
-ResCitVillname_2	subclass	residence	Specifies the participant second residence history City or village name																				
-ResHouseType_2	subclass	residence	Specifies the participant second residence history House Type																				
-ResDuration_3	subclass	residence	Specifies the participant third residence history Duration																				
-ResCitVill_3	subclass	residence	Specifies the participant third residence history in Village or City																				
-ResDistrict_3	subclass	residence	Specifies the participant third residence history District																				
-ResCitVillname_3	subclass	residence	Specifies the participant third residence history City or village name																				
-ResHouseType_3	subclass	residence	Specifies the participant third residence history House Type																				
-FoodWatSource			Specifies participant used water source																				
-FoodWatYearsPipe			Specifies how many years participant used pipe water																				
-FoodWatPriorPipeSource			Specifies what water source participant used prior to pipe water																				
-HeatAndFuelDuration_1			Specifies the duration the participant Used Heating or Fuel system, first history																				
-HeatingSystemType_1			Specifies the participant Used Heating Type, first history																				
-HeatMethod_1			Specifies the participant Used Heating Type of fuel, first history																				
-CookingMethod_1			Specifies the participant Used Cooking Type of fuel, first history																				
-HeatAndFuelDuration_2			Specifies the duration the participant Used Heating or Fuel system, second history																				
-HeatingSystemType_2			Specifies the participant Used Heating Type, second history																				
-HeatMethod_2			Specifies the participant Used Heating Type of fuel, second history																				
-CookingMethod_2			Specifies the participant Used Cooking Type of fuel, second history																				
-HeatAndFuelDuration_3			Specifies the duration participant Used Heating or Fuel system, third history																				
-HeatingSystemType_3			Specifies the participant Used Heating Type, third history																				
-HeatMethod_3			Specifies the participant Used Heating Type of fuel, third history																				
-CookingMethod_3			Specifies the participant Used Cooking Type of fuel, third history																				
-WorkEverWorkedFlag	subclass	occupation	Working for at least one year of full-time job																				
-WorkAgeBegan	subclass	occupation	Specifies participant start work age																				
-WorkCurrently	subclass	occupation	Specifies participant work now																				
-JobsStartAge	subclass	occupation	Age of starting the job for last history																				
-JobsEndAge	subclass	occupation	Age of quiting the job for last history																				
-JobsTitleOccupation	subclass	occupation	Name of the job																				
-JobsTitleOccupationCode	subclass	occupation	Code of the job (Appendix)																				
-JobsHoursPerDay	subclass	occupation	Number of working hours per day																				
-JobsIntensity	subclass	occupation	The intensity of physical activity during the job																				
-JobMonthPerYear	subclass	occupation	Number of working months per year																				
-HusbandOccupation			Code of the husband job (Appendix)	maybe family?																			
-FoodWatFoodPreserve			Specifies How to Preserve foods	is this lifestyle or diet?																			
-FoodWatBreadPreserve			Specifies How to Preserve bread																				
-FoodWatShallowFryVeg			Specifies Using vegetable in Small frying																				
-FoodWatShallowFryMeat			Specifies Using Meat in Small frying																				
-FoodWatShallowFryFish			Specifies Using Fish in Small frying																				
-FoodWatDeepFryVeg			Specifies Using vegetable in Deep frying																				
-FoodWatDeepFryMeat			Specifies Using Meat in Deep frying																				
-FoodWatDeepFryFish			Specifies Using Fish in Deep frying																				
-FoodWatBBQVeg			Specifies Using vegetable in BBQ																				
-FoodWatBBQMeat			Specifies Using Meat in BBQ																				
-FoodWatBBQFish			Specifies Using Fish in BBQ																				
-FoodWatBoilVeg			Specifies Using vegetable Boiling																				
-FoodWatBoilMeat			Specifies Using Meat Boiling																				
-FoodWatBoilFish			Specifies Using Fish Boiling																				
-FoodWatSteamVeg			Specifies Using vegetable Steaming																				
-FoodWatSteamMeat			Specifies Using Meat Steaming																				
-FoodWatSteamFish			Specifies Using Fish Steaming																				
-FoodWatOthVeg			Specifies Using vegetable by any Other method																				
-FoodWatOthMeat			Specifies Using Meat by any Other method																				
-FoodWatOthFish			Specifies Using Fish in by any Other method																				
-FoodWatFreshLocalFruitChange			Specifies the change in using Local Fruit from 1353																				
-FoodWatFreshImportedFruitChange			Specifies the change in using Imported Fruit from 1353																				
-FoodWatFreshVegChange			Specifies the change in using Fresh Vegetable from 1353																				
-FoodWatFreshMeatChange			Specifies the change in using Fresh Meat from 1353																				
-Homeownership			Specifies participant Homeownership status	is this lifestyle or sociodemographic? this is all talking about wealth																			
-house_nonowned			Specifies house owned or non-owned																				
-HomeSize			Specifies participant Home Area	residence?																			
-PropertyAutoOwned			If the participant has personal car select yes if no select no																				
-PropertyAutoYears			Specifies the length of time that the participant has a personal car(Year)																				
-PropertyMotorcycleOwned			If the participant has Motorcycle select yes if no select no																				
-PropertyMotorcycleYears			Specifies the length of time that the participant has Motorcycle(Year)																				
-PropertyColorTVOwned			If the participant has Color TV select yes if no select no																				
-PropertyColorTVYears			Specifies the length of time that the participant has Color TV(Year)																				
-PropertyBandWTVOwned			If the participant has BandW TV select yes if no select no																				
-PropertyBandWTVYears			Specifies the length of time that the participant has BandW TV(Year)																				
-PropertyIndoorBathOwned			If the participant has Indoor Bath room select yes if no select no																				
-PropertyIndoorBathYears			Specifies the length of time that the participant has Indoor Bath room(Year)																				
-PropertyVacuumOwned			If the participant has Vacuum cleaner select yes if no select no																				
-PropertyVacuumYears			Specifies the length of time that the participant has Vacuum cleaner(Year)																				
-PropertyWashMachOwned			If the participant has Washing machine select yes if no select no																				
-PropertyWashMachYears			Specifies the length of time that the participant has Washing machine(Year)																				
-PropertyRefrigeratorOwned			If the participant has Refrigerator select yes if no select no																				
-PropertyRefrigeratorYears			Specifies the length of time that the participant has Refrigerator(Year)																				
-PropertyFreezerOwned			If the participant has Freezer select yes if no select no																				
-PropertyFreezerYears			Specifies the length of time that the participant has Freezer(Year)																				
-PropertyComputerOwned			If the participant has Computer select yes if no select no																				
-PropertyComputerYears			Specifies the length of time that the participant has Computer(Year)																				
-HomeRooms			Number of rooms in the house																				
-HaveBath			Specifies if the household has bathroom																				
-HaveKitchen			Specifies if the household has kitchen																				
-MCA			Composite wealth score (Multiple Correspondence Analysis)	lifestyle or sociodemographic?																			
-NumberPregnancies		pregnancy history	Specifies the number of Pregnancies for women only																				
-NumberLiveBirths		pregnancy history	Specifies the number of live births for women only																				
-DisRheumaticHeartDx		diagnosis of heart disease	if the diagnosis of Rheumatic Heart Disease was made for participant by a physician																				
-DisRheumaticHeartAge		diagnosis of heart disease	participant age at Rheumatic Heart Disease diagnosis																				
-DisHeartDiseaseDx		diagnosis of heart disease	if the diagnosis of Heart Disease was made for participant by a physician																				
-DisHeartDiseaseAge		diagnosis of heart disease	participant age in first Heart Disease diagnosis																				
-DisStrokeDx		occurrence of stroke	if the diagnosis of Stroke was made for participant by a physician																				
-DisStrokeAge		occurrence of stroke	participant age in first Stroke diagnosis																				
-DisHypertensionDx		diagnosis of hypertension	if the diagnosis of Hypertension was made for participant by a physician																				
-DisHypertensionAge		diagnosis of hypertension	participant age in first Hypertension diagnosis																				
-DisDiabetesDx		diagnosis of diabetes	if the diagnosis of Diabetes was made for participant by a physician																				
-DisDiabetesAge		diagnosis of diabetes	participant age in first Diabetes diagnosis																				
-DisCOPDDx		diagnosis of chronic obstructive pulmonary disease	if the diagnosis of COPD was made for participant by a physician																				
-DisCOPDAge		diagnosis of chronic obstructive pulmonary disease	participant age in first COPD diagnosis																				
-DisRenalFailureDx		diagnosis of renal failure	if the diagnosis of Renal Failure was made for participant by a physician																				
-DisRenalFailureAge		diagnosis of renal failure	participant age in first RenalFailure diagnosis																				
-DisJaundiceDx		diagnosis of jaundice	if the diagnosis of Jaundice was made for participant by a physician																				
-DisJaundiceAge		diagnosis of jaundice	participant age in first Jaundice diagnosis																				
-DisLiverDx		diagnosis of liver failure	if the diagnosis of Chronic Liver Failure was made for participant by a physician																				
-DisLiverAge		diagnosis of liver failure	participant age in first Chronic liver failure diagnosis																				
-DisTBDx		diagnosis of tuberculosis	if the diagnosis of Tuberculosis was made for participant by a physician																				
-DisTBAge		diagnosis of tuberculosis	participant age in first Tuberculosis diagnosis																				
-SurgeryFlag		surgical interventions	If the participant had had any history of surgery																				
-SurgeryType		surgical interventions	Specifies the participant surgery Type																				
-SurgeryAge		surgical interventions	Specifies the participant age in surgery Time																				
-TransfusionFlag			if the participant has had Transfusion history																				
-TransfusionRecentFlag			if the participant has Transfusion history in last month																				
-SymRefluxFlag		occurrence of acid reflux	if the participant has Reflux Symptom history select yes if not select no																				
-SymRefluxWhen		occurrence of acid reflux	when Reflux Symptom happen in First time																				
-SymHeartburnFlag		occurrence of heartburn	if the participant has Heartburn Symptom history select yes if not select no																				
-SymHeartburnWhen		occurrence of heartburn	when Heartburn Symptom happen in First time																				
-SymDifficultSwallowingFlag		occurrence of difficulty swallowing	if the participant has Difficult Swallowing Symptom history select yes if not select no																				
-SymDifficultSwallowingWhen		occurrence of difficulty swallowing	when Difficult Swallowing Symptom happen in First time																				
-SymRefluxPastYearFreq		occurrence of acid reflux	if the participant has Reflux Symptom in past year select yes if not select no																				
-SymRefluxPastYearSeverity		occurrence of acid reflux	Severity Reflux Symptom in past year																				
-SymRefluxPriorYearsFreq		occurrence of acid reflux	if the participant has Reflux Symptom in Prior year select yes if not select no																				
-SymRefluxPriorYearsSeverity		occurrence of acid reflux	Severity Reflux Symptom in Prior year																				
-RefluxHeartburnTXFlag		medication	if participant used drug for Heartburn symptoms select yes if not select no and if participant doesn't have symtom selectLack of signage	should we create medication for heartburn?																			
-WeightLossFlag		clinical history	if the patient has Weightloss in past year select yes if not select no	should we be more specific here?																			
-WeightLossAmount		clinical history	Specifies the amount of weight loss																				
-WeightLossIntent		clinical history	if the patient has Intentional weight loss select Yes if not select no and doesn't have weight loss select I have no weight loss																				
-cancerdxflag		clinical history of cancer	Past history of cancer diagnosed by a physician?																				
-cancerdxage		clinical history of cancer	Year of diagnosis of cancer if detected in participant																				
-cancerdxsite		clinical history of cancer	Original site of cancer																				
-CancRelRelativeCode_1		clinical history of cancer	Specifies the relative of participants with a history of cancer																				
-CancRelAgeDiagnosis_1		clinical history of cancer	Specifies the age of relative when cancer was diagnosed																				
-CancRelSite_1		clinical history of cancer	Specifies the site of cancer in the relative of participant																				
-CancRelICD10_1		clinical history of cancer	Specifies the ICD-10 code of cancer in the relative of participant																				
-CancRelRelativeCode_2		family clinical history	Specifies the additional relative of participants with a history of cancer																				
-CancRelAgeDiagnosis_2		family clinical history	Specifies the age of relative when cancer was diagnosed																				
-CancRelSite_2		family clinical history	Specifies the site of cancer in the relative of participant																				
-CancRelICD10_2		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
-CancRelRelativeCode_3		family clinical history	Specifies the additional relative of participants with a history of cancer																				
-CancRelAgeDiagnosis_3		family clinical history	Specifies the age of relative when cancer was diagnosed																				
-CancRelSite_3		family clinical history	Specifies the site of cancer in the relative of participant																				
-CancRelICD10_3		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
-CancRelRelativeCode_4		family clinical history	Specifies the additional relative of participants with a history of cancer																				
-CancRelAgeDiagnosis_4		family clinical history	Specifies the age of relative when cancer was diagnosed																				
-CancRelSite_4		family clinical history	Specifies the site of cancer in the relative of participant																				
-CancRelICD10_4		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
-TobEverRegularFlag	subclass	tobacco	Specifies the participant used cigar for 6 Months																				
-TobCigsNow	subclass	tobacco	Specifies the participant uses cigar Now																				
-TobNonCigFlag	subclass	tobacco	Specifies the participant used tobacco other than cigar for 6 Months																				
-TobStartAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, first history																				
-TobEndAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, first history																				
-TobDuration_1	subclass	tobacco	Specifies the participant Used tobacco Duration, first history																				
-TobType_1	subclass	tobacco	Specifies the participant Used type of Tobacco, first history																				
-TobNumberPerDay_1	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, first history																				
-TobDaysPerWeek_1	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, first history																				
-CigNumPerDay_1	subclass	tobacco	Specifies the participant Used this cigar how many times per day, first history																				
-Cigpackyear_1	subclass	tobacco	Specifies the participant cumulative use, first history																				
-TobStartAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, second history																				
-TobEndAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, second history																				
-TobDuration_2	subclass	tobacco	Specifies the participant Used tobacco Duration, second history																				
-TobType_2	subclass	tobacco	Specifies the participant Used type of Tobacco, second history																				
-TobNumberPerDay_2	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, second history																				
-TobDaysPerWeek_2	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, second history																				
-CigNumPerDay_2	subclass	tobacco	Specifies the participant Used this cigar how many times per day, second history																				
-Cigpackyear_2	subclass	tobacco	Specifies the participant cumulative use, second history																				
-TobStartAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, third history																				
-TobEndAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, third history																				
-TobDuration_3	subclass	tobacco	Specifies the participant Used tobacco Duration, third history																				
-TobType_3	subclass	tobacco	Specifies the participant Used type of Tobacco, third history																				
-TobNumberPerDay_3	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, third history																				
-TobDaysPerWeek_3	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, third history																				
-CigNumPerDay_3	subclass	tobacco	Specifies the participant Used this cigar how many times per day, third history																				
-Cigpackyear_3	subclass	tobacco	Specifies the participant cumulative use, third history																				
-TobStartAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, fourth history																				
-TobEndAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, fourth history																				
-TobDuration_4	subclass	tobacco	Specifies the participant Used tobacco Duration, fourth history																				
-TobType_4	subclass	tobacco	Specifies the participant Used type of Tobacco, fourth history																				
-TobNumberPerDay_4	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, fourth history																				
-TobDaysPerWeek_4	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, fourth history																				
-CigNumPerDay_4	subclass	tobacco	Specifies the participant Used this cigar how many times per day, fourth history																				
-Cigpackyear_4	subclass	tobacco	Specifies the participant cumulative use, fourth history																				
-total_packyear	subclass	tobacco	Specifies the participant total cumulative use																				
-OpiateEverRegularFlag		opiate use history	Specifies the participant ever used opiume for 6 Months																				
-OpiatePersonalChildhoodExp		opiate use history	Specifies the using opium in Childhood																				
-OpiateAdministeredToChildrenFlag			Specifies the participant gave opium to children	???																			
-OpiateType		opiate use history	Specifies the participant Used Opium type																				
-OpiateRoute		opiate use history	Specifies the route by which participant uses opium																				
-OpiateStartAge_1		opiate use history	Specifies the participant Used this Opium type From Age, first history																				
-OpiateEndAge_1		opiate use history	Specifies the participant Used this Opium type To Age, first history																				
-OpiateDuration_1		opiate use history	Specifies the participant Used this Opium Duration, first history																				
-OpiateNokhod_1		opiate use history	Specifies the participant Used this Opium amount in Pea size, first history																				
-OpiateDaysPerWeek_1		opiate use history	Specifies the participant Used this Opium day in week, first history																				
-OpiateAmountperDay_1		opiate use history	Specifies the participant Used this Opium Amount per day, first history																				
-Opiatecum_1		opiate use history	Specifies the participant cumulative use of Opium, first history																				
-OpiateStartAge_2		opiate use history	Specifies the participant Used this Opium type From Age, second history																				
-OpiateEndAge_2		opiate use history	Specifies the participant Used this Opium type To Age, second history																				
-OpiateDuration_2		opiate use history	Specifies the participant Used this Opium Duration, second history																				
-OpiateNokhod_2		opiate use history	Specifies the participant Used this Opium amount in Pea size, second history																				
-OpiateDaysPerWeek_2		opiate use history	Specifies the participant Used this Opium day in week, second history																				
-OpiateAmountperDay_2		opiate use history	Specifies the participant Used this Opium Amount per day, second history																				
-Opiatecum_2		opiate use history	Specifies the participant cumulative use of Opium, second history																				
-OpiateStartAge_3		opiate use history	Specifies the participant Used this Opium type From Age, third history																				
-OpiateEndAge_3		opiate use history	Specifies the participant Used this Opium type To Age, third history																				
-OpiateDuration_3		opiate use history	Specifies the participant Used this Opium Duration, third history																				
-OpiateNokhod_3		opiate use history	Specifies the participant Used this Opium amount in Pea size, third history																				
-OpiateDaysPerWeek_3		opiate use history	Specifies the participant Used this Opium day in week, third history																				
-OpiateAmountperDay_3		opiate use history	Specifies the participant Used this Opium Amount per day, third history																				
-Opiatecum_3		opiate use history	Specifies the participant cumulative use of Opium, third history																				
-OpiateStartAge_4		opiate use history	Specifies the participant Used this Opium type From Age, fourth history																				
-OpiateEndAge_4		opiate use history	Specifies the participant Used this Opium type To Age, fourth history																				
-OpiateDuration_4		opiate use history	Specifies the participant Used this Opium Duration, fourth history																				
-OpiateNokhod_4		opiate use history	Specifies the participant Used this Opium amount in Pea size, fourth history																				
-OpiateDaysPerWeek_4		opiate use history	Specifies the participant Used this Opium day in week, fourth history																				
-OpiateAmountperDay_4		opiate use history	Specifies the participant Used this Opium Amount per day, fourth history																				
-Opiatecum_4		opiate use history	Specifies the participant cumulative use of Opium, fourth history																				
-TotalNokhodDay		opiate use history	Specifies the participant total cumulative use of Opium																				
-AlcEverRegularFlag	subclass	alcohol	Specifies the participant ever used alcohol for 6 Months																				
-AlcStartAge_1	subclass	alcohol	Specifies the participant used alcohol From Age, first history																				
-AlcEndAge_1	subclass	alcohol	Specifies the participant used alcohol To Age, first history																				
-AlcType_1	subclass	alcohol	Specifies the participant alcohol used Type, first history																				
-AlcQuantityPerEpisode_1	subclass	alcohol	Specifies the average alcohol the participant used per episode, first history																				
-AlcEpisodesPerMonth_1	subclass	alcohol	Specifies the participant Alcohol episodes in month, first history																				
-AlcStartAge_2	subclass	alcohol	Specifies the participant used alcohol From Age, second history																				
-AlcEndAge_2	subclass	alcohol	Specifies the participant used alcohol To Age, second history																				
-AlcType_2	subclass	alcohol	Specifies the participant alcohol used Type, second history																				
-AlcQuantityPerEpisode_2	subclass	alcohol	Specifies the average alcohol the participant used per episode, second history																				
-AlcEpisodesPerMonth_2	subclass	alcohol	Specifies the participant Alcohol episodes in month, second history																				
-AlcStartAge_3	subclass	alcohol	Specifies the participant used alcohol From Age, third history																				
-AlcEndAge_3	subclass	alcohol	Specifies the participant used alcohol To Age, third history																				
-AlcType_3	subclass	alcohol	Specifies the participant alcohol used Type, third history																				
-AlcQuantityPerEpisode_3	subclass	alcohol	Specifies the average alcohol the participant used per episode, third history																				
-AlcEpisodesPerMonth_3	subclass	alcohol	Specifies the participant Alcohol episodes in month, third history																				
-DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
-antiHTN	subclass	history of medication for hypertension	Anti-hypertensive drugs: 1: diuretics 2: beta-blockers 3: ACE Inhibitors 4: ARBs 5: Alpha-adrenergic blockers 6: Calcium channel blockers 7:other anti-hypertensives																				
-antiDM	subclass	history of medication for diabetes	Anti-diabetic drugs: 1: Glibenclamide 2: metformin 3: insulin 4: other																				
-cardiac	subclass	history of medication for cardiac disease	Cardiac drugs: 1: Anti-platelets 2: statins 3: Beta-blockers 4: Nitrates 5: ACE Inhibitors 6: ARBs 7: Calcium Channel blockers 8: other																				
-antilipid	subclass	history of medication for high cholesterol	Lipid-lowering drugs: 1: Statins 2: Gemfibrozil 3: other																				
-mentaldrug	subclass	history of medication for mental disorder	Mental disorders: 1: Benzodiazepines 2: Sodium Valproate 3: Anti-epileptics 4: Antidepressants 5: Anti-anxiety medications 6: Psychoactive medications																				
-Corticosteroid	subclass	use of corticosteroids	Corticosteroids: 1: injection 2: oral 3: topical																				
-Gidrugs	subclass	history of medication for gastrointestinal disease	Gastrointestinal: 1: H2 Blockers 2: PPIs 3: Clindinium C																				
-antibiotics	subclass	use of antibiotics	Antibiotics: 1: Amoxicillin 2: Cefixime 3: Azithromycin 4: Metronidazole 5: other																				
-diuretic	subclass	use of diuretics	Diuretics																				
-betablocker	subclass	use of beta blockers	Beta Blockers																				
-ACEinhibitor	subclass	use of angiotensin convertin enzyme inhibitors	Angiotensin Converting Enzyme Inhibitors																				
-ARB	subclass	use of angiotensin receptor blockers	Angiotensin Receptor Blockers																				
-alphablocker	subclass	use of alpha adrenergic blockers	Alpha Adrenergic Blockers																				
-CCBlocker	subclass	use of calcium channel blockers	Calcium Channel Blockers																				
-Glibenclamide	subclass	use of glibenclamide	Glibenclamide																				
-Metformin	subclass	use of metformin	Metformin																				
-Insulin	subclass	use of insulin	Insulin																				
-Antiplatelets	subclass	use of antiplatelets	Anti-platelets																				
-Statins	subclass	use of statins	Statins																				
-Nitrates	subclass	use of nitrates	Nitrates																				
-Gemfibrozil	subclass	use of gemfibroxil	Gemfibrozil																				
-Acetaminophen	subclass	use of acetaminophen	Acetaminophen and Acetaminophen Codein																				
-Ibuprofen	subclass	use of ibuprofen	Ibuprofen																				
-Diclophenac	subclass	use of diclophenac	Diclophenac																				
-Indomethacin	subclass	use of indomethacin	Indomethacin																				
-Levothyroxin	subclass	use of levthyroxine	Levthyroxin																				
-Methotrexate	subclass	use of methotrexate	Methotrexate																				
-Other	subclass	medication history	Other																				
-DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
-drugname_1	subclass	medication history	Name of drug 1	Could name fall under "prescription"?																			
-drugduration_1	subclass	medication history	Number of years being under treatment 1																				
-drugfrequency_1	subclass	posology	Frequency of drug consumption 1																				
-drugdose_1	subclass	posology	Dose of drug consumed 1																				
-drugname_2	subclass	medication history	Name of drug 2																				
-drugduration_2	subclass	medication history	Number of years being under treatment 2																				
-drugfrequency_2	subclass	posology	Frequency of drug consumption 2																				
-drugdose_2	subclass	posology	Dose of drug consumed 2																				
-drugname_3	subclass	medication history	Name of drug 3																				
-drugduration_3	subclass	medication history	Number of years being under treatment 3																				
-drugfrequency_3	subclass	posology	Frequency of drug consumption 3																				
-drugdose_3	subclass	posology	Dose of drug consumed 3																				
-drugname_4	subclass	medication history	Name of drug 4																				
-drugduration_4	subclass	medication history	Number of years being under treatment 4																				
-drugfrequency_4	subclass	posology	Frequency of drug consumption 4																				
-drugdose_4	subclass	posology	Dose of drug consumed 4																				
-drugname_5	subclass	medication history	Name of drug 5																				
-drugduration_5	subclass	medication history	Number of years being under treatment 5																				
-drugfrequency_5	subclass	posology	Frequency of drug consumption 5																				
-drugdose_5	subclass	posology	Dose of drug consumed 5																				
-drugname_6	subclass	medication history	Name of drug 6																				
-drugduration_6	subclass	medication history	Number of years being under treatment 6																				
-drugfrequency_6	subclass	posology	Frequency of drug consumption 6																				
-drugdose_6	subclass	posology	Dose of drug consumed 6																				
-drugname_7	subclass	medication history	Name of drug 7																				
-drugduration_7	subclass	medication history	Number of years being under treatment 7																				
-drugfrequency_7	subclass	posology	Frequency of drug consumption 7																				
-drugdose_7	subclass	posology	Dose of drug consumed 7																				
-drugname_8	subclass	medication history	Name of drug 8																				
-drugduration_8	subclass	medication history	Number of years being under treatment 8																				
-drugfrequency_8	subclass	posology	Frequency of drug consumption 8																				
-drugdose_8	subclass	posology	Dose of drug consumed 8																				
-drugname_9	subclass	medication history	Name of drug 9																				
-drugduration_9	subclass	medication history	Number of years being under treatment 9																				
-drugfrequency_9	subclass	posology	Frequency of drug consumption 9																				
-drugdose_9	subclass	posology	Dose of drug consumed 9																				
-drugname_10	subclass	medication history	Name of drug 10																				
-drugduration_10	subclass	medication history	Number of years being under treatment 10																				
-drugfrequency_10	subclass	posology	Frequency of drug consumption 10																				
-drugdose_10	subclass	posology	Dose of drug consumed 10																				
-OralPermanentTeethLossFlag	subclass	oral health history	Permanent Teeth Loss																				
-OralPermanentTeethAgeFirstLoss	subclass	oral health history	Specifies the age of first Permanent Teeth Loss																				
-OralUpperDentureFlag	subclass	oral health history	Specifies the participant used Upper Denture																				
-OralLowerDentureFlag	subclass	oral health history	Specifies the participant used Lower Denture																				
-OralUpperDentureUse	subclass	oral health history	Specifies the participant used Upper Denture during the day																				
-OralLowerDentureUse	subclass	oral health history	Specifies the participant used Lower Denture during the day																				
-OralAgeDentureUpper	subclass	oral health history	Specifies the age of participant first used Upper Denture																				
-OralAgeDentureLower	subclass	oral health history	Specifies the age of participant First used Lower Denture																				
-OralFreqBrushing	subclass	oral health history	Specifies the participant Brushing Frequency																				
-OralFoodDiscomfortFlag	subclass	oral health history	Specifies the frequency the participant experienced discomfort while eating food in Past Year																				
-OralFoodDiscomfortType	subclass	oral health history	Specifies the food that caused discomfort for the participant																				
-OralNumTeeth	subclass	oral health history	Specifies the participant Total number of teeth																				
-OralNumTeethDecayed	subclass	oral health history	Specifies the participant Total number of Decayed teeth																				
-OralNumTeethMissing	subclass	oral health history	Specifies the participant Total number of Missing teeth																				
-OralNumTeethFilled	subclass	oral health history	Specifies the participant Total number of Filled teeth																				
-OralMucosa	subclass	oral health history	Specifies the participant Mucosa Status																				
-TeaTempDegrees		information about diet	Specifies participant consumption of tea temperature	is this diet?																			
-TeaTempDescription		information about diet	Specifies participant used tea type																				
-TeaSteepingTime		information about diet	Specifies the duration between pouring and drinking the tea																				
-TeaSipOrGulp		information about diet	Specifies how participant drinks tea																				
-physactworkallyearflag	subclass	occupation|physical activity	Working all months of the year?																				
-physactworkmonths	subclass	occupation|physical activity	Number of working months in a year																				
-physactworkstrenuousflag	subclass	physical activity	Daily intensive physical activity?																				
-physactworkstrenuousfreq	subclass	physical activity	Number of working days in a week																				
-physactworkstrenuoushours	subclass	physical activity	Number of working hours in a day																				
-physactworkstrenuousyears	subclass	physical activity	Number of entire working years																				
-physacthouseworkflag	subclass	physical activity	Doing house work?																				
-physacthouseworkfreq	subclass	physical activity	Number of working days in a week																				
-physacthouseworkhours	subclass	physical activity	Number of working hours in a day																				
-physacthouseworkyears	subclass	physical activity	Number of entire working years																				
-physacthouseworkminsduringwork	subclass	physical activity	Doing house work: minutes during working times																				
-physacthouseworkminsnowork	subclass	physical activity	Doing house work: minutes during leasure times																				
-physactexmildminsduringwork	subclass	physical activity	Mild exercise such as jogging: minutes during working times																				
-physactexmildminsnowork	subclass	physical activity	Mild exercise such as jogging: minutes during leasure times																				
-physactexmodminsduringwork	subclass	physical activity	Moderate exercise such as volleyball: minutes during working times																				
-physactexmodminsnowork	subclass	physical activity	Moderate exercise such as volleyball: minutes during leasure times																				
-physactexstrenminsduringwork	subclass	physical activity	Intensive exercise such as horse riding: minutes during working times																				
-physactexstrenminsnowork	subclass	physical activity	Intensive exercise such as horse riding: minutes during leasure times																				
-physacttvminsduringwork	subclass	physical activity	Watching TV, resting, reading: minutes during working times																				
-physacttvminsnowork	subclass	physical activity	Watching TV, resting, reading: minutes during leasure times																				
-Metabolic Equivalent Task	subclass	physical activity	Energy cost of physical activities defined as the ratio of metabolic rate (and therefore the rate of energy consumption) during a specific physical activity to a reference metabolic rate																				
-AnimalStartAge_1		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, first history	not sure if this is correct - do we want to be more specific?																			
-AnimalEndAge_1		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, first history																				
-AnimalLevelOfContact_1		lifestyle and behaviours	The intensity of animal contact, first history																				
-AnimalType_1		lifestyle and behaviours	The type of animal, first history																				
-AnimalStartAge_2		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, second history																				
-AnimalEndAge_2		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, second history																				
-AnimalLevelOfContact_2		lifestyle and behaviours	The intensity of animal contact, second history																				
-AnimalType_2		lifestyle and behaviours	The type of animal, second history																				
-AnimalStartAge_3		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, third history																				
-AnimalEndAge_3		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, third history																				
-AnimalLevelOfContact_3		lifestyle and behaviours	The intensity of animal contact, third history																				
-AnimalType_3		lifestyle and behaviours	The type of animal, third history																				
-AnimalStartAge_4		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, fourth history																				
-AnimalEndAge_4		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, fourth history																				
-AnimalLevelOfContact_4		lifestyle and behaviours	The intensity of animal contact, fourth history																				
-AnimalType_4		lifestyle and behaviours	The type of animal, fourth history																				
-bodyindicessizeage15	subclass	anthropometry	The body size participants assume they have had based on pictogram when they were 15 years old																				
-bodyindicessizeage30	subclass	anthropometry	The body size participants assume they have had based on pictogram when they wer3 30 years old																				
-bodyindicessizenow	subclass	anthropometry	The body size participants assume they have at the present time based on pictogram																				
-bodyindicesheight	equivalent	height	Height																				
-bodyindicesweight	equivalent	weight	Weight																				
-bodyindiceswaist	equivalent	waist circumference value	Waist circumference																				
-bodyindiceships	equivalent	hip circumference value	Hip circumference																				
-BMI	equivalent	body mass index value	Body mass index																				
-bpright1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the right arm																				
-bpright1dbp	subclass	diastolic blood pressure value	First measurement ofdiastolic blood pressure from the right arm																				
-bpright2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the right arm																				
-bpright2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the right arm																				
-bpleft1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the left arm																				
-bpleft1dbp	subclass	diastolic blood pressure value	First measurement of diastolic blood pressure from the left arm																				
-bpleft2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the left arm																				
-bpleft2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the left arm																				
-m_sbp	subclass	systolic blood pressure value	Mean systolic blood pressure measured second time																				
-m_dbp	subclass	diastolic blood pressure value	Mean diastolic blood pressure measured second time																				
-high_sbp	subclass	systolic blood pressure value	Systolic blood pressure >= 140 mmHg	also high BP																			
-high_dbp	subclass	diastolic blood pressure value	Diastolic blood pressure >= 90 mmHg	also high BP																			
-htndrug		use of antihypertensive agents	Consumption of any anti-hypertensive medication for more than 6 months																				
-HTN		diagnosis of hypertension	Being hypertensive																				
-HTNcat		diagnosis of hypertension	Categorization of hypetrension																				
-preHTN		diagnosis of hypertension	SBP/DBP >=120/80 AND <140/90	how do we handle prehypertension?																			
-pulse_p		calculated blood pressure value	Difference between SBP and DBP																				
-mean_bp		calculated blood pressure value	mean value of SBP and DBP																				
-mid_bp		calculated blood pressure value	Mid value of SBP and DBP																				
-diffsbp_right_left		systolic blood pressure value	Difference in SBP between arms																				
-diffdbp_right_left		diastolic blood pressure value	Difference in DBP between arms																				
-Energy		information about diet	Amount consumed per day	do we want to be more specific?																			
-fat		information about diet	Amount consumed per day																				
-salt		information about diet	Amount consumed per day																				
-protein		information about diet	Amount consumed per day																				
-total saturated fat		information about diet	Amount consumed per day																				
-total trans fat		information about diet	Amount consumed per day																				
-hydrogenated oil		information about diet	Amount consumed per day																				
-carbohyderate		information about diet	Amount consumed per day																				
-red meat		information about diet	Amount consumed per day																				
-processed meat		information about diet	Amount consumed per day																				
-fruits		information about diet	Amount consumed per day																				
-vegetables		information about diet	Amount consumed per day																				
-dairy products		information about diet	Amount consumed per day																				
-milk		information about diet	Amount consumed per day																				
-dietary fiber		information about diet	Amount consumed per day																				
-Fish		information about diet	Amount consumed per day																				
-Chicken		information about diet	Amount consumed per day																				
-SodiumNa		information about diet	Amount consumed per day																				
-Calcium		information about diet	Amount consumed per day																				
-Fe		information about diet	Amount consumed per day																				
-Magnesium		information about diet	Amount consumed per day																				
-Phosphorus		information about diet	Amount consumed per day																				
-Potassium		information about diet	Amount consumed per day																				
-Zinc		information about diet	Amount consumed per day																				
-Folate		information about diet	Amount consumed per day																				
-Vitamin D		information about diet	Amount consumed per day																				
-Vitamin A		information about diet	Amount consumed per day																				
-Vitamin B1		information about diet	Amount consumed per day																				
-Vitamin B2		information about diet	Amount consumed per day																				
-Vitamin B12		information about diet	Amount consumed per day																				
-Vitamin C		information about diet	Amount consumed per day																				
-Niacin		information about diet	Amount consumed per day																				
-Glycemic load		information about diet	Amount consumed per day																				
-Glycemic Index		information about diet	Amount consumed per day																				
-Sugar intake		information about diet	Amount consumed per day																				
-Nuts		information about diet	Amount consumed per day																				
-tea		information about diet	Amount consumed per day																				
-Coffee		information about diet	Amount consumed per day																				
-fbg	equivalent	blood fasting glucose level value	Fasting Blood Glucose																				
-urea			Urea																				
-creatinine			Creatinine																				
-cholesterol			Total Cholesterol																				
-triglycerides			Triglycerides																				
-hdl			High Density Lipoprotein																				
-ast			Aspartate Transaminase																				
-alt			Alanine Transaminase																				
-alkalinep			Alkaline Phosphatase																				
-ldl			Low Density Lipoprotein																				
-ldlhdl			LDL to HDL ratio																				
-gamma			Gamma Glutamyle Transpeptidase																				
-hbsag			HBsAg																				
-hbsab			HBsAb																				
-hbcab			HBcAb																				
-hbv			HBV DNA																				
-hcv			HCV Antibody																				
-wbc			White Blood Cell																				
-rbc			Red Blood Cell																				
-hb			Hemoglobin																				
-hct			Hematocrit																				
-plt		plateletcrit value	Platelet	maybe? not sure if this is the same																			
-mcv			Mean Corpuscular Volume																				
-mch			Mean Corpuscular Hemoglobin																				
-mchc			Mean Corpuscular Hemoglobin Concentration																				
-rdw	equivalent	red blood cell distribution width value	Red Cell Distribution Width																				
-BloodType	equivalent	blood type determination value	Specifies patient Blood Group																				
-Rh	equivalent	rheumatoid factor measurement value	Specifies patient Blood Rh																				
-BioSampHairAvailFlag			if patient has hair sample select YES if not Selct No																				
-BioSampNailAvailFlag			if patient has nail sample select YES if not Selct No																				
-BioSampBloodAvailFlag	equivalent	blood	if patient has Blood sample select YES if not Selct No																				
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
-																							
+ID	Field Label	Class Type	GECKO Label	Definition	Comment																			
+ID		CLASS_TYPE	C % SPLIT=|																					
+GCS:ID	Identity		GCS	Identity and contact information																				
+GCS:DEMO	Demographic Info	equivalent	demographic data	Demographic characteristics: sex, age, ethnicity, marital status, education																				
+GCS:FAM	Family members	subclass	family and household structure	Characteristics of relatives in the household																				
+GCS:RESID	Residence	equivalent	residence	The residential area (urban/rural), structure of the house, and duration of residing in the house																				
+GCS:SOURCE	Water and fuel source		GCS	Water source, heat and fuel system, and cooking method																				
+GCS:JOB	Job	equivalent	occupation	The names of all jobs the participant has had and the duration of work																				
+GCS:FOOD	Food preservation and cooking		GCS	Food preservation, frying, boiling, BBQ, steaming, ‚Ä¶																				
+GCS:PROP	Properties		GCS	Transferable and non-transferable belongings and wealth score (Multiple Correspondence Analysis)																				
+GCS:MED	Medical History	equivalent	clinical history	Suffering from any disease at the baseline of cohort																				
+GCS:CC	Chief complaints		GCS	The complaints of participants from their physical or mental sufferings																				
+GCS:CANCER	Cancer History	equivalent	clinical history of cancer	History of cancer, site, and age diagnosed in the participant or any of his/her relatives																				
+GCS:SMOK	Smoking	equivalent	tobacco	Ever or current smoker, age of use, type, number per day and days per week																				
+GCS:OPIUM	Opium use	equivalent	opiate use history	Ever or current user, age and route of use, type, time per day and days per week																				
+GCS:ALC	Alcohol use	equivalent	alcohol	Ever or current user, age of use, type, quantity per episode and episodes per month																				
+GCS:DRUGCAT	Drug history (1)	equivalent	recreational drug use history	The main created categories of drugs consumed by participants																				
+GCS:DRUGDETAIL	Drug History (2)	equivalent	recreational drug use history	The exact name, duration, dose, and frequency of drugs consumed																				
+GCS:ORAL	Oral health	equivalent	oral health history	Decayed, filled, and missing teeth along with the age of the participant in each of these occasions																				
+GCS:TEA	Tea		GCS	Tea temperature, type of tea, and type of habit for drinking the tea																				
+GCS:ACTIVITY	Physical activity	equivalent	physical activity	The duration and intensity of physical activities during working and leasure times of the day, and Metabolic Equivalent Task (MET)																				
+GCS:ANIMAL	Animal contact		GCS	The age of the participant in contact with animals, the duration and intensity of animal contact, and the type of animal																				
+GCS:ANTHRO	Anthropometric measurements	equivalent	anthropometry	Physically measured height, weight, waist circumference, hip circumference and data of pictogram																				
+GCS:BP	Blood pressure measurements	equivalent	blood pressure	Both systolic and diastolic blood pressure measured in sitting position twice from each arm																				
+GCS:FFQ	Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result	Units of food categories consumed per day																				
+GCS:LAB	Lab markers		GCS	Biochemical markers																				
+GCS:PID	PID			The Unique Id for eatch participant																				
+GCS:FirstName	FirstName			The first name of participant.																				
+GCS:LastName	LastName			The last name of participant.																				
+GCS:Province	Province	subclass	residence	Specifies the participant Province of Residence																				
+GCS:District	District	subclass	residence	Specifies the participant District of Residence																				
+GCS:City	City	subclass	residence	Specifies the participant City of Residence																				
+GCS:Subdistrict	Subdistrict	subclass	residence	Specifies the participant Subdistrict of Residence																				
+GCS:Village	Village	subclass	residence	Specifies the participant Village of Residence																				
+GCS:Street	Street	subclass	residence	Specifies the participant Street of Residence																				
+GCS:Alley	Alley	subclass	residence	Specifies the participant Alley of Residence																				
+GCS:CV name	CV name	subclass	residence	Specifies the names of cities or villages in one variable																				
+GCS:City_Village	City_Village	subclass	residence	Specifies residence in cities or villages																				
+GCS:HouseNumber	HouseNumber	subclass	residence	Specifies the participant's House Number of Residence																				
+GCS:ZipCode	ZipCode	subclass	residence	Specifies the participant's Zip Code of Residence																				
+GCS:HomePhone	HomePhone			Specifies the participants Home Phone																				
+GCS:AreaCode	AreaCode			Specifies the participant's home Phone Area Code																				
+GCS:CellPhone	CellPhone			Specifies the participant's Cell phone number																				
+GCS:HealthCenter	HealthCenter			participant related to this health center(the participant covered by this health center)																				
+GCS:FamilyMemPhone	FamilyMemPhone			Specifies the phone number of one of participant's family members																				
+GCS:FamilyMemAreaCode	FamilyMemAreaCode			Specifies the area code of the phone number of one of participant's family members																				
+GCS:FamilyMemName	FamilyMemName			Specifies the name of one family member of the participant																				
+GCS:FriendName	FriendName			Specifies the name of one of friends of the participant																				
+GCS:FriendProvince	FriendProvince			Specifies the province in which the friend of the participant resides																				
+GCS:FriendDistrict	FriendDistrict			Specifies the district in which the friend of the participant resides																				
+GCS:FriendCity	FriendCity			Specifies the city in which the friend of the participant resides																				
+GCS:FriendSubdistrict	FriendSubdistrict			Specifies the subdistrict in which the friend of the participant resides																				
+GCS:FriendVillage	FriendVillage			Specifies the village in which the friend of the participant resides																				
+GCS:FriendStreet	FriendStreet			Specifies the street in which the friend of the participant resides																				
+GCS:FriendAlley	FriendAlley			Specifies the alley in which the friend of the participant resides																				
+GCS:FriendHouseNumber	FriendHouseNumber			Specifies the house number in which the friend of the participant resides																				
+GCS:FriendZipCode	FriendZipCode			Specifies the zip code in which the friend of the participant resides																				
+GCS:FriendHomePhone	FriendHomePhone			Specifies the phone number of the participant's friend																				
+GCS:FriendAreaCode	FriendAreaCode			Specifies the area code of the phone number of participant's friend																				
+GCS:FriendCellPhone	FriendCellPhone			Specifies the cell phone number of participant's friend																				
+GCS:PlaceOfInterview	PlaceOfInterview			Specifies the participant interview place																				
+GCS:InterviewPDate_Y	InterviewPDate_Y			participant year of Interview date in Shamsi format																				
+GCS:InterviewPDate_M	InterviewPDate_M			participant month of Interview date in Shamsi format																				
+GCS:InterviewPDate_D	InterviewPDate_D			participant Day of Interview date in Shamsi format																				
+GCS:Gender	Gender	equivalent	gender	Specifies the participant Gender																				
+GCS:BdatePDate_Y	BdatePDate_Y	subclass	age/birthdate	Year of participant Birth date in Shamsi format																				
+GCS:BdatePDate_M	BdatePDate_M	subclass	age/birthdate	Month of participant Birth date in Shamsi format																				
+GCS:BdatePDate_D	BdatePDate_D	subclass	age/birthdate	Day of participant Birth date in Shamsi format																				
+GCS:Age_self	Age_self	subclass	age/birthdate	Specifies the self-report participant age in inteview time																				
+GCS:Age_new	Age_new	subclass	age/birthdate	Age calculated from birth date and interview date																				
+GCS:Ethnicity	Ethnicity	equivalent	ethnicity/race	Specifies the participant Ethnicity																				
+GCS:ethnicity_new	ethnicity_new	subclass	ethnicity/race	Specifies ethnicity by Turkmen or Non-turkmen																				
+GCS:MaritalStatus	MaritalStatus	equivalent	marital status value	Specifies the participant marital status																				
+GCS:marital_new	marital_new	subclass	marital status value	Specifies marital status into married or non-married																				
+GCS:Education	Education	equivalent	education	Specifies the participant Education Level																				
+GCS:FamilyInHousehold	FamilyInHousehold	subclass	family and household structure	Specifies the number of participant family living in the household																				
+GCS:BrothersN	BrothersN	subclass	family and household structure	Specifies participant No. of Brothers																				
+GCS:StepbrothersN	StepbrothersN	subclass	family and household structure	Specifies participant No. of Step brothers																				
+GCS:SistersN	SistersN	subclass	family and household structure	Specifies participant No. of Sisters																				
+GCS:Stepsisters	Stepsisters	subclass	family and household structure	Specifies participant No. of Step sisters																				
+GCS:Sons	Sons	subclass	family and household structure	Specifies participant No. of Sons																				
+GCS:Daughters	Daughters	subclass	family and household structure	Specifies participant No. of Daughters																				
+GCS:TwinYesNo	TwinYesNo	subclass	family and household structure	Specifies whether the participant has twin brother or sister																				
+GCS:TwinAlive	TwinAlive	subclass	family and household structure	Specifies whether the twin of the participant is alive																				
+GCS:ResDuration_1	ResDuration_1	subclass	residence	Specifies the participant first residence history Duration																				
+GCS:ResCitVill_1	ResCitVill_1	subclass	residence	Specifies the participant first residence history in Village or City																				
+GCS:ResDistrict_1	ResDistrict_1	subclass	residence	Specifies the participant first residence history District																				
+GCS:ResCitVillname_1	ResCitVillname_1	subclass	residence	Specifies the participant first residence history City or village name																				
+GCS:ResHouseType_1	ResHouseType_1	subclass	residence	Specifies the participant first residence history House Type																				
+GCS:ResDuration_2	ResDuration_2	subclass	residence	Specifies the participant second residence history Duration																				
+GCS:ResCitVill_2	ResCitVill_2	subclass	residence	Specifies the participant second residence history in Village or City																				
+GCS:ResDistrict_2	ResDistrict_2	subclass	residence	Specifies the participant second residence history District																				
+GCS:ResCitVillname_2	ResCitVillname_2	subclass	residence	Specifies the participant second residence history City or village name																				
+GCS:ResHouseType_2	ResHouseType_2	subclass	residence	Specifies the participant second residence history House Type																				
+GCS:ResDuration_3	ResDuration_3	subclass	residence	Specifies the participant third residence history Duration																				
+GCS:ResCitVill_3	ResCitVill_3	subclass	residence	Specifies the participant third residence history in Village or City																				
+GCS:ResDistrict_3	ResDistrict_3	subclass	residence	Specifies the participant third residence history District																				
+GCS:ResCitVillname_3	ResCitVillname_3	subclass	residence	Specifies the participant third residence history City or village name																				
+GCS:ResHouseType_3	ResHouseType_3	subclass	residence	Specifies the participant third residence history House Type																				
+GCS:FoodWatSource	FoodWatSource			Specifies participant used water source																				
+GCS:FoodWatYearsPipe	FoodWatYearsPipe			Specifies how many years participant used pipe water																				
+GCS:FoodWatPriorPipeSource	FoodWatPriorPipeSource			Specifies what water source participant used prior to pipe water																				
+GCS:HeatAndFuelDuration_1	HeatAndFuelDuration_1			Specifies the duration the participant Used Heating or Fuel system, first history																				
+GCS:HeatingSystemType_1	HeatingSystemType_1			Specifies the participant Used Heating Type, first history																				
+GCS:HeatMethod_1	HeatMethod_1			Specifies the participant Used Heating Type of fuel, first history																				
+GCS:CookingMethod_1	CookingMethod_1			Specifies the participant Used Cooking Type of fuel, first history																				
+GCS:HeatAndFuelDuration_2	HeatAndFuelDuration_2			Specifies the duration the participant Used Heating or Fuel system, second history																				
+GCS:HeatingSystemType_2	HeatingSystemType_2			Specifies the participant Used Heating Type, second history																				
+GCS:HeatMethod_2	HeatMethod_2			Specifies the participant Used Heating Type of fuel, second history																				
+GCS:CookingMethod_2	CookingMethod_2			Specifies the participant Used Cooking Type of fuel, second history																				
+GCS:HeatAndFuelDuration_3	HeatAndFuelDuration_3			Specifies the duration participant Used Heating or Fuel system, third history																				
+GCS:HeatingSystemType_3	HeatingSystemType_3			Specifies the participant Used Heating Type, third history																				
+GCS:HeatMethod_3	HeatMethod_3			Specifies the participant Used Heating Type of fuel, third history																				
+GCS:CookingMethod_3	CookingMethod_3			Specifies the participant Used Cooking Type of fuel, third history																				
+GCS:WorkEverWorkedFlag	WorkEverWorkedFlag	subclass	occupation	Working for at least one year of full-time job																				
+GCS:WorkAgeBegan	WorkAgeBegan	subclass	occupation	Specifies participant start work age																				
+GCS:WorkCurrently	WorkCurrently	subclass	occupation	Specifies participant work now																				
+GCS:JobsStartAge	JobsStartAge	subclass	occupation	Age of starting the job for last history																				
+GCS:JobsEndAge	JobsEndAge	subclass	occupation	Age of quiting the job for last history																				
+GCS:JobsTitleOccupation	JobsTitleOccupation	subclass	occupation	Name of the job																				
+GCS:JobsTitleOccupationCode	JobsTitleOccupationCode	subclass	occupation	Code of the job (Appendix)																				
+GCS:JobsHoursPerDay	JobsHoursPerDay	subclass	occupation	Number of working hours per day																				
+GCS:JobsIntensity	JobsIntensity	subclass	occupation	The intensity of physical activity during the job																				
+GCS:JobMonthPerYear	JobMonthPerYear	subclass	occupation	Number of working months per year																				
+GCS:HusbandOccupation	HusbandOccupation			Code of the husband job (Appendix)	maybe family?																			
+GCS:FoodWatFoodPreserve	FoodWatFoodPreserve			Specifies How to Preserve foods	is this lifestyle or diet?																			
+GCS:FoodWatBreadPreserve	FoodWatBreadPreserve			Specifies How to Preserve bread																				
+GCS:FoodWatShallowFryVeg	FoodWatShallowFryVeg			Specifies Using vegetable in Small frying																				
+GCS:FoodWatShallowFryMeat	FoodWatShallowFryMeat			Specifies Using Meat in Small frying																				
+GCS:FoodWatShallowFryFish	FoodWatShallowFryFish			Specifies Using Fish in Small frying																				
+GCS:FoodWatDeepFryVeg	FoodWatDeepFryVeg			Specifies Using vegetable in Deep frying																				
+GCS:FoodWatDeepFryMeat	FoodWatDeepFryMeat			Specifies Using Meat in Deep frying																				
+GCS:FoodWatDeepFryFish	FoodWatDeepFryFish			Specifies Using Fish in Deep frying																				
+GCS:FoodWatBBQVeg	FoodWatBBQVeg			Specifies Using vegetable in BBQ																				
+GCS:FoodWatBBQMeat	FoodWatBBQMeat			Specifies Using Meat in BBQ																				
+GCS:FoodWatBBQFish	FoodWatBBQFish			Specifies Using Fish in BBQ																				
+GCS:FoodWatBoilVeg	FoodWatBoilVeg			Specifies Using vegetable Boiling																				
+GCS:FoodWatBoilMeat	FoodWatBoilMeat			Specifies Using Meat Boiling																				
+GCS:FoodWatBoilFish	FoodWatBoilFish			Specifies Using Fish Boiling																				
+GCS:FoodWatSteamVeg	FoodWatSteamVeg			Specifies Using vegetable Steaming																				
+GCS:FoodWatSteamMeat	FoodWatSteamMeat			Specifies Using Meat Steaming																				
+GCS:FoodWatSteamFish	FoodWatSteamFish			Specifies Using Fish Steaming																				
+GCS:FoodWatOthVeg	FoodWatOthVeg			Specifies Using vegetable by any Other method																				
+GCS:FoodWatOthMeat	FoodWatOthMeat			Specifies Using Meat by any Other method																				
+GCS:FoodWatOthFish	FoodWatOthFish			Specifies Using Fish in by any Other method																				
+GCS:FoodWatFreshLocalFruitChange	FoodWatFreshLocalFruitChange			Specifies the change in using Local Fruit from 1353																				
+GCS:FoodWatFreshImportedFruitChange	FoodWatFreshImportedFruitChange			Specifies the change in using Imported Fruit from 1353																				
+GCS:FoodWatFreshVegChange	FoodWatFreshVegChange			Specifies the change in using Fresh Vegetable from 1353																				
+GCS:FoodWatFreshMeatChange	FoodWatFreshMeatChange			Specifies the change in using Fresh Meat from 1353																				
+GCS:Homeownership	Homeownership			Specifies participant Homeownership status	is this lifestyle or sociodemographic? this is all talking about wealth																			
+GCS:house_nonowned	house_nonowned			Specifies house owned or non-owned																				
+GCS:HomeSize	HomeSize			Specifies participant Home Area	residence?																			
+GCS:PropertyAutoOwned	PropertyAutoOwned			If the participant has personal car select yes if no select no																				
+GCS:PropertyAutoYears	PropertyAutoYears			Specifies the length of time that the participant has a personal car(Year)																				
+GCS:PropertyMotorcycleOwned	PropertyMotorcycleOwned			If the participant has Motorcycle select yes if no select no																				
+GCS:PropertyMotorcycleYears	PropertyMotorcycleYears			Specifies the length of time that the participant has Motorcycle(Year)																				
+GCS:PropertyColorTVOwned	PropertyColorTVOwned			If the participant has Color TV select yes if no select no																				
+GCS:PropertyColorTVYears	PropertyColorTVYears			Specifies the length of time that the participant has Color TV(Year)																				
+GCS:PropertyBandWTVOwned	PropertyBandWTVOwned			If the participant has BandW TV select yes if no select no																				
+GCS:PropertyBandWTVYears	PropertyBandWTVYears			Specifies the length of time that the participant has BandW TV(Year)																				
+GCS:PropertyIndoorBathOwned	PropertyIndoorBathOwned			If the participant has Indoor Bath room select yes if no select no																				
+GCS:PropertyIndoorBathYears	PropertyIndoorBathYears			Specifies the length of time that the participant has Indoor Bath room(Year)																				
+GCS:PropertyVacuumOwned	PropertyVacuumOwned			If the participant has Vacuum cleaner select yes if no select no																				
+GCS:PropertyVacuumYears	PropertyVacuumYears			Specifies the length of time that the participant has Vacuum cleaner(Year)																				
+GCS:PropertyWashMachOwned	PropertyWashMachOwned			If the participant has Washing machine select yes if no select no																				
+GCS:PropertyWashMachYears	PropertyWashMachYears			Specifies the length of time that the participant has Washing machine(Year)																				
+GCS:PropertyRefrigeratorOwned	PropertyRefrigeratorOwned			If the participant has Refrigerator select yes if no select no																				
+GCS:PropertyRefrigeratorYears	PropertyRefrigeratorYears			Specifies the length of time that the participant has Refrigerator(Year)																				
+GCS:PropertyFreezerOwned	PropertyFreezerOwned			If the participant has Freezer select yes if no select no																				
+GCS:PropertyFreezerYears	PropertyFreezerYears			Specifies the length of time that the participant has Freezer(Year)																				
+GCS:PropertyComputerOwned	PropertyComputerOwned			If the participant has Computer select yes if no select no																				
+GCS:PropertyComputerYears	PropertyComputerYears			Specifies the length of time that the participant has Computer(Year)																				
+GCS:HomeRooms	HomeRooms			Number of rooms in the house																				
+GCS:HaveBath	HaveBath			Specifies if the household has bathroom																				
+GCS:HaveKitchen	HaveKitchen			Specifies if the household has kitchen																				
+GCS:MCA	MCA			Composite wealth score (Multiple Correspondence Analysis)	lifestyle or sociodemographic?																			
+GCS:NumberPregnancies	NumberPregnancies		pregnancy history	Specifies the number of Pregnancies for women only																				
+GCS:NumberLiveBirths	NumberLiveBirths		pregnancy history	Specifies the number of live births for women only																				
+GCS:DisRheumaticHeartDx	DisRheumaticHeartDx		diagnosis of heart disease	if the diagnosis of Rheumatic Heart Disease was made for participant by a physician																				
+GCS:DisRheumaticHeartAge	DisRheumaticHeartAge		diagnosis of heart disease	participant age at Rheumatic Heart Disease diagnosis																				
+GCS:DisHeartDiseaseDx	DisHeartDiseaseDx		diagnosis of heart disease	if the diagnosis of Heart Disease was made for participant by a physician																				
+GCS:DisHeartDiseaseAge	DisHeartDiseaseAge		diagnosis of heart disease	participant age in first Heart Disease diagnosis																				
+GCS:DisStrokeDx	DisStrokeDx		occurrence of stroke	if the diagnosis of Stroke was made for participant by a physician																				
+GCS:DisStrokeAge	DisStrokeAge		occurrence of stroke	participant age in first Stroke diagnosis																				
+GCS:DisHypertensionDx	DisHypertensionDx		diagnosis of hypertension	if the diagnosis of Hypertension was made for participant by a physician																				
+GCS:DisHypertensionAge	DisHypertensionAge		diagnosis of hypertension	participant age in first Hypertension diagnosis																				
+GCS:DisDiabetesDx	DisDiabetesDx		diagnosis of diabetes	if the diagnosis of Diabetes was made for participant by a physician																				
+GCS:DisDiabetesAge	DisDiabetesAge		diagnosis of diabetes	participant age in first Diabetes diagnosis																				
+GCS:DisCOPDDx	DisCOPDDx		diagnosis of chronic obstructive pulmonary disease	if the diagnosis of COPD was made for participant by a physician																				
+GCS:DisCOPDAge	DisCOPDAge		diagnosis of chronic obstructive pulmonary disease	participant age in first COPD diagnosis																				
+GCS:DisRenalFailureDx	DisRenalFailureDx		diagnosis of renal failure	if the diagnosis of Renal Failure was made for participant by a physician																				
+GCS:DisRenalFailureAge	DisRenalFailureAge		diagnosis of renal failure	participant age in first RenalFailure diagnosis																				
+GCS:DisJaundiceDx	DisJaundiceDx		diagnosis of jaundice	if the diagnosis of Jaundice was made for participant by a physician																				
+GCS:DisJaundiceAge	DisJaundiceAge		diagnosis of jaundice	participant age in first Jaundice diagnosis																				
+GCS:DisLiverDx	DisLiverDx		diagnosis of liver failure	if the diagnosis of Chronic Liver Failure was made for participant by a physician																				
+GCS:DisLiverAge	DisLiverAge		diagnosis of liver failure	participant age in first Chronic liver failure diagnosis																				
+GCS:DisTBDx	DisTBDx		diagnosis of tuberculosis	if the diagnosis of Tuberculosis was made for participant by a physician																				
+GCS:DisTBAge	DisTBAge		diagnosis of tuberculosis	participant age in first Tuberculosis diagnosis																				
+GCS:SurgeryFlag	SurgeryFlag		surgical interventions	If the participant had had any history of surgery																				
+GCS:SurgeryType	SurgeryType		surgical interventions	Specifies the participant surgery Type																				
+GCS:SurgeryAge	SurgeryAge		surgical interventions	Specifies the participant age in surgery Time																				
+GCS:TransfusionFlag	TransfusionFlag			if the participant has had Transfusion history																				
+GCS:TransfusionRecentFlag	TransfusionRecentFlag			if the participant has Transfusion history in last month																				
+GCS:SymRefluxFlag	SymRefluxFlag		occurrence of acid reflux	if the participant has Reflux Symptom history select yes if not select no																				
+GCS:SymRefluxWhen	SymRefluxWhen		occurrence of acid reflux	when Reflux Symptom happen in First time																				
+GCS:SymHeartburnFlag	SymHeartburnFlag		occurrence of heartburn	if the participant has Heartburn Symptom history select yes if not select no																				
+GCS:SymHeartburnWhen	SymHeartburnWhen		occurrence of heartburn	when Heartburn Symptom happen in First time																				
+GCS:SymDifficultSwallowingFlag	SymDifficultSwallowingFlag		occurrence of difficulty swallowing	if the participant has Difficult Swallowing Symptom history select yes if not select no																				
+GCS:SymDifficultSwallowingWhen	SymDifficultSwallowingWhen		occurrence of difficulty swallowing	when Difficult Swallowing Symptom happen in First time																				
+GCS:SymRefluxPastYearFreq	SymRefluxPastYearFreq		occurrence of acid reflux	if the participant has Reflux Symptom in past year select yes if not select no																				
+GCS:SymRefluxPastYearSeverity	SymRefluxPastYearSeverity		occurrence of acid reflux	Severity Reflux Symptom in past year																				
+GCS:SymRefluxPriorYearsFreq	SymRefluxPriorYearsFreq		occurrence of acid reflux	if the participant has Reflux Symptom in Prior year select yes if not select no																				
+GCS:SymRefluxPriorYearsSeverity	SymRefluxPriorYearsSeverity		occurrence of acid reflux	Severity Reflux Symptom in Prior year																				
+GCS:RefluxHeartburnTXFlag	RefluxHeartburnTXFlag		medication history	if participant used drug for Heartburn symptoms select yes if not select no and if participant doesn't have symtom selectLack of signage	should we create medication for heartburn?																			
+GCS:WeightLossFlag	WeightLossFlag		clinical history	if the patient has Weightloss in past year select yes if not select no	should we be more specific here?																			
+GCS:WeightLossAmount	WeightLossAmount		clinical history	Specifies the amount of weight loss																				
+GCS:WeightLossIntent	WeightLossIntent		clinical history	if the patient has Intentional weight loss select Yes if not select no and doesn't have weight loss select I have no weight loss																				
+GCS:cancerdxflag	cancerdxflag		clinical history of cancer	Past history of cancer diagnosed by a physician?																				
+GCS:cancerdxage	cancerdxage		clinical history of cancer	Year of diagnosis of cancer if detected in participant																				
+GCS:cancerdxsite	cancerdxsite		clinical history of cancer	Original site of cancer																				
+GCS:CancRelRelativeCode_1	CancRelRelativeCode_1		clinical history of cancer	Specifies the relative of participants with a history of cancer																				
+GCS:CancRelAgeDiagnosis_1	CancRelAgeDiagnosis_1		clinical history of cancer	Specifies the age of relative when cancer was diagnosed																				
+GCS:CancRelSite_1	CancRelSite_1		clinical history of cancer	Specifies the site of cancer in the relative of participant																				
+GCS:CancRelICD10_1	CancRelICD10_1		clinical history of cancer	Specifies the ICD-10 code of cancer in the relative of participant																				
+GCS:CancRelRelativeCode_2	CancRelRelativeCode_2		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+GCS:CancRelAgeDiagnosis_2	CancRelAgeDiagnosis_2		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+GCS:CancRelSite_2	CancRelSite_2		family clinical history	Specifies the site of cancer in the relative of participant																				
+GCS:CancRelICD10_2	CancRelICD10_2		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+GCS:CancRelRelativeCode_3	CancRelRelativeCode_3		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+GCS:CancRelAgeDiagnosis_3	CancRelAgeDiagnosis_3		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+GCS:CancRelSite_3	CancRelSite_3		family clinical history	Specifies the site of cancer in the relative of participant																				
+GCS:CancRelICD10_3	CancRelICD10_3		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+GCS:CancRelRelativeCode_4	CancRelRelativeCode_4		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+GCS:CancRelAgeDiagnosis_4	CancRelAgeDiagnosis_4		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+GCS:CancRelSite_4	CancRelSite_4		family clinical history	Specifies the site of cancer in the relative of participant																				
+GCS:CancRelICD10_4	CancRelICD10_4		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+GCS:TobEverRegularFlag	TobEverRegularFlag	subclass	tobacco	Specifies the participant used cigar for 6 Months																				
+GCS:TobCigsNow	TobCigsNow	subclass	tobacco	Specifies the participant uses cigar Now																				
+GCS:TobNonCigFlag	TobNonCigFlag	subclass	tobacco	Specifies the participant used tobacco other than cigar for 6 Months																				
+GCS:TobStartAge_1	TobStartAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, first history																				
+GCS:TobEndAge_1	TobEndAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, first history																				
+GCS:TobDuration_1	TobDuration_1	subclass	tobacco	Specifies the participant Used tobacco Duration, first history																				
+GCS:TobType_1	TobType_1	subclass	tobacco	Specifies the participant Used type of Tobacco, first history																				
+GCS:TobNumberPerDay_1	TobNumberPerDay_1	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, first history																				
+GCS:TobDaysPerWeek_1	TobDaysPerWeek_1	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, first history																				
+GCS:CigNumPerDay_1	CigNumPerDay_1	subclass	tobacco	Specifies the participant Used this cigar how many times per day, first history																				
+GCS:Cigpackyear_1	Cigpackyear_1	subclass	tobacco	Specifies the participant cumulative use, first history																				
+GCS:TobStartAge_2	TobStartAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, second history																				
+GCS:TobEndAge_2	TobEndAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, second history																				
+GCS:TobDuration_2	TobDuration_2	subclass	tobacco	Specifies the participant Used tobacco Duration, second history																				
+GCS:TobType_2	TobType_2	subclass	tobacco	Specifies the participant Used type of Tobacco, second history																				
+GCS:TobNumberPerDay_2	TobNumberPerDay_2	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, second history																				
+GCS:TobDaysPerWeek_2	TobDaysPerWeek_2	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, second history																				
+GCS:CigNumPerDay_2	CigNumPerDay_2	subclass	tobacco	Specifies the participant Used this cigar how many times per day, second history																				
+GCS:Cigpackyear_2	Cigpackyear_2	subclass	tobacco	Specifies the participant cumulative use, second history																				
+GCS:TobStartAge_3	TobStartAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, third history																				
+GCS:TobEndAge_3	TobEndAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, third history																				
+GCS:TobDuration_3	TobDuration_3	subclass	tobacco	Specifies the participant Used tobacco Duration, third history																				
+GCS:TobType_3	TobType_3	subclass	tobacco	Specifies the participant Used type of Tobacco, third history																				
+GCS:TobNumberPerDay_3	TobNumberPerDay_3	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, third history																				
+GCS:TobDaysPerWeek_3	TobDaysPerWeek_3	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, third history																				
+GCS:CigNumPerDay_3	CigNumPerDay_3	subclass	tobacco	Specifies the participant Used this cigar how many times per day, third history																				
+GCS:Cigpackyear_3	Cigpackyear_3	subclass	tobacco	Specifies the participant cumulative use, third history																				
+GCS:TobStartAge_4	TobStartAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, fourth history																				
+GCS:TobEndAge_4	TobEndAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, fourth history																				
+GCS:TobDuration_4	TobDuration_4	subclass	tobacco	Specifies the participant Used tobacco Duration, fourth history																				
+GCS:TobType_4	TobType_4	subclass	tobacco	Specifies the participant Used type of Tobacco, fourth history																				
+GCS:TobNumberPerDay_4	TobNumberPerDay_4	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, fourth history																				
+GCS:TobDaysPerWeek_4	TobDaysPerWeek_4	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, fourth history																				
+GCS:CigNumPerDay_4	CigNumPerDay_4	subclass	tobacco	Specifies the participant Used this cigar how many times per day, fourth history																				
+GCS:Cigpackyear_4	Cigpackyear_4	subclass	tobacco	Specifies the participant cumulative use, fourth history																				
+GCS:total_packyear	total_packyear	subclass	tobacco	Specifies the participant total cumulative use																				
+GCS:OpiateEverRegularFlag	OpiateEverRegularFlag		opiate use history	Specifies the participant ever used opiume for 6 Months																				
+GCS:OpiatePersonalChildhoodExp	OpiatePersonalChildhoodExp		opiate use history	Specifies the using opium in Childhood																				
+GCS:OpiateAdministeredToChildrenFlag	OpiateAdministeredToChildrenFlag			Specifies the participant gave opium to children	???																			
+GCS:OpiateType	OpiateType		opiate use history	Specifies the participant Used Opium type																				
+GCS:OpiateRoute	OpiateRoute		opiate use history	Specifies the route by which participant uses opium																				
+GCS:OpiateStartAge_1	OpiateStartAge_1		opiate use history	Specifies the participant Used this Opium type From Age, first history																				
+GCS:OpiateEndAge_1	OpiateEndAge_1		opiate use history	Specifies the participant Used this Opium type To Age, first history																				
+GCS:OpiateDuration_1	OpiateDuration_1		opiate use history	Specifies the participant Used this Opium Duration, first history																				
+GCS:OpiateNokhod_1	OpiateNokhod_1		opiate use history	Specifies the participant Used this Opium amount in Pea size, first history																				
+GCS:OpiateDaysPerWeek_1	OpiateDaysPerWeek_1		opiate use history	Specifies the participant Used this Opium day in week, first history																				
+GCS:OpiateAmountperDay_1	OpiateAmountperDay_1		opiate use history	Specifies the participant Used this Opium Amount per day, first history																				
+GCS:Opiatecum_1	Opiatecum_1		opiate use history	Specifies the participant cumulative use of Opium, first history																				
+GCS:OpiateStartAge_2	OpiateStartAge_2		opiate use history	Specifies the participant Used this Opium type From Age, second history																				
+GCS:OpiateEndAge_2	OpiateEndAge_2		opiate use history	Specifies the participant Used this Opium type To Age, second history																				
+GCS:OpiateDuration_2	OpiateDuration_2		opiate use history	Specifies the participant Used this Opium Duration, second history																				
+GCS:OpiateNokhod_2	OpiateNokhod_2		opiate use history	Specifies the participant Used this Opium amount in Pea size, second history																				
+GCS:OpiateDaysPerWeek_2	OpiateDaysPerWeek_2		opiate use history	Specifies the participant Used this Opium day in week, second history																				
+GCS:OpiateAmountperDay_2	OpiateAmountperDay_2		opiate use history	Specifies the participant Used this Opium Amount per day, second history																				
+GCS:Opiatecum_2	Opiatecum_2		opiate use history	Specifies the participant cumulative use of Opium, second history																				
+GCS:OpiateStartAge_3	OpiateStartAge_3		opiate use history	Specifies the participant Used this Opium type From Age, third history																				
+GCS:OpiateEndAge_3	OpiateEndAge_3		opiate use history	Specifies the participant Used this Opium type To Age, third history																				
+GCS:OpiateDuration_3	OpiateDuration_3		opiate use history	Specifies the participant Used this Opium Duration, third history																				
+GCS:OpiateNokhod_3	OpiateNokhod_3		opiate use history	Specifies the participant Used this Opium amount in Pea size, third history																				
+GCS:OpiateDaysPerWeek_3	OpiateDaysPerWeek_3		opiate use history	Specifies the participant Used this Opium day in week, third history																				
+GCS:OpiateAmountperDay_3	OpiateAmountperDay_3		opiate use history	Specifies the participant Used this Opium Amount per day, third history																				
+GCS:Opiatecum_3	Opiatecum_3		opiate use history	Specifies the participant cumulative use of Opium, third history																				
+GCS:OpiateStartAge_4	OpiateStartAge_4		opiate use history	Specifies the participant Used this Opium type From Age, fourth history																				
+GCS:OpiateEndAge_4	OpiateEndAge_4		opiate use history	Specifies the participant Used this Opium type To Age, fourth history																				
+GCS:OpiateDuration_4	OpiateDuration_4		opiate use history	Specifies the participant Used this Opium Duration, fourth history																				
+GCS:OpiateNokhod_4	OpiateNokhod_4		opiate use history	Specifies the participant Used this Opium amount in Pea size, fourth history																				
+GCS:OpiateDaysPerWeek_4	OpiateDaysPerWeek_4		opiate use history	Specifies the participant Used this Opium day in week, fourth history																				
+GCS:OpiateAmountperDay_4	OpiateAmountperDay_4		opiate use history	Specifies the participant Used this Opium Amount per day, fourth history																				
+GCS:Opiatecum_4	Opiatecum_4		opiate use history	Specifies the participant cumulative use of Opium, fourth history																				
+GCS:TotalNokhodDay	TotalNokhodDay		opiate use history	Specifies the participant total cumulative use of Opium																				
+GCS:AlcEverRegularFlag	AlcEverRegularFlag	subclass	alcohol	Specifies the participant ever used alcohol for 6 Months																				
+GCS:AlcStartAge_1	AlcStartAge_1	subclass	alcohol	Specifies the participant used alcohol From Age, first history																				
+GCS:AlcEndAge_1	AlcEndAge_1	subclass	alcohol	Specifies the participant used alcohol To Age, first history																				
+GCS:AlcType_1	AlcType_1	subclass	alcohol	Specifies the participant alcohol used Type, first history																				
+GCS:AlcQuantityPerEpisode_1	AlcQuantityPerEpisode_1	subclass	alcohol	Specifies the average alcohol the participant used per episode, first history																				
+GCS:AlcEpisodesPerMonth_1	AlcEpisodesPerMonth_1	subclass	alcohol	Specifies the participant Alcohol episodes in month, first history																				
+GCS:AlcStartAge_2	AlcStartAge_2	subclass	alcohol	Specifies the participant used alcohol From Age, second history																				
+GCS:AlcEndAge_2	AlcEndAge_2	subclass	alcohol	Specifies the participant used alcohol To Age, second history																				
+GCS:AlcType_2	AlcType_2	subclass	alcohol	Specifies the participant alcohol used Type, second history																				
+GCS:AlcQuantityPerEpisode_2	AlcQuantityPerEpisode_2	subclass	alcohol	Specifies the average alcohol the participant used per episode, second history																				
+GCS:AlcEpisodesPerMonth_2	AlcEpisodesPerMonth_2	subclass	alcohol	Specifies the participant Alcohol episodes in month, second history																				
+GCS:AlcStartAge_3	AlcStartAge_3	subclass	alcohol	Specifies the participant used alcohol From Age, third history																				
+GCS:AlcEndAge_3	AlcEndAge_3	subclass	alcohol	Specifies the participant used alcohol To Age, third history																				
+GCS:AlcType_3	AlcType_3	subclass	alcohol	Specifies the participant alcohol used Type, third history																				
+GCS:AlcQuantityPerEpisode_3	AlcQuantityPerEpisode_3	subclass	alcohol	Specifies the average alcohol the participant used per episode, third history																				
+GCS:AlcEpisodesPerMonth_3	AlcEpisodesPerMonth_3	subclass	alcohol	Specifies the participant Alcohol episodes in month, third history																				
+GCS:DrugCurrentuse	DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
+GCS:antiHTN	antiHTN	subclass	history of medication for hypertension	Anti-hypertensive drugs: 1: diuretics 2: beta-blockers 3: ACE Inhibitors 4: ARBs 5: Alpha-adrenergic blockers 6: Calcium channel blockers 7:other anti-hypertensives																				
+GCS:antiDM	antiDM	subclass	history of medication for diabetes	Anti-diabetic drugs: 1: Glibenclamide 2: metformin 3: insulin 4: other																				
+GCS:cardiac	cardiac	subclass	history of medication for cardiac disease	Cardiac drugs: 1: Anti-platelets 2: statins 3: Beta-blockers 4: Nitrates 5: ACE Inhibitors 6: ARBs 7: Calcium Channel blockers 8: other																				
+GCS:antilipid	antilipid	subclass	history of medication for high cholesterol	Lipid-lowering drugs: 1: Statins 2: Gemfibrozil 3: other																				
+GCS:mentaldrug	mentaldrug	subclass	history of medication for mental disorder	Mental disorders: 1: Benzodiazepines 2: Sodium Valproate 3: Anti-epileptics 4: Antidepressants 5: Anti-anxiety medications 6: Psychoactive medications																				
+GCS:Corticosteroid	Corticosteroid	subclass	use of corticosteroids	Corticosteroids: 1: injection 2: oral 3: topical																				
+GCS:Gidrugs	Gidrugs	subclass	history of medication for gastrointestinal disease	Gastrointestinal: 1: H2 Blockers 2: PPIs 3: Clindinium C																				
+GCS:antibiotics	antibiotics	subclass	use of antibiotics	Antibiotics: 1: Amoxicillin 2: Cefixime 3: Azithromycin 4: Metronidazole 5: other																				
+GCS:diuretic	diuretic	subclass	use of diuretics	Diuretics																				
+GCS:betablocker	betablocker	subclass	use of beta blockers	Beta Blockers																				
+GCS:ACEinhibitor	ACEinhibitor	subclass	use of angiotensin convertin enzyme inhibitors	Angiotensin Converting Enzyme Inhibitors																				
+GCS:ARB	ARB	subclass	use of angiotensin receptor blockers	Angiotensin Receptor Blockers																				
+GCS:alphablocker	alphablocker	subclass	use of alpha adrenergic blockers	Alpha Adrenergic Blockers																				
+GCS:CCBlocker	CCBlocker	subclass	use of calcium channel blockers	Calcium Channel Blockers																				
+GCS:Glibenclamide	Glibenclamide	subclass	use of glibenclamide	Glibenclamide																				
+GCS:Metformin	Metformin	subclass	use of metformin	Metformin																				
+GCS:Insulin	Insulin	subclass	use of insulin	Insulin																				
+GCS:Antiplatelets	Antiplatelets	subclass	use of antiplatelets	Anti-platelets																				
+GCS:Statins	Statins	subclass	use of statins	Statins																				
+GCS:Nitrates	Nitrates	subclass	use of nitrates	Nitrates																				
+GCS:Gemfibrozil	Gemfibrozil	subclass	use of gemfibroxil	Gemfibrozil																				
+GCS:Acetaminophen	Acetaminophen	subclass	use of acetaminophen	Acetaminophen and Acetaminophen Codein																				
+GCS:Ibuprofen	Ibuprofen	subclass	use of ibuprofen	Ibuprofen																				
+GCS:Diclophenac	Diclophenac	subclass	use of diclophenac	Diclophenac																				
+GCS:Indomethacin	Indomethacin	subclass	use of indomethacin	Indomethacin																				
+GCS:Levothyroxin	Levothyroxin	subclass	use of levthyroxine	Levthyroxin																				
+GCS:Methotrexate	Methotrexate	subclass	use of methotrexate	Methotrexate																				
+GCS:Other	Other	subclass	medication history	Other																				
+GCS:DrugCurrentuse	DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
+GCS:drugname_1	drugname_1	subclass	medication history	Name of drug 1	Could name fall under "prescription"?																			
+GCS:drugduration_1	drugduration_1	subclass	medication history	Number of years being under treatment 1																				
+GCS:drugfrequency_1	drugfrequency_1	subclass	posology	Frequency of drug consumption 1																				
+GCS:drugdose_1	drugdose_1	subclass	posology	Dose of drug consumed 1																				
+GCS:drugname_2	drugname_2	subclass	medication history	Name of drug 2																				
+GCS:drugduration_2	drugduration_2	subclass	medication history	Number of years being under treatment 2																				
+GCS:drugfrequency_2	drugfrequency_2	subclass	posology	Frequency of drug consumption 2																				
+GCS:drugdose_2	drugdose_2	subclass	posology	Dose of drug consumed 2																				
+GCS:drugname_3	drugname_3	subclass	medication history	Name of drug 3																				
+GCS:drugduration_3	drugduration_3	subclass	medication history	Number of years being under treatment 3																				
+GCS:drugfrequency_3	drugfrequency_3	subclass	posology	Frequency of drug consumption 3																				
+GCS:drugdose_3	drugdose_3	subclass	posology	Dose of drug consumed 3																				
+GCS:drugname_4	drugname_4	subclass	medication history	Name of drug 4																				
+GCS:drugduration_4	drugduration_4	subclass	medication history	Number of years being under treatment 4																				
+GCS:drugfrequency_4	drugfrequency_4	subclass	posology	Frequency of drug consumption 4																				
+GCS:drugdose_4	drugdose_4	subclass	posology	Dose of drug consumed 4																				
+GCS:drugname_5	drugname_5	subclass	medication history	Name of drug 5																				
+GCS:drugduration_5	drugduration_5	subclass	medication history	Number of years being under treatment 5																				
+GCS:drugfrequency_5	drugfrequency_5	subclass	posology	Frequency of drug consumption 5																				
+GCS:drugdose_5	drugdose_5	subclass	posology	Dose of drug consumed 5																				
+GCS:drugname_6	drugname_6	subclass	medication history	Name of drug 6																				
+GCS:drugduration_6	drugduration_6	subclass	medication history	Number of years being under treatment 6																				
+GCS:drugfrequency_6	drugfrequency_6	subclass	posology	Frequency of drug consumption 6																				
+GCS:drugdose_6	drugdose_6	subclass	posology	Dose of drug consumed 6																				
+GCS:drugname_7	drugname_7	subclass	medication history	Name of drug 7																				
+GCS:drugduration_7	drugduration_7	subclass	medication history	Number of years being under treatment 7																				
+GCS:drugfrequency_7	drugfrequency_7	subclass	posology	Frequency of drug consumption 7																				
+GCS:drugdose_7	drugdose_7	subclass	posology	Dose of drug consumed 7																				
+GCS:drugname_8	drugname_8	subclass	medication history	Name of drug 8																				
+GCS:drugduration_8	drugduration_8	subclass	medication history	Number of years being under treatment 8																				
+GCS:drugfrequency_8	drugfrequency_8	subclass	posology	Frequency of drug consumption 8																				
+GCS:drugdose_8	drugdose_8	subclass	posology	Dose of drug consumed 8																				
+GCS:drugname_9	drugname_9	subclass	medication history	Name of drug 9																				
+GCS:drugduration_9	drugduration_9	subclass	medication history	Number of years being under treatment 9																				
+GCS:drugfrequency_9	drugfrequency_9	subclass	posology	Frequency of drug consumption 9																				
+GCS:drugdose_9	drugdose_9	subclass	posology	Dose of drug consumed 9																				
+GCS:drugname_10	drugname_10	subclass	medication history	Name of drug 10																				
+GCS:drugduration_10	drugduration_10	subclass	medication history	Number of years being under treatment 10																				
+GCS:drugfrequency_10	drugfrequency_10	subclass	posology	Frequency of drug consumption 10																				
+GCS:drugdose_10	drugdose_10	subclass	posology	Dose of drug consumed 10																				
+GCS:OralPermanentTeethLossFlag	OralPermanentTeethLossFlag	subclass	oral health history	Permanent Teeth Loss																				
+GCS:OralPermanentTeethAgeFirstLoss	OralPermanentTeethAgeFirstLoss	subclass	oral health history	Specifies the age of first Permanent Teeth Loss																				
+GCS:OralUpperDentureFlag	OralUpperDentureFlag	subclass	oral health history	Specifies the participant used Upper Denture																				
+GCS:OralLowerDentureFlag	OralLowerDentureFlag	subclass	oral health history	Specifies the participant used Lower Denture																				
+GCS:OralUpperDentureUse	OralUpperDentureUse	subclass	oral health history	Specifies the participant used Upper Denture during the day																				
+GCS:OralLowerDentureUse	OralLowerDentureUse	subclass	oral health history	Specifies the participant used Lower Denture during the day																				
+GCS:OralAgeDentureUpper	OralAgeDentureUpper	subclass	oral health history	Specifies the age of participant first used Upper Denture																				
+GCS:OralAgeDentureLower	OralAgeDentureLower	subclass	oral health history	Specifies the age of participant First used Lower Denture																				
+GCS:OralFreqBrushing	OralFreqBrushing	subclass	oral health history	Specifies the participant Brushing Frequency																				
+GCS:OralFoodDiscomfortFlag	OralFoodDiscomfortFlag	subclass	oral health history	Specifies the frequency the participant experienced discomfort while eating food in Past Year																				
+GCS:OralFoodDiscomfortType	OralFoodDiscomfortType	subclass	oral health history	Specifies the food that caused discomfort for the participant																				
+GCS:OralNumTeeth	OralNumTeeth	subclass	oral health history	Specifies the participant Total number of teeth																				
+GCS:OralNumTeethDecayed	OralNumTeethDecayed	subclass	oral health history	Specifies the participant Total number of Decayed teeth																				
+GCS:OralNumTeethMissing	OralNumTeethMissing	subclass	oral health history	Specifies the participant Total number of Missing teeth																				
+GCS:OralNumTeethFilled	OralNumTeethFilled	subclass	oral health history	Specifies the participant Total number of Filled teeth																				
+GCS:OralMucosa	OralMucosa	subclass	oral health history	Specifies the participant Mucosa Status																				
+GCS:TeaTempDegrees	TeaTempDegrees		information about diet	Specifies participant consumption of tea temperature	is this diet?																			
+GCS:TeaTempDescription	TeaTempDescription		information about diet	Specifies participant used tea type																				
+GCS:TeaSteepingTime	TeaSteepingTime		information about diet	Specifies the duration between pouring and drinking the tea																				
+GCS:TeaSipOrGulp	TeaSipOrGulp		information about diet	Specifies how participant drinks tea																				
+GCS:physactworkallyearflag	physactworkallyearflag	subclass	occupation|physical activity	Working all months of the year?																				
+GCS:physactworkmonths	physactworkmonths	subclass	occupation|physical activity	Number of working months in a year																				
+GCS:physactworkstrenuousflag	physactworkstrenuousflag	subclass	physical activity	Daily intensive physical activity?																				
+GCS:physactworkstrenuousfreq	physactworkstrenuousfreq	subclass	physical activity	Number of working days in a week																				
+GCS:physactworkstrenuoushours	physactworkstrenuoushours	subclass	physical activity	Number of working hours in a day																				
+GCS:physactworkstrenuousyears	physactworkstrenuousyears	subclass	physical activity	Number of entire working years																				
+GCS:physacthouseworkflag	physacthouseworkflag	subclass	physical activity	Doing house work?																				
+GCS:physacthouseworkfreq	physacthouseworkfreq	subclass	physical activity	Number of working days in a week																				
+GCS:physacthouseworkhours	physacthouseworkhours	subclass	physical activity	Number of working hours in a day																				
+GCS:physacthouseworkyears	physacthouseworkyears	subclass	physical activity	Number of entire working years																				
+GCS:physacthouseworkminsduringwork	physacthouseworkminsduringwork	subclass	physical activity	Doing house work: minutes during working times																				
+GCS:physacthouseworkminsnowork	physacthouseworkminsnowork	subclass	physical activity	Doing house work: minutes during leasure times																				
+GCS:physactexmildminsduringwork	physactexmildminsduringwork	subclass	physical activity	Mild exercise such as jogging: minutes during working times																				
+GCS:physactexmildminsnowork	physactexmildminsnowork	subclass	physical activity	Mild exercise such as jogging: minutes during leasure times																				
+GCS:physactexmodminsduringwork	physactexmodminsduringwork	subclass	physical activity	Moderate exercise such as volleyball: minutes during working times																				
+GCS:physactexmodminsnowork	physactexmodminsnowork	subclass	physical activity	Moderate exercise such as volleyball: minutes during leasure times																				
+GCS:physactexstrenminsduringwork	physactexstrenminsduringwork	subclass	physical activity	Intensive exercise such as horse riding: minutes during working times																				
+GCS:physactexstrenminsnowork	physactexstrenminsnowork	subclass	physical activity	Intensive exercise such as horse riding: minutes during leasure times																				
+GCS:physacttvminsduringwork	physacttvminsduringwork	subclass	physical activity	Watching TV, resting, reading: minutes during working times																				
+GCS:physacttvminsnowork	physacttvminsnowork	subclass	physical activity	Watching TV, resting, reading: minutes during leasure times																				
+GCS:Metabolic Equivalent Task	Metabolic Equivalent Task	subclass	physical activity	Energy cost of physical activities defined as the ratio of metabolic rate (and therefore the rate of energy consumption) during a specific physical activity to a reference metabolic rate																				
+GCS:AnimalStartAge_1	AnimalStartAge_1		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, first history	not sure if this is correct - do we want to be more specific?																			
+GCS:AnimalEndAge_1	AnimalEndAge_1		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, first history																				
+GCS:AnimalLevelOfContact_1	AnimalLevelOfContact_1		lifestyle and behaviours	The intensity of animal contact, first history																				
+GCS:AnimalType_1	AnimalType_1		lifestyle and behaviours	The type of animal, first history																				
+GCS:AnimalStartAge_2	AnimalStartAge_2		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, second history																				
+GCS:AnimalEndAge_2	AnimalEndAge_2		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, second history																				
+GCS:AnimalLevelOfContact_2	AnimalLevelOfContact_2		lifestyle and behaviours	The intensity of animal contact, second history																				
+GCS:AnimalType_2	AnimalType_2		lifestyle and behaviours	The type of animal, second history																				
+GCS:AnimalStartAge_3	AnimalStartAge_3		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, third history																				
+GCS:AnimalEndAge_3	AnimalEndAge_3		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, third history																				
+GCS:AnimalLevelOfContact_3	AnimalLevelOfContact_3		lifestyle and behaviours	The intensity of animal contact, third history																				
+GCS:AnimalType_3	AnimalType_3		lifestyle and behaviours	The type of animal, third history																				
+GCS:AnimalStartAge_4	AnimalStartAge_4		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, fourth history																				
+GCS:AnimalEndAge_4	AnimalEndAge_4		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, fourth history																				
+GCS:AnimalLevelOfContact_4	AnimalLevelOfContact_4		lifestyle and behaviours	The intensity of animal contact, fourth history																				
+GCS:AnimalType_4	AnimalType_4		lifestyle and behaviours	The type of animal, fourth history																				
+GCS:bodyindicessizeage15	bodyindicessizeage15	subclass	anthropometry	The body size participants assume they have had based on pictogram when they were 15 years old																				
+GCS:bodyindicessizeage30	bodyindicessizeage30	subclass	anthropometry	The body size participants assume they have had based on pictogram when they wer3 30 years old																				
+GCS:bodyindicessizenow	bodyindicessizenow	subclass	anthropometry	The body size participants assume they have at the present time based on pictogram																				
+GCS:bodyindicesheight	bodyindicesheight	equivalent	height	Height																				
+GCS:bodyindicesweight	bodyindicesweight	equivalent	weight	Weight																				
+GCS:bodyindiceswaist	bodyindiceswaist	equivalent	waist circumference value	Waist circumference																				
+GCS:bodyindiceships	bodyindiceships	equivalent	hip circumference value	Hip circumference																				
+GCS:BMI	BMI	equivalent	body mass index value	Body mass index																				
+GCS:bpright1sbp	bpright1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the right arm																				
+GCS:bpright1dbp	bpright1dbp	subclass	diastolic blood pressure value	First measurement ofdiastolic blood pressure from the right arm																				
+GCS:bpright2sbp	bpright2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the right arm																				
+GCS:bpright2dbp	bpright2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the right arm																				
+GCS:bpleft1sbp	bpleft1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the left arm																				
+GCS:bpleft1dbp	bpleft1dbp	subclass	diastolic blood pressure value	First measurement of diastolic blood pressure from the left arm																				
+GCS:bpleft2sbp	bpleft2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the left arm																				
+GCS:bpleft2dbp	bpleft2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the left arm																				
+GCS:m_sbp	m_sbp	subclass	systolic blood pressure value	Mean systolic blood pressure measured second time																				
+GCS:m_dbp	m_dbp	subclass	diastolic blood pressure value	Mean diastolic blood pressure measured second time																				
+GCS:high_sbp	high_sbp	subclass	systolic blood pressure value	Systolic blood pressure >= 140 mmHg	also high BP																			
+GCS:high_dbp	high_dbp	subclass	diastolic blood pressure value	Diastolic blood pressure >= 90 mmHg	also high BP																			
+GCS:htndrug	htndrug		use of antihypertensive agents	Consumption of any anti-hypertensive medication for more than 6 months																				
+GCS:HTN	HTN		diagnosis of hypertension	Being hypertensive																				
+GCS:HTNcat	HTNcat		diagnosis of hypertension	Categorization of hypetrension																				
+GCS:preHTN	preHTN		diagnosis of hypertension	SBP/DBP >=120/80 AND <140/90	how do we handle prehypertension?																			
+GCS:pulse_p	pulse_p		calculated blood pressure value	Difference between SBP and DBP																				
+GCS:mean_bp	mean_bp		calculated blood pressure value	mean value of SBP and DBP																				
+GCS:mid_bp	mid_bp		calculated blood pressure value	Mid value of SBP and DBP																				
+GCS:diffsbp_right_left	diffsbp_right_left		systolic blood pressure value	Difference in SBP between arms																				
+GCS:diffdbp_right_left	diffdbp_right_left		diastolic blood pressure value	Difference in DBP between arms																				
+GCS:Energy	Energy		information about diet	Amount consumed per day	do we want to be more specific?																			
+GCS:fat	fat		information about diet	Amount consumed per day																				
+GCS:salt	salt		information about diet	Amount consumed per day																				
+GCS:protein	protein		information about diet	Amount consumed per day																				
+GCS:total saturated fat	total saturated fat		information about diet	Amount consumed per day																				
+GCS:total trans fat	total trans fat		information about diet	Amount consumed per day																				
+GCS:hydrogenated oil	hydrogenated oil		information about diet	Amount consumed per day																				
+GCS:carbohyderate	carbohyderate		information about diet	Amount consumed per day																				
+GCS:red meat	red meat		information about diet	Amount consumed per day																				
+GCS:processed meat	processed meat		information about diet	Amount consumed per day																				
+GCS:fruits	fruits		information about diet	Amount consumed per day																				
+GCS:vegetables	vegetables		information about diet	Amount consumed per day																				
+GCS:dairy products	dairy products		information about diet	Amount consumed per day																				
+GCS:milk	milk		information about diet	Amount consumed per day																				
+GCS:dietary fiber	dietary fiber		information about diet	Amount consumed per day																				
+GCS:Fish	Fish		information about diet	Amount consumed per day																				
+GCS:Chicken	Chicken		information about diet	Amount consumed per day																				
+GCS:SodiumNa	SodiumNa		information about diet	Amount consumed per day																				
+GCS:Calcium	Calcium		information about diet	Amount consumed per day																				
+GCS:Fe	Fe		information about diet	Amount consumed per day																				
+GCS:Magnesium	Magnesium		information about diet	Amount consumed per day																				
+GCS:Phosphorus	Phosphorus		information about diet	Amount consumed per day																				
+GCS:Potassium	Potassium		information about diet	Amount consumed per day																				
+GCS:Zinc	Zinc		information about diet	Amount consumed per day																				
+GCS:Folate	Folate		information about diet	Amount consumed per day																				
+GCS:Vitamin D	Vitamin D		information about diet	Amount consumed per day																				
+GCS:Vitamin A	Vitamin A		information about diet	Amount consumed per day																				
+GCS:Vitamin B1	Vitamin B1		information about diet	Amount consumed per day																				
+GCS:Vitamin B2	Vitamin B2		information about diet	Amount consumed per day																				
+GCS:Vitamin B12	Vitamin B12		information about diet	Amount consumed per day																				
+GCS:Vitamin C	Vitamin C		information about diet	Amount consumed per day																				
+GCS:Niacin	Niacin		information about diet	Amount consumed per day																				
+GCS:Glycemic load	Glycemic load		information about diet	Amount consumed per day																				
+GCS:Glycemic Index	Glycemic Index		information about diet	Amount consumed per day																				
+GCS:Sugar intake	Sugar intake		information about diet	Amount consumed per day																				
+GCS:Nuts	Nuts		information about diet	Amount consumed per day																				
+GCS:tea	tea		information about diet	Amount consumed per day																				
+GCS:Coffee	Coffee		information about diet	Amount consumed per day																				
+GCS:fbg	fbg	equivalent	blood fasting glucose level value	Fasting Blood Glucose																				
+GCS:urea	urea			Urea																				
+GCS:creatinine	creatinine			Creatinine																				
+GCS:cholesterol	cholesterol			Total Cholesterol																				
+GCS:triglycerides	triglycerides			Triglycerides																				
+GCS:hdl	hdl			High Density Lipoprotein																				
+GCS:ast	ast			Aspartate Transaminase																				
+GCS:alt	alt			Alanine Transaminase																				
+GCS:alkalinep	alkalinep			Alkaline Phosphatase																				
+GCS:ldl	ldl			Low Density Lipoprotein																				
+GCS:ldlhdl	ldlhdl			LDL to HDL ratio																				
+GCS:gamma	gamma			Gamma Glutamyle Transpeptidase																				
+GCS:hbsag	hbsag			HBsAg																				
+GCS:hbsab	hbsab			HBsAb																				
+GCS:hbcab	hbcab			HBcAb																				
+GCS:hbv	hbv			HBV DNA																				
+GCS:hcv	hcv			HCV Antibody																				
+GCS:wbc	wbc			White Blood Cell																				
+GCS:rbc	rbc			Red Blood Cell																				
+GCS:hb	hb			Hemoglobin																				
+GCS:hct	hct			Hematocrit																				
+GCS:plt	plt		plateletcrit value	Platelet	maybe? not sure if this is the same																			
+GCS:mcv	mcv			Mean Corpuscular Volume																				
+GCS:mch	mch			Mean Corpuscular Hemoglobin																				
+GCS:mchc	mchc			Mean Corpuscular Hemoglobin Concentration																				
+GCS:rdw	rdw	equivalent	red blood cell distribution width value	Red Cell Distribution Width																				
+GCS:BloodType	BloodType	equivalent	blood type determination value	Specifies patient Blood Group																				
+GCS:Rh	Rh	equivalent	rheumatoid factor measurement value	Specifies patient Blood Rh																				
+GCS:BioSampHairAvailFlag	BioSampHairAvailFlag			if patient has hair sample select YES if not Selct No																				
+GCS:BioSampNailAvailFlag	BioSampNailAvailFlag			if patient has nail sample select YES if not Selct No																				
+GCS:BioSampBloodAvailFlag	BioSampBloodAvailFlag	equivalent	blood	if patient has Blood sample select YES if not Selct No																				
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								

--- a/mappings/gcs-mapping.tsv
+++ b/mappings/gcs-mapping.tsv
@@ -1,1002 +1,1001 @@
-Field ID	Field Label	Definition	Class Type	GECKO Label	Comment																			
-ID	LABEL		CLASS_TYPE	C % SPLIT=|																				
-GCS:0000000	GCS																							
-GCS:ID	Identity	Identity and contact information																						
-GCS:DEMO	Demographic Info	Demographic characteristics: sex, age, ethnicity, marital status, education	equivalent	demographic data																				
-GCS:FAM	Family members	Characteristics of relatives in the household	subclass	family and household structure																				
-GCS:RESID	Residence	The residential area (urban/rural), structure of the house, and duration of residing in the house	equivalent	residence																				
-GCS:SOURCE	Water and fuel source	Water source, heat and fuel system, and cooking method																						
-GCS:JOB	Job	The names of all jobs the participant has had and the duration of work	equivalent	occupation																				
-GCS:FOOD	Food preservation and cooking	Food preservation, frying, boiling, BBQ, steaming, ‚Ä¶																						
-GCS:PROP	Properties	Transferable and non-transferable belongings and wealth score (Multiple Correspondence Analysis)																						
-GCS:MED	Medical History	Suffering from any disease at the baseline of cohort	equivalent	clinical history																				
-GCS:CC	Chief complaints	The complaints of participants from their physical or mental sufferings																						
-GCS:CANCER	Cancer History	History of cancer, site, and age diagnosed in the participant or any of his/her relatives	equivalent	clinical history of cancer																				
-GCS:SMOK	Smoking	Ever or current smoker, age of use, type, number per day and days per week	equivalent	tobacco																				
-GCS:OPIUM	Opium use	Ever or current user, age and route of use, type, time per day and days per week	equivalent	opiate use history																				
-GCS:ALC	Alcohol use	Ever or current user, age of use, type, quantity per episode and episodes per month	equivalent	alcohol																				
-GCS:DRUGCAT	Drug history (1)	The main created categories of drugs consumed by participants	equivalent	recreational drug use history																				
-GCS:DRUGDETAIL	Drug History (2)	The exact name, duration, dose, and frequency of drugs consumed	equivalent	recreational drug use history																				
-GCS:ORAL	Oral health	Decayed, filled, and missing teeth along with the age of the participant in each of these occasions	equivalent	oral health history																				
-GCS:TEA	Tea	Tea temperature, type of tea, and type of habit for drinking the tea																						
-GCS:ACTIVITY	Physical activity	The duration and intensity of physical activities during working and leasure times of the day, and Metabolic Equivalent Task (MET)	equivalent	physical activity																				
-GCS:ANIMAL	Animal contact	The age of the participant in contact with animals, the duration and intensity of animal contact, and the type of animal																						
-GCS:ANTHRO	Anthropometric measurements	Physically measured height, weight, waist circumference, hip circumference and data of pictogram	equivalent	anthropometry																				
-GCS:BP	Blood pressure measurements	Both systolic and diastolic blood pressure measured in sitting position twice from each arm	equivalent	blood pressure																				
-GCS:FFQ	Food Frequency Questionnaire	Units of food categories consumed per day	equivalent	Food Frequency Questionnaire result																				
-GCS:LAB	Lab markers	Biochemical markers																						
-GCS:PID	PID	The Unique Id for eatch participant																						
-GCS:FirstName	FirstName	The first name of participant.																						
-GCS:LastName	LastName	The last name of participant.																						
-GCS:Province	Province	Specifies the participant Province of Residence	subclass	residence																				
-GCS:District	District	Specifies the participant District of Residence	subclass	residence																				
-GCS:City	City	Specifies the participant City of Residence	subclass	residence																				
-GCS:Subdistrict	Subdistrict	Specifies the participant Subdistrict of Residence	subclass	residence																				
-GCS:Village	Village	Specifies the participant Village of Residence	subclass	residence																				
-GCS:Street	Street	Specifies the participant Street of Residence	subclass	residence																				
-GCS:Alley	Alley	Specifies the participant Alley of Residence	subclass	residence																				
-GCS:CV name	CV name	Specifies the names of cities or villages in one variable	subclass	residence																				
-GCS:City_Village	City_Village	Specifies residence in cities or villages	subclass	residence																				
-GCS:HouseNumber	HouseNumber	Specifies the participant's House Number of Residence	subclass	residence																				
-GCS:ZipCode	ZipCode	Specifies the participant's Zip Code of Residence	subclass	residence																				
-GCS:HomePhone	HomePhone	Specifies the participants Home Phone																						
-GCS:AreaCode	AreaCode	Specifies the participant's home Phone Area Code																						
-GCS:CellPhone	CellPhone	Specifies the participant's Cell phone number																						
-GCS:HealthCenter	HealthCenter	participant related to this health center(the participant covered by this health center)																						
-GCS:FamilyMemPhone	FamilyMemPhone	Specifies the phone number of one of participant's family members																						
-GCS:FamilyMemAreaCode	FamilyMemAreaCode	Specifies the area code of the phone number of one of participant's family members																						
-GCS:FamilyMemName	FamilyMemName	Specifies the name of one family member of the participant																						
-GCS:FriendName	FriendName	Specifies the name of one of friends of the participant																						
-GCS:FriendProvince	FriendProvince	Specifies the province in which the friend of the participant resides																						
-GCS:FriendDistrict	FriendDistrict	Specifies the district in which the friend of the participant resides																						
-GCS:FriendCity	FriendCity	Specifies the city in which the friend of the participant resides																						
-GCS:FriendSubdistrict	FriendSubdistrict	Specifies the subdistrict in which the friend of the participant resides																						
-GCS:FriendVillage	FriendVillage	Specifies the village in which the friend of the participant resides																						
-GCS:FriendStreet	FriendStreet	Specifies the street in which the friend of the participant resides																						
-GCS:FriendAlley	FriendAlley	Specifies the alley in which the friend of the participant resides																						
-GCS:FriendHouseNumber	FriendHouseNumber	Specifies the house number in which the friend of the participant resides																						
-GCS:FriendZipCode	FriendZipCode	Specifies the zip code in which the friend of the participant resides																						
-GCS:FriendHomePhone	FriendHomePhone	Specifies the phone number of the participant's friend																						
-GCS:FriendAreaCode	FriendAreaCode	Specifies the area code of the phone number of participant's friend																						
-GCS:FriendCellPhone	FriendCellPhone	Specifies the cell phone number of participant's friend																						
-GCS:PlaceOfInterview	PlaceOfInterview	Specifies the participant interview place																						
-GCS:InterviewPDate_Y	InterviewPDate_Y	participant year of Interview date in Shamsi format																						
-GCS:InterviewPDate_M	InterviewPDate_M	participant month of Interview date in Shamsi format																						
-GCS:InterviewPDate_D	InterviewPDate_D	participant Day of Interview date in Shamsi format																						
-GCS:Gender	Gender	Specifies the participant Gender	equivalent	gender																				
-GCS:BdatePDate_Y	BdatePDate_Y	Year of participant Birth date in Shamsi format	subclass	age/birthdate																				
-GCS:BdatePDate_M	BdatePDate_M	Month of participant Birth date in Shamsi format	subclass	age/birthdate																				
-GCS:BdatePDate_D	BdatePDate_D	Day of participant Birth date in Shamsi format	subclass	age/birthdate																				
-GCS:Age_self	Age_self	Specifies the self-report participant age in inteview time	subclass	age/birthdate																				
-GCS:Age_new	Age_new	Age calculated from birth date and interview date	subclass	age/birthdate																				
-GCS:Ethnicity	Ethnicity	Specifies the participant Ethnicity	equivalent	ethnicity/race																				
-GCS:ethnicity_new	ethnicity_new	Specifies ethnicity by Turkmen or Non-turkmen	subclass	ethnicity/race																				
-GCS:MaritalStatus	MaritalStatus	Specifies the participant marital status	equivalent	marital status value																				
-GCS:marital_new	marital_new	Specifies marital status into married or non-married	subclass	marital status value																				
-GCS:Education	Education	Specifies the participant Education Level	equivalent	education																				
-GCS:FamilyInHousehold	FamilyInHousehold	Specifies the number of participant family living in the household	subclass	family and household structure																				
-GCS:BrothersN	BrothersN	Specifies participant No. of Brothers	subclass	family and household structure																				
-GCS:StepbrothersN	StepbrothersN	Specifies participant No. of Step brothers	subclass	family and household structure																				
-GCS:SistersN	SistersN	Specifies participant No. of Sisters	subclass	family and household structure																				
-GCS:Stepsisters	Stepsisters	Specifies participant No. of Step sisters	subclass	family and household structure																				
-GCS:Sons	Sons	Specifies participant No. of Sons	subclass	family and household structure																				
-GCS:Daughters	Daughters	Specifies participant No. of Daughters	subclass	family and household structure																				
-GCS:TwinYesNo	TwinYesNo	Specifies whether the participant has twin brother or sister	subclass	family and household structure																				
-GCS:TwinAlive	TwinAlive	Specifies whether the twin of the participant is alive	subclass	family and household structure																				
-GCS:ResDuration_1	ResDuration_1	Specifies the participant first residence history Duration	subclass	residence																				
-GCS:ResCitVill_1	ResCitVill_1	Specifies the participant first residence history in Village or City	subclass	residence																				
-GCS:ResDistrict_1	ResDistrict_1	Specifies the participant first residence history District	subclass	residence																				
-GCS:ResCitVillname_1	ResCitVillname_1	Specifies the participant first residence history City or village name	subclass	residence																				
-GCS:ResHouseType_1	ResHouseType_1	Specifies the participant first residence history House Type	subclass	residence																				
-GCS:ResDuration_2	ResDuration_2	Specifies the participant second residence history Duration	subclass	residence																				
-GCS:ResCitVill_2	ResCitVill_2	Specifies the participant second residence history in Village or City	subclass	residence																				
-GCS:ResDistrict_2	ResDistrict_2	Specifies the participant second residence history District	subclass	residence																				
-GCS:ResCitVillname_2	ResCitVillname_2	Specifies the participant second residence history City or village name	subclass	residence																				
-GCS:ResHouseType_2	ResHouseType_2	Specifies the participant second residence history House Type	subclass	residence																				
-GCS:ResDuration_3	ResDuration_3	Specifies the participant third residence history Duration	subclass	residence																				
-GCS:ResCitVill_3	ResCitVill_3	Specifies the participant third residence history in Village or City	subclass	residence																				
-GCS:ResDistrict_3	ResDistrict_3	Specifies the participant third residence history District	subclass	residence																				
-GCS:ResCitVillname_3	ResCitVillname_3	Specifies the participant third residence history City or village name	subclass	residence																				
-GCS:ResHouseType_3	ResHouseType_3	Specifies the participant third residence history House Type	subclass	residence																				
-GCS:FoodWatSource	FoodWatSource	Specifies participant used water source																						
-GCS:FoodWatYearsPipe	FoodWatYearsPipe	Specifies how many years participant used pipe water																						
-GCS:FoodWatPriorPipeSource	FoodWatPriorPipeSource	Specifies what water source participant used prior to pipe water																						
-GCS:HeatAndFuelDuration_1	HeatAndFuelDuration_1	Specifies the duration the participant Used Heating or Fuel system, first history																						
-GCS:HeatingSystemType_1	HeatingSystemType_1	Specifies the participant Used Heating Type, first history																						
-GCS:HeatMethod_1	HeatMethod_1	Specifies the participant Used Heating Type of fuel, first history																						
-GCS:CookingMethod_1	CookingMethod_1	Specifies the participant Used Cooking Type of fuel, first history																						
-GCS:HeatAndFuelDuration_2	HeatAndFuelDuration_2	Specifies the duration the participant Used Heating or Fuel system, second history																						
-GCS:HeatingSystemType_2	HeatingSystemType_2	Specifies the participant Used Heating Type, second history																						
-GCS:HeatMethod_2	HeatMethod_2	Specifies the participant Used Heating Type of fuel, second history																						
-GCS:CookingMethod_2	CookingMethod_2	Specifies the participant Used Cooking Type of fuel, second history																						
-GCS:HeatAndFuelDuration_3	HeatAndFuelDuration_3	Specifies the duration participant Used Heating or Fuel system, third history																						
-GCS:HeatingSystemType_3	HeatingSystemType_3	Specifies the participant Used Heating Type, third history																						
-GCS:HeatMethod_3	HeatMethod_3	Specifies the participant Used Heating Type of fuel, third history																						
-GCS:CookingMethod_3	CookingMethod_3	Specifies the participant Used Cooking Type of fuel, third history																						
-GCS:WorkEverWorkedFlag	WorkEverWorkedFlag	Working for at least one year of full-time job	subclass	occupation																				
-GCS:WorkAgeBegan	WorkAgeBegan	Specifies participant start work age	subclass	occupation																				
-GCS:WorkCurrently	WorkCurrently	Specifies participant work now	subclass	occupation																				
-GCS:JobsStartAge	JobsStartAge	Age of starting the job for last history	subclass	occupation																				
-GCS:JobsEndAge	JobsEndAge	Age of quiting the job for last history	subclass	occupation																				
-GCS:JobsTitleOccupation	JobsTitleOccupation	Name of the job	subclass	occupation																				
-GCS:JobsTitleOccupationCode	JobsTitleOccupationCode	Code of the job (Appendix)	subclass	occupation																				
-GCS:JobsHoursPerDay	JobsHoursPerDay	Number of working hours per day	subclass	occupation																				
-GCS:JobsIntensity	JobsIntensity	The intensity of physical activity during the job	subclass	occupation																				
-GCS:JobMonthPerYear	JobMonthPerYear	Number of working months per year	subclass	occupation																				
-GCS:HusbandOccupation	HusbandOccupation	Code of the husband job (Appendix)			maybe family?																			
-GCS:FoodWatFoodPreserve	FoodWatFoodPreserve	Specifies How to Preserve foods			is this lifestyle or diet?																			
-GCS:FoodWatBreadPreserve	FoodWatBreadPreserve	Specifies How to Preserve bread																						
-GCS:FoodWatShallowFryVeg	FoodWatShallowFryVeg	Specifies Using vegetable in Small frying																						
-GCS:FoodWatShallowFryMeat	FoodWatShallowFryMeat	Specifies Using Meat in Small frying																						
-GCS:FoodWatShallowFryFish	FoodWatShallowFryFish	Specifies Using Fish in Small frying																						
-GCS:FoodWatDeepFryVeg	FoodWatDeepFryVeg	Specifies Using vegetable in Deep frying																						
-GCS:FoodWatDeepFryMeat	FoodWatDeepFryMeat	Specifies Using Meat in Deep frying																						
-GCS:FoodWatDeepFryFish	FoodWatDeepFryFish	Specifies Using Fish in Deep frying																						
-GCS:FoodWatBBQVeg	FoodWatBBQVeg	Specifies Using vegetable in BBQ																						
-GCS:FoodWatBBQMeat	FoodWatBBQMeat	Specifies Using Meat in BBQ																						
-GCS:FoodWatBBQFish	FoodWatBBQFish	Specifies Using Fish in BBQ																						
-GCS:FoodWatBoilVeg	FoodWatBoilVeg	Specifies Using vegetable Boiling																						
-GCS:FoodWatBoilMeat	FoodWatBoilMeat	Specifies Using Meat Boiling																						
-GCS:FoodWatBoilFish	FoodWatBoilFish	Specifies Using Fish Boiling																						
-GCS:FoodWatSteamVeg	FoodWatSteamVeg	Specifies Using vegetable Steaming																						
-GCS:FoodWatSteamMeat	FoodWatSteamMeat	Specifies Using Meat Steaming																						
-GCS:FoodWatSteamFish	FoodWatSteamFish	Specifies Using Fish Steaming																						
-GCS:FoodWatOthVeg	FoodWatOthVeg	Specifies Using vegetable by any Other method																						
-GCS:FoodWatOthMeat	FoodWatOthMeat	Specifies Using Meat by any Other method																						
-GCS:FoodWatOthFish	FoodWatOthFish	Specifies Using Fish in by any Other method																						
-GCS:FoodWatFreshLocalFruitChange	FoodWatFreshLocalFruitChange	Specifies the change in using Local Fruit from 1353																						
-GCS:FoodWatFreshImportedFruitChange	FoodWatFreshImportedFruitChange	Specifies the change in using Imported Fruit from 1353																						
-GCS:FoodWatFreshVegChange	FoodWatFreshVegChange	Specifies the change in using Fresh Vegetable from 1353																						
-GCS:FoodWatFreshMeatChange	FoodWatFreshMeatChange	Specifies the change in using Fresh Meat from 1353																						
-GCS:Homeownership	Homeownership	Specifies participant Homeownership status			is this lifestyle or sociodemographic? this is all talking about wealth																			
-GCS:house_nonowned	house_nonowned	Specifies house owned or non-owned																						
-GCS:HomeSize	HomeSize	Specifies participant Home Area			residence?																			
-GCS:PropertyAutoOwned	PropertyAutoOwned	If the participant has personal car select yes if no select no																						
-GCS:PropertyAutoYears	PropertyAutoYears	Specifies the length of time that the participant has a personal car(Year)																						
-GCS:PropertyMotorcycleOwned	PropertyMotorcycleOwned	If the participant has Motorcycle select yes if no select no																						
-GCS:PropertyMotorcycleYears	PropertyMotorcycleYears	Specifies the length of time that the participant has Motorcycle(Year)																						
-GCS:PropertyColorTVOwned	PropertyColorTVOwned	If the participant has Color TV select yes if no select no																						
-GCS:PropertyColorTVYears	PropertyColorTVYears	Specifies the length of time that the participant has Color TV(Year)																						
-GCS:PropertyBandWTVOwned	PropertyBandWTVOwned	If the participant has BandW TV select yes if no select no																						
-GCS:PropertyBandWTVYears	PropertyBandWTVYears	Specifies the length of time that the participant has BandW TV(Year)																						
-GCS:PropertyIndoorBathOwned	PropertyIndoorBathOwned	If the participant has Indoor Bath room select yes if no select no																						
-GCS:PropertyIndoorBathYears	PropertyIndoorBathYears	Specifies the length of time that the participant has Indoor Bath room(Year)																						
-GCS:PropertyVacuumOwned	PropertyVacuumOwned	If the participant has Vacuum cleaner select yes if no select no																						
-GCS:PropertyVacuumYears	PropertyVacuumYears	Specifies the length of time that the participant has Vacuum cleaner(Year)																						
-GCS:PropertyWashMachOwned	PropertyWashMachOwned	If the participant has Washing machine select yes if no select no																						
-GCS:PropertyWashMachYears	PropertyWashMachYears	Specifies the length of time that the participant has Washing machine(Year)																						
-GCS:PropertyRefrigeratorOwned	PropertyRefrigeratorOwned	If the participant has Refrigerator select yes if no select no																						
-GCS:PropertyRefrigeratorYears	PropertyRefrigeratorYears	Specifies the length of time that the participant has Refrigerator(Year)																						
-GCS:PropertyFreezerOwned	PropertyFreezerOwned	If the participant has Freezer select yes if no select no																						
-GCS:PropertyFreezerYears	PropertyFreezerYears	Specifies the length of time that the participant has Freezer(Year)																						
-GCS:PropertyComputerOwned	PropertyComputerOwned	If the participant has Computer select yes if no select no																						
-GCS:PropertyComputerYears	PropertyComputerYears	Specifies the length of time that the participant has Computer(Year)																						
-GCS:HomeRooms	HomeRooms	Number of rooms in the house																						
-GCS:HaveBath	HaveBath	Specifies if the household has bathroom																						
-GCS:HaveKitchen	HaveKitchen	Specifies if the household has kitchen																						
-GCS:MCA	MCA	Composite wealth score (Multiple Correspondence Analysis)			lifestyle or sociodemographic?																			
-GCS:NumberPregnancies	NumberPregnancies	Specifies the number of Pregnancies for women only		pregnancy history																				
-GCS:NumberLiveBirths	NumberLiveBirths	Specifies the number of live births for women only		pregnancy history																				
-GCS:DisRheumaticHeartDx	DisRheumaticHeartDx	if the diagnosis of Rheumatic Heart Disease was made for participant by a physician		diagnosis of heart disease																				
-GCS:DisRheumaticHeartAge	DisRheumaticHeartAge	participant age at Rheumatic Heart Disease diagnosis		diagnosis of heart disease																				
-GCS:DisHeartDiseaseDx	DisHeartDiseaseDx	if the diagnosis of Heart Disease was made for participant by a physician		diagnosis of heart disease																				
-GCS:DisHeartDiseaseAge	DisHeartDiseaseAge	participant age in first Heart Disease diagnosis		diagnosis of heart disease																				
-GCS:DisStrokeDx	DisStrokeDx	if the diagnosis of Stroke was made for participant by a physician		diagnosis of stroke																				
-GCS:DisStrokeAge	DisStrokeAge	participant age in first Stroke diagnosis		diagnosis of stroke																				
-GCS:DisHypertensionDx	DisHypertensionDx	if the diagnosis of Hypertension was made for participant by a physician		diagnosis of hypertension																				
-GCS:DisHypertensionAge	DisHypertensionAge	participant age in first Hypertension diagnosis		diagnosis of hypertension																				
-GCS:DisDiabetesDx	DisDiabetesDx	if the diagnosis of Diabetes was made for participant by a physician		diagnosis of diabetes																				
-GCS:DisDiabetesAge	DisDiabetesAge	participant age in first Diabetes diagnosis		diagnosis of diabetes																				
-GCS:DisCOPDDx	DisCOPDDx	if the diagnosis of COPD was made for participant by a physician		diagnosis of chronic obstructive pulmonary disease																				
-GCS:DisCOPDAge	DisCOPDAge	participant age in first COPD diagnosis		diagnosis of chronic obstructive pulmonary disease																				
-GCS:DisRenalFailureDx	DisRenalFailureDx	if the diagnosis of Renal Failure was made for participant by a physician		diagnosis of renal failure																				
-GCS:DisRenalFailureAge	DisRenalFailureAge	participant age in first RenalFailure diagnosis		diagnosis of renal failure																				
-GCS:DisJaundiceDx	DisJaundiceDx	if the diagnosis of Jaundice was made for participant by a physician		diagnosis of jaundice																				
-GCS:DisJaundiceAge	DisJaundiceAge	participant age in first Jaundice diagnosis		diagnosis of jaundice																				
-GCS:DisLiverDx	DisLiverDx	if the diagnosis of Chronic Liver Failure was made for participant by a physician		diagnosis of liver failure																				
-GCS:DisLiverAge	DisLiverAge	participant age in first Chronic liver failure diagnosis		diagnosis of liver failure																				
-GCS:DisTBDx	DisTBDx	if the diagnosis of Tuberculosis was made for participant by a physician		diagnosis of tuberculosis																				
-GCS:DisTBAge	DisTBAge	participant age in first Tuberculosis diagnosis		diagnosis of tuberculosis																				
-GCS:SurgeryFlag	SurgeryFlag	If the participant had had any history of surgery		surgical interventions																				
-GCS:SurgeryType	SurgeryType	Specifies the participant surgery Type		surgical interventions																				
-GCS:SurgeryAge	SurgeryAge	Specifies the participant age in surgery Time		surgical interventions																				
-GCS:TransfusionFlag	TransfusionFlag	if the participant has had Transfusion history																						
-GCS:TransfusionRecentFlag	TransfusionRecentFlag	if the participant has Transfusion history in last month																						
-GCS:SymRefluxFlag	SymRefluxFlag	if the participant has Reflux Symptom history select yes if not select no		occurrence of acid reflux																				
-GCS:SymRefluxWhen	SymRefluxWhen	when Reflux Symptom happen in First time		occurrence of acid reflux																				
-GCS:SymHeartburnFlag	SymHeartburnFlag	if the participant has Heartburn Symptom history select yes if not select no		occurrence of heartburn																				
-GCS:SymHeartburnWhen	SymHeartburnWhen	when Heartburn Symptom happen in First time		occurrence of heartburn																				
-GCS:SymDifficultSwallowingFlag	SymDifficultSwallowingFlag	if the participant has Difficult Swallowing Symptom history select yes if not select no		occurrence of difficulty swallowing																				
-GCS:SymDifficultSwallowingWhen	SymDifficultSwallowingWhen	when Difficult Swallowing Symptom happen in First time		occurrence of difficulty swallowing																				
-GCS:SymRefluxPastYearFreq	SymRefluxPastYearFreq	if the participant has Reflux Symptom in past year select yes if not select no		occurrence of acid reflux																				
-GCS:SymRefluxPastYearSeverity	SymRefluxPastYearSeverity	Severity Reflux Symptom in past year		occurrence of acid reflux																				
-GCS:SymRefluxPriorYearsFreq	SymRefluxPriorYearsFreq	if the participant has Reflux Symptom in Prior year select yes if not select no		occurrence of acid reflux																				
-GCS:SymRefluxPriorYearsSeverity	SymRefluxPriorYearsSeverity	Severity Reflux Symptom in Prior year		occurrence of acid reflux																				
-GCS:RefluxHeartburnTXFlag	RefluxHeartburnTXFlag	if participant used drug for Heartburn symptoms select yes if not select no and if participant doesn't have symtom selectLack of signage		medication	should we create medication for heartburn?																			
-GCS:WeightLossFlag	WeightLossFlag	if the patient has Weightloss in past year select yes if not select no		clinical history	should we be more specific here?																			
-GCS:WeightLossAmount	WeightLossAmount	Specifies the amount of weight loss		clinical history																				
-GCS:WeightLossIntent	WeightLossIntent	if the patient has Intentional weight loss select Yes if not select no and doesn't have weight loss select I have no weight loss		clinical history																				
-GCS:cancerdxflag	cancerdxflag	Past history of cancer diagnosed by a physician?		clinical history of cancer																				
-GCS:cancerdxage	cancerdxage	Year of diagnosis of cancer if detected in participant		clinical history of cancer																				
-GCS:cancerdxsite	cancerdxsite	Original site of cancer		clinical history of cancer																				
-GCS:CancRelRelativeCode_1	CancRelRelativeCode_1	Specifies the relative of participants with a history of cancer		clinical history of cancer																				
-GCS:CancRelAgeDiagnosis_1	CancRelAgeDiagnosis_1	Specifies the age of relative when cancer was diagnosed		clinical history of cancer																				
-GCS:CancRelSite_1	CancRelSite_1	Specifies the site of cancer in the relative of participant		clinical history of cancer																				
-GCS:CancRelICD10_1	CancRelICD10_1	Specifies the ICD-10 code of cancer in the relative of participant		clinical history of cancer																				
-GCS:CancRelRelativeCode_2	CancRelRelativeCode_2	Specifies the additional relative of participants with a history of cancer		family clinical history																				
-GCS:CancRelAgeDiagnosis_2	CancRelAgeDiagnosis_2	Specifies the age of relative when cancer was diagnosed		family clinical history																				
-GCS:CancRelSite_2	CancRelSite_2	Specifies the site of cancer in the relative of participant		family clinical history																				
-GCS:CancRelICD10_2	CancRelICD10_2	Specifies the ICD-10 code of cancer in the relative of participant		family clinical history																				
-GCS:CancRelRelativeCode_3	CancRelRelativeCode_3	Specifies the additional relative of participants with a history of cancer		family clinical history																				
-GCS:CancRelAgeDiagnosis_3	CancRelAgeDiagnosis_3	Specifies the age of relative when cancer was diagnosed		family clinical history																				
-GCS:CancRelSite_3	CancRelSite_3	Specifies the site of cancer in the relative of participant		family clinical history																				
-GCS:CancRelICD10_3	CancRelICD10_3	Specifies the ICD-10 code of cancer in the relative of participant		family clinical history																				
-GCS:CancRelRelativeCode_4	CancRelRelativeCode_4	Specifies the additional relative of participants with a history of cancer		family clinical history																				
-GCS:CancRelAgeDiagnosis_4	CancRelAgeDiagnosis_4	Specifies the age of relative when cancer was diagnosed		family clinical history																				
-GCS:CancRelSite_4	CancRelSite_4	Specifies the site of cancer in the relative of participant		family clinical history																				
-GCS:CancRelICD10_4	CancRelICD10_4	Specifies the ICD-10 code of cancer in the relative of participant		family clinical history																				
-GCS:TobEverRegularFlag	TobEverRegularFlag	Specifies the participant used cigar for 6 Months	subclass	tobacco																				
-GCS:TobCigsNow	TobCigsNow	Specifies the participant uses cigar Now	subclass	tobacco																				
-GCS:TobNonCigFlag	TobNonCigFlag	Specifies the participant used tobacco other than cigar for 6 Months	subclass	tobacco																				
-GCS:TobStartAge_1	TobStartAge_1	Specifies the participant Used this Tobacco type From Age, first history	subclass	tobacco																				
-GCS:TobEndAge_1	TobEndAge_1	Specifies the participant Used this Tobacco type To Age, first history	subclass	tobacco																				
-GCS:TobDuration_1	TobDuration_1	Specifies the participant Used tobacco Duration, first history	subclass	tobacco																				
-GCS:TobType_1	TobType_1	Specifies the participant Used type of Tobacco, first history	subclass	tobacco																				
-GCS:TobNumberPerDay_1	TobNumberPerDay_1	Specifies the participant Used this tobacco how many times per day, first history	subclass	tobacco																				
-GCS:TobDaysPerWeek_1	TobDaysPerWeek_1	Specifies the participant Used this tobacco how many days in week, first history	subclass	tobacco																				
-GCS:CigNumPerDay_1	CigNumPerDay_1	Specifies the participant Used this cigar how many times per day, first history	subclass	tobacco																				
-GCS:Cigpackyear_1	Cigpackyear_1	Specifies the participant cumulative use, first history	subclass	tobacco																				
-GCS:TobStartAge_2	TobStartAge_2	Specifies the participant Used this Tobacco type From Age, second history	subclass	tobacco																				
-GCS:TobEndAge_2	TobEndAge_2	Specifies the participant Used this Tobacco type To Age, second history	subclass	tobacco																				
-GCS:TobDuration_2	TobDuration_2	Specifies the participant Used tobacco Duration, second history	subclass	tobacco																				
-GCS:TobType_2	TobType_2	Specifies the participant Used type of Tobacco, second history	subclass	tobacco																				
-GCS:TobNumberPerDay_2	TobNumberPerDay_2	Specifies the participant Used this tobacco how many times per day, second history	subclass	tobacco																				
-GCS:TobDaysPerWeek_2	TobDaysPerWeek_2	Specifies the participant Used this tobacco how many days in week, second history	subclass	tobacco																				
-GCS:CigNumPerDay_2	CigNumPerDay_2	Specifies the participant Used this cigar how many times per day, second history	subclass	tobacco																				
-GCS:Cigpackyear_2	Cigpackyear_2	Specifies the participant cumulative use, second history	subclass	tobacco																				
-GCS:TobStartAge_3	TobStartAge_3	Specifies the participant Used this Tobacco type From Age, third history	subclass	tobacco																				
-GCS:TobEndAge_3	TobEndAge_3	Specifies the participant Used this Tobacco type To Age, third history	subclass	tobacco																				
-GCS:TobDuration_3	TobDuration_3	Specifies the participant Used tobacco Duration, third history	subclass	tobacco																				
-GCS:TobType_3	TobType_3	Specifies the participant Used type of Tobacco, third history	subclass	tobacco																				
-GCS:TobNumberPerDay_3	TobNumberPerDay_3	Specifies the participant Used this tobacco how many times per day, third history	subclass	tobacco																				
-GCS:TobDaysPerWeek_3	TobDaysPerWeek_3	Specifies the participant Used this tobacco how many days in week, third history	subclass	tobacco																				
-GCS:CigNumPerDay_3	CigNumPerDay_3	Specifies the participant Used this cigar how many times per day, third history	subclass	tobacco																				
-GCS:Cigpackyear_3	Cigpackyear_3	Specifies the participant cumulative use, third history	subclass	tobacco																				
-GCS:TobStartAge_4	TobStartAge_4	Specifies the participant Used this Tobacco type From Age, fourth history	subclass	tobacco																				
-GCS:TobEndAge_4	TobEndAge_4	Specifies the participant Used this Tobacco type To Age, fourth history	subclass	tobacco																				
-GCS:TobDuration_4	TobDuration_4	Specifies the participant Used tobacco Duration, fourth history	subclass	tobacco																				
-GCS:TobType_4	TobType_4	Specifies the participant Used type of Tobacco, fourth history	subclass	tobacco																				
-GCS:TobNumberPerDay_4	TobNumberPerDay_4	Specifies the participant Used this tobacco how many times per day, fourth history	subclass	tobacco																				
-GCS:TobDaysPerWeek_4	TobDaysPerWeek_4	Specifies the participant Used this tobacco how many days in week, fourth history	subclass	tobacco																				
-GCS:CigNumPerDay_4	CigNumPerDay_4	Specifies the participant Used this cigar how many times per day, fourth history	subclass	tobacco																				
-GCS:Cigpackyear_4	Cigpackyear_4	Specifies the participant cumulative use, fourth history	subclass	tobacco																				
-GCS:total_packyear	total_packyear	Specifies the participant total cumulative use	subclass	tobacco																				
-GCS:OpiateEverRegularFlag	OpiateEverRegularFlag	Specifies the participant ever used opiume for 6 Months		opiate use history																				
-GCS:OpiatePersonalChildhoodExp	OpiatePersonalChildhoodExp	Specifies the using opium in Childhood		opiate use history																				
-GCS:OpiateAdministeredToChildrenFlag	OpiateAdministeredToChildrenFlag	Specifies the participant gave opium to children			???																			
-GCS:OpiateType	OpiateType	Specifies the participant Used Opium type		opiate use history																				
-GCS:OpiateRoute	OpiateRoute	Specifies the route by which participant uses opium		opiate use history																				
-GCS:OpiateStartAge_1	OpiateStartAge_1	Specifies the participant Used this Opium type From Age, first history		opiate use history																				
-GCS:OpiateEndAge_1	OpiateEndAge_1	Specifies the participant Used this Opium type To Age, first history		opiate use history																				
-GCS:OpiateDuration_1	OpiateDuration_1	Specifies the participant Used this Opium Duration, first history		opiate use history																				
-GCS:OpiateNokhod_1	OpiateNokhod_1	Specifies the participant Used this Opium amount in Pea size, first history		opiate use history																				
-GCS:OpiateDaysPerWeek_1	OpiateDaysPerWeek_1	Specifies the participant Used this Opium day in week, first history		opiate use history																				
-GCS:OpiateAmountperDay_1	OpiateAmountperDay_1	Specifies the participant Used this Opium Amount per day, first history		opiate use history																				
-GCS:Opiatecum_1	Opiatecum_1	Specifies the participant cumulative use of Opium, first history		opiate use history																				
-GCS:OpiateStartAge_2	OpiateStartAge_2	Specifies the participant Used this Opium type From Age, second history		opiate use history																				
-GCS:OpiateEndAge_2	OpiateEndAge_2	Specifies the participant Used this Opium type To Age, second history		opiate use history																				
-GCS:OpiateDuration_2	OpiateDuration_2	Specifies the participant Used this Opium Duration, second history		opiate use history																				
-GCS:OpiateNokhod_2	OpiateNokhod_2	Specifies the participant Used this Opium amount in Pea size, second history		opiate use history																				
-GCS:OpiateDaysPerWeek_2	OpiateDaysPerWeek_2	Specifies the participant Used this Opium day in week, second history		opiate use history																				
-GCS:OpiateAmountperDay_2	OpiateAmountperDay_2	Specifies the participant Used this Opium Amount per day, second history		opiate use history																				
-GCS:Opiatecum_2	Opiatecum_2	Specifies the participant cumulative use of Opium, second history		opiate use history																				
-GCS:OpiateStartAge_3	OpiateStartAge_3	Specifies the participant Used this Opium type From Age, third history		opiate use history																				
-GCS:OpiateEndAge_3	OpiateEndAge_3	Specifies the participant Used this Opium type To Age, third history		opiate use history																				
-GCS:OpiateDuration_3	OpiateDuration_3	Specifies the participant Used this Opium Duration, third history		opiate use history																				
-GCS:OpiateNokhod_3	OpiateNokhod_3	Specifies the participant Used this Opium amount in Pea size, third history		opiate use history																				
-GCS:OpiateDaysPerWeek_3	OpiateDaysPerWeek_3	Specifies the participant Used this Opium day in week, third history		opiate use history																				
-GCS:OpiateAmountperDay_3	OpiateAmountperDay_3	Specifies the participant Used this Opium Amount per day, third history		opiate use history																				
-GCS:Opiatecum_3	Opiatecum_3	Specifies the participant cumulative use of Opium, third history		opiate use history																				
-GCS:OpiateStartAge_4	OpiateStartAge_4	Specifies the participant Used this Opium type From Age, fourth history		opiate use history																				
-GCS:OpiateEndAge_4	OpiateEndAge_4	Specifies the participant Used this Opium type To Age, fourth history		opiate use history																				
-GCS:OpiateDuration_4	OpiateDuration_4	Specifies the participant Used this Opium Duration, fourth history		opiate use history																				
-GCS:OpiateNokhod_4	OpiateNokhod_4	Specifies the participant Used this Opium amount in Pea size, fourth history		opiate use history																				
-GCS:OpiateDaysPerWeek_4	OpiateDaysPerWeek_4	Specifies the participant Used this Opium day in week, fourth history		opiate use history																				
-GCS:OpiateAmountperDay_4	OpiateAmountperDay_4	Specifies the participant Used this Opium Amount per day, fourth history		opiate use history																				
-GCS:Opiatecum_4	Opiatecum_4	Specifies the participant cumulative use of Opium, fourth history		opiate use history																				
-GCS:TotalNokhodDay	TotalNokhodDay	Specifies the participant total cumulative use of Opium		opiate use history																				
-GCS:AlcEverRegularFlag	AlcEverRegularFlag	Specifies the participant ever used alcohol for 6 Months	subclass	alcohol																				
-GCS:AlcStartAge_1	AlcStartAge_1	Specifies the participant used alcohol From Age, first history	subclass	alcohol																				
-GCS:AlcEndAge_1	AlcEndAge_1	Specifies the participant used alcohol To Age, first history	subclass	alcohol																				
-GCS:AlcType_1	AlcType_1	Specifies the participant alcohol used Type, first history	subclass	alcohol																				
-GCS:AlcQuantityPerEpisode_1	AlcQuantityPerEpisode_1	Specifies the average alcohol the participant used per episode, first history	subclass	alcohol																				
-GCS:AlcEpisodesPerMonth_1	AlcEpisodesPerMonth_1	Specifies the participant Alcohol episodes in month, first history	subclass	alcohol																				
-GCS:AlcStartAge_2	AlcStartAge_2	Specifies the participant used alcohol From Age, second history	subclass	alcohol																				
-GCS:AlcEndAge_2	AlcEndAge_2	Specifies the participant used alcohol To Age, second history	subclass	alcohol																				
-GCS:AlcType_2	AlcType_2	Specifies the participant alcohol used Type, second history	subclass	alcohol																				
-GCS:AlcQuantityPerEpisode_2	AlcQuantityPerEpisode_2	Specifies the average alcohol the participant used per episode, second history	subclass	alcohol																				
-GCS:AlcEpisodesPerMonth_2	AlcEpisodesPerMonth_2	Specifies the participant Alcohol episodes in month, second history	subclass	alcohol																				
-GCS:AlcStartAge_3	AlcStartAge_3	Specifies the participant used alcohol From Age, third history	subclass	alcohol																				
-GCS:AlcEndAge_3	AlcEndAge_3	Specifies the participant used alcohol To Age, third history	subclass	alcohol																				
-GCS:AlcType_3	AlcType_3	Specifies the participant alcohol used Type, third history	subclass	alcohol																				
-GCS:AlcQuantityPerEpisode_3	AlcQuantityPerEpisode_3	Specifies the average alcohol the participant used per episode, third history	subclass	alcohol																				
-GCS:AlcEpisodesPerMonth_3	AlcEpisodesPerMonth_3	Specifies the participant Alcohol episodes in month, third history	subclass	alcohol																				
-GCS:DrugCurrentuse	DrugCurrentuse	Currently taking any medication?	subclass	medication history																				
-GCS:antiHTN	antiHTN	Anti-hypertensive drugs: 1: diuretics 2: beta-blockers 3: ACE Inhibitors 4: ARBs 5: Alpha-adrenergic blockers 6: Calcium channel blockers 7:other anti-hypertensives	subclass	history of medication for hypertension																				
-GCS:antiDM	antiDM	Anti-diabetic drugs: 1: Glibenclamide 2: metformin 3: insulin 4: other	subclass	history of medication for diabetes																				
-GCS:cardiac	cardiac	Cardiac drugs: 1: Anti-platelets 2: statins 3: Beta-blockers 4: Nitrates 5: ACE Inhibitors 6: ARBs 7: Calcium Channel blockers 8: other	subclass	history of medication for cardiac disease																				
-GCS:antilipid	antilipid	Lipid-lowering drugs: 1: Statins 2: Gemfibrozil 3: other	subclass	history of medication for high cholesterol																				
-GCS:mentaldrug	mentaldrug	Mental disorders: 1: Benzodiazepines 2: Sodium Valproate 3: Anti-epileptics 4: Antidepressants 5: Anti-anxiety medications 6: Psychoactive medications	subclass	history of medication for mental disorder																				
-GCS:Corticosteroid	Corticosteroid	Corticosteroids: 1: injection 2: oral 3: topical	subclass	use of corticosteroids																				
-GCS:Gidrugs	Gidrugs	Gastrointestinal: 1: H2 Blockers 2: PPIs 3: Clindinium C	subclass	history of medication for gastrointestinal disease																				
-GCS:antibiotics	antibiotics	Antibiotics: 1: Amoxicillin 2: Cefixime 3: Azithromycin 4: Metronidazole 5: other	subclass	use of antibiotics																				
-GCS:diuretic	diuretic	Diuretics	subclass	use of diuretics																				
-GCS:betablocker	betablocker	Beta Blockers	subclass	use of beta blockers																				
-GCS:ACEinhibitor	ACEinhibitor	Angiotensin Converting Enzyme Inhibitors	subclass	use of angiotensin convertin enzyme inhibitors																				
-GCS:ARB	ARB	Angiotensin Receptor Blockers	subclass	use of angiotensin receptor blockers																				
-GCS:alphablocker	alphablocker	Alpha Adrenergic Blockers	subclass	use of alpha adrenergic blockers																				
-GCS:CCBlocker	CCBlocker	Calcium Channel Blockers	subclass	use of calcium channel blockers																				
-GCS:Glibenclamide	Glibenclamide	Glibenclamide	subclass	use of glibenclamide																				
-GCS:Metformin	Metformin	Metformin	subclass	use of metformin																				
-GCS:Insulin	Insulin	Insulin	subclass	use of insulin																				
-GCS:Antiplatelets	Antiplatelets	Anti-platelets	subclass	use of antiplatelets																				
-GCS:Statins	Statins	Statins	subclass	use of statins																				
-GCS:Nitrates	Nitrates	Nitrates	subclass	use of nitrates																				
-GCS:Gemfibrozil	Gemfibrozil	Gemfibrozil	subclass	use of gemfibroxil																				
-GCS:Acetaminophen	Acetaminophen	Acetaminophen and Acetaminophen Codein	subclass	use of acetaminophen																				
-GCS:Ibuprofen	Ibuprofen	Ibuprofen	subclass	use of ibuprofen																				
-GCS:Diclophenac	Diclophenac	Diclophenac	subclass	use of diclophenac																				
-GCS:Indomethacin	Indomethacin	Indomethacin	subclass	use of indomethacin																				
-GCS:Levothyroxin	Levothyroxin	Levthyroxin	subclass	use of levthyroxine																				
-GCS:Methotrexate	Methotrexate	Methotrexate	subclass	use of methotrexate																				
-GCS:Other	Other	Other	subclass	medication history																				
-GCS:DrugCurrentuse	DrugCurrentuse	Currently taking any medication?	subclass	medication history																				
-GCS:drugname_1	drugname_1	Name of drug 1	subclass	medication history	Could name fall under "prescription"?																			
-GCS:drugduration_1	drugduration_1	Number of years being under treatment 1	subclass	medication history																				
-GCS:drugfrequency_1	drugfrequency_1	Frequency of drug consumption 1	subclass	posology																				
-GCS:drugdose_1	drugdose_1	Dose of drug consumed 1	subclass	posology																				
-GCS:drugname_2	drugname_2	Name of drug 2	subclass	medication history																				
-GCS:drugduration_2	drugduration_2	Number of years being under treatment 2	subclass	medication history																				
-GCS:drugfrequency_2	drugfrequency_2	Frequency of drug consumption 2	subclass	posology																				
-GCS:drugdose_2	drugdose_2	Dose of drug consumed 2	subclass	posology																				
-GCS:drugname_3	drugname_3	Name of drug 3	subclass	medication history																				
-GCS:drugduration_3	drugduration_3	Number of years being under treatment 3	subclass	medication history																				
-GCS:drugfrequency_3	drugfrequency_3	Frequency of drug consumption 3	subclass	posology																				
-GCS:drugdose_3	drugdose_3	Dose of drug consumed 3	subclass	posology																				
-GCS:drugname_4	drugname_4	Name of drug 4	subclass	medication history																				
-GCS:drugduration_4	drugduration_4	Number of years being under treatment 4	subclass	medication history																				
-GCS:drugfrequency_4	drugfrequency_4	Frequency of drug consumption 4	subclass	posology																				
-GCS:drugdose_4	drugdose_4	Dose of drug consumed 4	subclass	posology																				
-GCS:drugname_5	drugname_5	Name of drug 5	subclass	medication history																				
-GCS:drugduration_5	drugduration_5	Number of years being under treatment 5	subclass	medication history																				
-GCS:drugfrequency_5	drugfrequency_5	Frequency of drug consumption 5	subclass	posology																				
-GCS:drugdose_5	drugdose_5	Dose of drug consumed 5	subclass	posology																				
-GCS:drugname_6	drugname_6	Name of drug 6	subclass	medication history																				
-GCS:drugduration_6	drugduration_6	Number of years being under treatment 6	subclass	medication history																				
-GCS:drugfrequency_6	drugfrequency_6	Frequency of drug consumption 6	subclass	posology																				
-GCS:drugdose_6	drugdose_6	Dose of drug consumed 6	subclass	posology																				
-GCS:drugname_7	drugname_7	Name of drug 7	subclass	medication history																				
-GCS:drugduration_7	drugduration_7	Number of years being under treatment 7	subclass	medication history																				
-GCS:drugfrequency_7	drugfrequency_7	Frequency of drug consumption 7	subclass	posology																				
-GCS:drugdose_7	drugdose_7	Dose of drug consumed 7	subclass	posology																				
-GCS:drugname_8	drugname_8	Name of drug 8	subclass	medication history																				
-GCS:drugduration_8	drugduration_8	Number of years being under treatment 8	subclass	medication history																				
-GCS:drugfrequency_8	drugfrequency_8	Frequency of drug consumption 8	subclass	posology																				
-GCS:drugdose_8	drugdose_8	Dose of drug consumed 8	subclass	posology																				
-GCS:drugname_9	drugname_9	Name of drug 9	subclass	medication history																				
-GCS:drugduration_9	drugduration_9	Number of years being under treatment 9	subclass	medication history																				
-GCS:drugfrequency_9	drugfrequency_9	Frequency of drug consumption 9	subclass	posology																				
-GCS:drugdose_9	drugdose_9	Dose of drug consumed 9	subclass	posology																				
-GCS:drugname_10	drugname_10	Name of drug 10	subclass	medication history																				
-GCS:drugduration_10	drugduration_10	Number of years being under treatment 10	subclass	medication history																				
-GCS:drugfrequency_10	drugfrequency_10	Frequency of drug consumption 10	subclass	posology																				
-GCS:drugdose_10	drugdose_10	Dose of drug consumed 10	subclass	posology																				
-GCS:OralPermanentTeethLossFlag	OralPermanentTeethLossFlag	Permanent Teeth Loss	subclass	oral health history																				
-GCS:OralPermanentTeethAgeFirstLoss	OralPermanentTeethAgeFirstLoss	Specifies the age of first Permanent Teeth Loss	subclass	oral health history																				
-GCS:OralUpperDentureFlag	OralUpperDentureFlag	Specifies the participant used Upper Denture	subclass	oral health history																				
-GCS:OralLowerDentureFlag	OralLowerDentureFlag	Specifies the participant used Lower Denture	subclass	oral health history																				
-GCS:OralUpperDentureUse	OralUpperDentureUse	Specifies the participant used Upper Denture during the day	subclass	oral health history																				
-GCS:OralLowerDentureUse	OralLowerDentureUse	Specifies the participant used Lower Denture during the day	subclass	oral health history																				
-GCS:OralAgeDentureUpper	OralAgeDentureUpper	Specifies the age of participant first used Upper Denture	subclass	oral health history																				
-GCS:OralAgeDentureLower	OralAgeDentureLower	Specifies the age of participant First used Lower Denture	subclass	oral health history																				
-GCS:OralFreqBrushing	OralFreqBrushing	Specifies the participant Brushing Frequency	subclass	oral health history																				
-GCS:OralFoodDiscomfortFlag	OralFoodDiscomfortFlag	Specifies the frequency the participant experienced discomfort while eating food in Past Year	subclass	oral health history																				
-GCS:OralFoodDiscomfortType	OralFoodDiscomfortType	Specifies the food that caused discomfort for the participant	subclass	oral health history																				
-GCS:OralNumTeeth	OralNumTeeth	Specifies the participant Total number of teeth	subclass	oral health history																				
-GCS:OralNumTeethDecayed	OralNumTeethDecayed	Specifies the participant Total number of Decayed teeth	subclass	oral health history																				
-GCS:OralNumTeethMissing	OralNumTeethMissing	Specifies the participant Total number of Missing teeth	subclass	oral health history																				
-GCS:OralNumTeethFilled	OralNumTeethFilled	Specifies the participant Total number of Filled teeth	subclass	oral health history																				
-GCS:OralMucosa	OralMucosa	Specifies the participant Mucosa Status	subclass	oral health history																				
-GCS:TeaTempDegrees	TeaTempDegrees	Specifies participant consumption of tea temperature		information about diet	is this diet?																			
-GCS:TeaTempDescription	TeaTempDescription	Specifies participant used tea type		information about diet																				
-GCS:TeaSteepingTime	TeaSteepingTime	Specifies the duration between pouring and drinking the tea		information about diet																				
-GCS:TeaSipOrGulp	TeaSipOrGulp	Specifies how participant drinks tea		information about diet																				
-GCS:physactworkallyearflag	physactworkallyearflag	Working all months of the year?	subclass	occupation|physical activity																				
-GCS:physactworkmonths	physactworkmonths	Number of working months in a year	subclass	occupation|physical activity																				
-GCS:physactworkstrenuousflag	physactworkstrenuousflag	Daily intensive physical activity?	subclass	physical activity																				
-GCS:physactworkstrenuousfreq	physactworkstrenuousfreq	Number of working days in a week	subclass	physical activity																				
-GCS:physactworkstrenuoushours	physactworkstrenuoushours	Number of working hours in a day	subclass	physical activity																				
-GCS:physactworkstrenuousyears	physactworkstrenuousyears	Number of entire working years	subclass	physical activity																				
-GCS:physacthouseworkflag	physacthouseworkflag	Doing house work?	subclass	physical activity																				
-GCS:physacthouseworkfreq	physacthouseworkfreq	Number of working days in a week	subclass	physical activity																				
-GCS:physacthouseworkhours	physacthouseworkhours	Number of working hours in a day	subclass	physical activity																				
-GCS:physacthouseworkyears	physacthouseworkyears	Number of entire working years	subclass	physical activity																				
-GCS:physacthouseworkminsduringwork	physacthouseworkminsduringwork	Doing house work: minutes during working times	subclass	physical activity																				
-GCS:physacthouseworkminsnowork	physacthouseworkminsnowork	Doing house work: minutes during leasure times	subclass	physical activity																				
-GCS:physactexmildminsduringwork	physactexmildminsduringwork	Mild exercise such as jogging: minutes during working times	subclass	physical activity																				
-GCS:physactexmildminsnowork	physactexmildminsnowork	Mild exercise such as jogging: minutes during leasure times	subclass	physical activity																				
-GCS:physactexmodminsduringwork	physactexmodminsduringwork	Moderate exercise such as volleyball: minutes during working times	subclass	physical activity																				
-GCS:physactexmodminsnowork	physactexmodminsnowork	Moderate exercise such as volleyball: minutes during leasure times	subclass	physical activity																				
-GCS:physactexstrenminsduringwork	physactexstrenminsduringwork	Intensive exercise such as horse riding: minutes during working times	subclass	physical activity																				
-GCS:physactexstrenminsnowork	physactexstrenminsnowork	Intensive exercise such as horse riding: minutes during leasure times	subclass	physical activity																				
-GCS:physacttvminsduringwork	physacttvminsduringwork	Watching TV, resting, reading: minutes during working times	subclass	physical activity																				
-GCS:physacttvminsnowork	physacttvminsnowork	Watching TV, resting, reading: minutes during leasure times	subclass	physical activity																				
-GCS:Metabolic Equivalent Task	Metabolic Equivalent Task	Energy cost of physical activities defined as the ratio of metabolic rate (and therefore the rate of energy consumption) during a specific physical activity to a reference metabolic rate	subclass	physical activity																				
-GCS:AnimalStartAge_1	AnimalStartAge_1	Specifies the age of the participants he had contact with animals, first history		lifestyle and behaviours	not sure if this is correct - do we want to be more specific?																			
-GCS:AnimalEndAge_1	AnimalEndAge_1	Specifies the age of the participants he didn't have contact with animals, first history		lifestyle and behaviours																				
-GCS:AnimalLevelOfContact_1	AnimalLevelOfContact_1	The intensity of animal contact, first history		lifestyle and behaviours																				
-GCS:AnimalType_1	AnimalType_1	The type of animal, first history		lifestyle and behaviours																				
-GCS:AnimalStartAge_2	AnimalStartAge_2	Specifies the age of the participants he had contact with animals, second history		lifestyle and behaviours																				
-GCS:AnimalEndAge_2	AnimalEndAge_2	Specifies the age of the participants he didn't have contact with animals, second history		lifestyle and behaviours																				
-GCS:AnimalLevelOfContact_2	AnimalLevelOfContact_2	The intensity of animal contact, second history		lifestyle and behaviours																				
-GCS:AnimalType_2	AnimalType_2	The type of animal, second history		lifestyle and behaviours																				
-GCS:AnimalStartAge_3	AnimalStartAge_3	Specifies the age of the participants he had contact with animals, third history		lifestyle and behaviours																				
-GCS:AnimalEndAge_3	AnimalEndAge_3	Specifies the age of the participants he didn't have contact with animals, third history		lifestyle and behaviours																				
-GCS:AnimalLevelOfContact_3	AnimalLevelOfContact_3	The intensity of animal contact, third history		lifestyle and behaviours																				
-GCS:AnimalType_3	AnimalType_3	The type of animal, third history		lifestyle and behaviours																				
-GCS:AnimalStartAge_4	AnimalStartAge_4	Specifies the age of the participants he had contact with animals, fourth history		lifestyle and behaviours																				
-GCS:AnimalEndAge_4	AnimalEndAge_4	Specifies the age of the participants he didn't have contact with animals, fourth history		lifestyle and behaviours																				
-GCS:AnimalLevelOfContact_4	AnimalLevelOfContact_4	The intensity of animal contact, fourth history		lifestyle and behaviours																				
-GCS:AnimalType_4	AnimalType_4	The type of animal, fourth history		lifestyle and behaviours																				
-GCS:bodyindicessizeage15	bodyindicessizeage15	The body size participants assume they have had based on pictogram when they were 15 years old	subclass	anthropometry																				
-GCS:bodyindicessizeage30	bodyindicessizeage30	The body size participants assume they have had based on pictogram when they wer3 30 years old	subclass	anthropometry																				
-GCS:bodyindicessizenow	bodyindicessizenow	The body size participants assume they have at the present time based on pictogram	subclass	anthropometry																				
-GCS:bodyindicesheight	bodyindicesheight	Height	equivalent	height																				
-GCS:bodyindicesweight	bodyindicesweight	Weight	equivalent	weight																				
-GCS:bodyindiceswaist	bodyindiceswaist	Waist circumference	equivalent	waist circumference value																				
-GCS:bodyindiceships	bodyindiceships	Hip circumference	equivalent	hip circumference value																				
-GCS:BMI	BMI	Body mass index	equivalent	body mass index value																				
-GCS:bpright1sbp	bpright1sbp	First measurement of systolic blood pressure from the right arm	subclass	systolic blood pressure value																				
-GCS:bpright1dbp	bpright1dbp	First measurement ofdiastolic blood pressure from the right arm	subclass	diastolic blood pressure value																				
-GCS:bpright2sbp	bpright2sbp	Second measurement of systolic blood pressure from the right arm	subclass	systolic blood pressure value																				
-GCS:bpright2dbp	bpright2dbp	Second measurement of diastolic blood pressure from the right arm	subclass	diastolic blood pressure value																				
-GCS:bpleft1sbp	bpleft1sbp	First measurement of systolic blood pressure from the left arm	subclass	systolic blood pressure value																				
-GCS:bpleft1dbp	bpleft1dbp	First measurement of diastolic blood pressure from the left arm	subclass	diastolic blood pressure value																				
-GCS:bpleft2sbp	bpleft2sbp	Second measurement of systolic blood pressure from the left arm	subclass	systolic blood pressure value																				
-GCS:bpleft2dbp	bpleft2dbp	Second measurement of diastolic blood pressure from the left arm	subclass	diastolic blood pressure value																				
-GCS:m_sbp	m_sbp	Mean systolic blood pressure measured second time	subclass	systolic blood pressure value																				
-GCS:m_dbp	m_dbp	Mean diastolic blood pressure measured second time	subclass	diastolic blood pressure value																				
-GCS:high_sbp	high_sbp	Systolic blood pressure >= 140 mmHg	subclass	systolic blood pressure value	also high BP																			
-GCS:high_dbp	high_dbp	Diastolic blood pressure >= 90 mmHg	subclass	diastolic blood pressure value	also high BP																			
-GCS:htndrug	htndrug	Consumption of any anti-hypertensive medication for more than 6 months		use of antihypertensive agents																				
-GCS:HTN	HTN	Being hypertensive		diagnosis of hypertension																				
-GCS:HTNcat	HTNcat	Categorization of hypetrension		diagnosis of hypertension																				
-GCS:preHTN	preHTN	SBP/DBP >=120/80 AND <140/90		diagnosis of hypertension	how do we handle prehypertension?																			
-GCS:pulse_p	pulse_p	Difference between SBP and DBP		calculated blood pressure value																				
-GCS:mean_bp	mean_bp	mean value of SBP and DBP		calculated blood pressure value																				
-GCS:mid_bp	mid_bp	Mid value of SBP and DBP		calculated blood pressure value																				
-GCS:diffsbp_right_left	diffsbp_right_left	Difference in SBP between arms		systolic blood pressure value																				
-GCS:diffdbp_right_left	diffdbp_right_left	Difference in DBP between arms		diastolic blood pressure value																				
-GCS:Energy	Energy	Amount consumed per day		information about diet	do we want to be more specific?																			
-GCS:fat	fat	Amount consumed per day		information about diet																				
-GCS:salt	salt	Amount consumed per day		information about diet																				
-GCS:protein	protein	Amount consumed per day		information about diet																				
-GCS:total saturated fat	total saturated fat	Amount consumed per day		information about diet																				
-GCS:total trans fat	total trans fat	Amount consumed per day		information about diet																				
-GCS:hydrogenated oil	hydrogenated oil	Amount consumed per day		information about diet																				
-GCS:carbohyderate	carbohyderate	Amount consumed per day		information about diet																				
-GCS:red meat	red meat	Amount consumed per day		information about diet																				
-GCS:processed meat	processed meat	Amount consumed per day		information about diet																				
-GCS:fruits	fruits	Amount consumed per day		information about diet																				
-GCS:vegetables	vegetables	Amount consumed per day		information about diet																				
-GCS:dairy products	dairy products	Amount consumed per day		information about diet																				
-GCS:milk	milk	Amount consumed per day		information about diet																				
-GCS:dietary fiber	dietary fiber	Amount consumed per day		information about diet																				
-GCS:Fish	Fish	Amount consumed per day		information about diet																				
-GCS:Chicken	Chicken	Amount consumed per day		information about diet																				
-GCS:SodiumNa	SodiumNa	Amount consumed per day		information about diet																				
-GCS:Calcium	Calcium	Amount consumed per day		information about diet																				
-GCS:Fe	Fe	Amount consumed per day		information about diet																				
-GCS:Magnesium	Magnesium	Amount consumed per day		information about diet																				
-GCS:Phosphorus	Phosphorus	Amount consumed per day		information about diet																				
-GCS:Potassium	Potassium	Amount consumed per day		information about diet																				
-GCS:Zinc	Zinc	Amount consumed per day		information about diet																				
-GCS:Folate	Folate	Amount consumed per day		information about diet																				
-GCS:Vitamin D	Vitamin D	Amount consumed per day		information about diet																				
-GCS:Vitamin A	Vitamin A	Amount consumed per day		information about diet																				
-GCS:Vitamin B1	Vitamin B1	Amount consumed per day		information about diet																				
-GCS:Vitamin B2	Vitamin B2	Amount consumed per day		information about diet																				
-GCS:Vitamin B12	Vitamin B12	Amount consumed per day		information about diet																				
-GCS:Vitamin C	Vitamin C	Amount consumed per day		information about diet																				
-GCS:Niacin	Niacin	Amount consumed per day		information about diet																				
-GCS:Glycemic load	Glycemic load	Amount consumed per day		information about diet																				
-GCS:Glycemic Index	Glycemic Index	Amount consumed per day		information about diet																				
-GCS:Sugar intake	Sugar intake	Amount consumed per day		information about diet																				
-GCS:Nuts	Nuts	Amount consumed per day		information about diet																				
-GCS:tea	tea	Amount consumed per day		information about diet																				
-GCS:Coffee	Coffee	Amount consumed per day		information about diet																				
-GCS:fbg	fbg	Fasting Blood Glucose	equivalent	blood fasting glucose level value																				
-GCS:urea	urea	Urea																						
-GCS:creatinine	creatinine	Creatinine																						
-GCS:cholesterol	cholesterol	Total Cholesterol																						
-GCS:triglycerides	triglycerides	Triglycerides																						
-GCS:hdl	hdl	High Density Lipoprotein																						
-GCS:ast	ast	Aspartate Transaminase																						
-GCS:alt	alt	Alanine Transaminase																						
-GCS:alkalinep	alkalinep	Alkaline Phosphatase																						
-GCS:ldl	ldl	Low Density Lipoprotein																						
-GCS:ldlhdl	ldlhdl	LDL to HDL ratio																						
-GCS:gamma	gamma	Gamma Glutamyle Transpeptidase																						
-GCS:hbsag	hbsag	HBsAg																						
-GCS:hbsab	hbsab	HBsAb																						
-GCS:hbcab	hbcab	HBcAb																						
-GCS:hbv	hbv	HBV DNA																						
-GCS:hcv	hcv	HCV Antibody																						
-GCS:wbc	wbc	White Blood Cell																						
-GCS:rbc	rbc	Red Blood Cell																						
-GCS:hb	hb	Hemoglobin																						
-GCS:hct	hct	Hematocrit																						
-GCS:plt	plt	Platelet		plateletcrit value	maybe? not sure if this is the same																			
-GCS:mcv	mcv	Mean Corpuscular Volume																						
-GCS:mch	mch	Mean Corpuscular Hemoglobin																						
-GCS:mchc	mchc	Mean Corpuscular Hemoglobin Concentration																						
-GCS:rdw	rdw	Red Cell Distribution Width	equivalent	red blood cell distribution width value																				
-GCS:BloodType	BloodType	Specifies patient Blood Group	equivalent	blood type determination value																				
-GCS:Rh	Rh	Specifies patient Blood Rh	equivalent	rheumatoid factor measurement value																				
-GCS:BioSampHairAvailFlag	BioSampHairAvailFlag	if patient has hair sample select YES if not Selct No																						
-GCS:BioSampNailAvailFlag	BioSampNailAvailFlag	if patient has nail sample select YES if not Selct No																						
-GCS:BioSampBloodAvailFlag	BioSampBloodAvailFlag	if patient has Blood sample select YES if not Selct No	equivalent	blood																				
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
+Field Label	Class Type	GECKO Label	Definition	Comment																			
+LABEL	CLASS_TYPE	C % SPLIT=|																					
+Identity		GCS	Identity and contact information																				
+Demographic Info	equivalent	demographic data	Demographic characteristics: sex, age, ethnicity, marital status, education																				
+Family members	subclass	family and household structure	Characteristics of relatives in the household																				
+Residence	equivalent	residence	The residential area (urban/rural), structure of the house, and duration of residing in the house																				
+Water and fuel source		GCS	Water source, heat and fuel system, and cooking method																				
+Job	equivalent	occupation	The names of all jobs the participant has had and the duration of work																				
+Food preservation and cooking		GCS	Food preservation, frying, boiling, BBQ, steaming, ‚Ä¶																				
+Properties		GCS	Transferable and non-transferable belongings and wealth score (Multiple Correspondence Analysis)																				
+Medical History	equivalent	clinical history	Suffering from any disease at the baseline of cohort																				
+Chief complaints		GCS	The complaints of participants from their physical or mental sufferings																				
+Cancer History	equivalent	clinical history of cancer	History of cancer, site, and age diagnosed in the participant or any of his/her relatives																				
+Smoking	equivalent	tobacco	Ever or current smoker, age of use, type, number per day and days per week																				
+Opium use	equivalent	opiate use history	Ever or current user, age and route of use, type, time per day and days per week																				
+Alcohol use	equivalent	alcohol	Ever or current user, age of use, type, quantity per episode and episodes per month																				
+Drug history (1)	equivalent	recreational drug use history	The main created categories of drugs consumed by participants																				
+Drug History (2)	equivalent	recreational drug use history	The exact name, duration, dose, and frequency of drugs consumed																				
+Oral health	equivalent	oral health history	Decayed, filled, and missing teeth along with the age of the participant in each of these occasions																				
+Tea		GCS	Tea temperature, type of tea, and type of habit for drinking the tea																				
+Physical activity	equivalent	physical activity	The duration and intensity of physical activities during working and leasure times of the day, and Metabolic Equivalent Task (MET)																				
+Animal contact		GCS	The age of the participant in contact with animals, the duration and intensity of animal contact, and the type of animal																				
+Anthropometric measurements	equivalent	anthropometry	Physically measured height, weight, waist circumference, hip circumference and data of pictogram																				
+Blood pressure measurements	equivalent	blood pressure	Both systolic and diastolic blood pressure measured in sitting position twice from each arm																				
+Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result	Units of food categories consumed per day																				
+Lab markers		GCS	Biochemical markers																				
+PID			The Unique Id for eatch participant																				
+FirstName			The first name of participant.																				
+LastName			The last name of participant.																				
+Province	subclass	residence	Specifies the participant Province of Residence																				
+District	subclass	residence	Specifies the participant District of Residence																				
+City	subclass	residence	Specifies the participant City of Residence																				
+Subdistrict	subclass	residence	Specifies the participant Subdistrict of Residence																				
+Village	subclass	residence	Specifies the participant Village of Residence																				
+Street	subclass	residence	Specifies the participant Street of Residence																				
+Alley	subclass	residence	Specifies the participant Alley of Residence																				
+CV name	subclass	residence	Specifies the names of cities or villages in one variable																				
+City_Village	subclass	residence	Specifies residence in cities or villages																				
+HouseNumber	subclass	residence	Specifies the participant's House Number of Residence																				
+ZipCode	subclass	residence	Specifies the participant's Zip Code of Residence																				
+HomePhone			Specifies the participants Home Phone																				
+AreaCode			Specifies the participant's home Phone Area Code																				
+CellPhone			Specifies the participant's Cell phone number																				
+HealthCenter			participant related to this health center(the participant covered by this health center)																				
+FamilyMemPhone			Specifies the phone number of one of participant's family members																				
+FamilyMemAreaCode			Specifies the area code of the phone number of one of participant's family members																				
+FamilyMemName			Specifies the name of one family member of the participant																				
+FriendName			Specifies the name of one of friends of the participant																				
+FriendProvince			Specifies the province in which the friend of the participant resides																				
+FriendDistrict			Specifies the district in which the friend of the participant resides																				
+FriendCity			Specifies the city in which the friend of the participant resides																				
+FriendSubdistrict			Specifies the subdistrict in which the friend of the participant resides																				
+FriendVillage			Specifies the village in which the friend of the participant resides																				
+FriendStreet			Specifies the street in which the friend of the participant resides																				
+FriendAlley			Specifies the alley in which the friend of the participant resides																				
+FriendHouseNumber			Specifies the house number in which the friend of the participant resides																				
+FriendZipCode			Specifies the zip code in which the friend of the participant resides																				
+FriendHomePhone			Specifies the phone number of the participant's friend																				
+FriendAreaCode			Specifies the area code of the phone number of participant's friend																				
+FriendCellPhone			Specifies the cell phone number of participant's friend																				
+PlaceOfInterview			Specifies the participant interview place																				
+InterviewPDate_Y			participant year of Interview date in Shamsi format																				
+InterviewPDate_M			participant month of Interview date in Shamsi format																				
+InterviewPDate_D			participant Day of Interview date in Shamsi format																				
+Gender	equivalent	gender	Specifies the participant Gender																				
+BdatePDate_Y	subclass	age/birthdate	Year of participant Birth date in Shamsi format																				
+BdatePDate_M	subclass	age/birthdate	Month of participant Birth date in Shamsi format																				
+BdatePDate_D	subclass	age/birthdate	Day of participant Birth date in Shamsi format																				
+Age_self	subclass	age/birthdate	Specifies the self-report participant age in inteview time																				
+Age_new	subclass	age/birthdate	Age calculated from birth date and interview date																				
+Ethnicity	equivalent	ethnicity/race	Specifies the participant Ethnicity																				
+ethnicity_new	subclass	ethnicity/race	Specifies ethnicity by Turkmen or Non-turkmen																				
+MaritalStatus	equivalent	marital status value	Specifies the participant marital status																				
+marital_new	subclass	marital status value	Specifies marital status into married or non-married																				
+Education	equivalent	education	Specifies the participant Education Level																				
+FamilyInHousehold	subclass	family and household structure	Specifies the number of participant family living in the household																				
+BrothersN	subclass	family and household structure	Specifies participant No. of Brothers																				
+StepbrothersN	subclass	family and household structure	Specifies participant No. of Step brothers																				
+SistersN	subclass	family and household structure	Specifies participant No. of Sisters																				
+Stepsisters	subclass	family and household structure	Specifies participant No. of Step sisters																				
+Sons	subclass	family and household structure	Specifies participant No. of Sons																				
+Daughters	subclass	family and household structure	Specifies participant No. of Daughters																				
+TwinYesNo	subclass	family and household structure	Specifies whether the participant has twin brother or sister																				
+TwinAlive	subclass	family and household structure	Specifies whether the twin of the participant is alive																				
+ResDuration_1	subclass	residence	Specifies the participant first residence history Duration																				
+ResCitVill_1	subclass	residence	Specifies the participant first residence history in Village or City																				
+ResDistrict_1	subclass	residence	Specifies the participant first residence history District																				
+ResCitVillname_1	subclass	residence	Specifies the participant first residence history City or village name																				
+ResHouseType_1	subclass	residence	Specifies the participant first residence history House Type																				
+ResDuration_2	subclass	residence	Specifies the participant second residence history Duration																				
+ResCitVill_2	subclass	residence	Specifies the participant second residence history in Village or City																				
+ResDistrict_2	subclass	residence	Specifies the participant second residence history District																				
+ResCitVillname_2	subclass	residence	Specifies the participant second residence history City or village name																				
+ResHouseType_2	subclass	residence	Specifies the participant second residence history House Type																				
+ResDuration_3	subclass	residence	Specifies the participant third residence history Duration																				
+ResCitVill_3	subclass	residence	Specifies the participant third residence history in Village or City																				
+ResDistrict_3	subclass	residence	Specifies the participant third residence history District																				
+ResCitVillname_3	subclass	residence	Specifies the participant third residence history City or village name																				
+ResHouseType_3	subclass	residence	Specifies the participant third residence history House Type																				
+FoodWatSource			Specifies participant used water source																				
+FoodWatYearsPipe			Specifies how many years participant used pipe water																				
+FoodWatPriorPipeSource			Specifies what water source participant used prior to pipe water																				
+HeatAndFuelDuration_1			Specifies the duration the participant Used Heating or Fuel system, first history																				
+HeatingSystemType_1			Specifies the participant Used Heating Type, first history																				
+HeatMethod_1			Specifies the participant Used Heating Type of fuel, first history																				
+CookingMethod_1			Specifies the participant Used Cooking Type of fuel, first history																				
+HeatAndFuelDuration_2			Specifies the duration the participant Used Heating or Fuel system, second history																				
+HeatingSystemType_2			Specifies the participant Used Heating Type, second history																				
+HeatMethod_2			Specifies the participant Used Heating Type of fuel, second history																				
+CookingMethod_2			Specifies the participant Used Cooking Type of fuel, second history																				
+HeatAndFuelDuration_3			Specifies the duration participant Used Heating or Fuel system, third history																				
+HeatingSystemType_3			Specifies the participant Used Heating Type, third history																				
+HeatMethod_3			Specifies the participant Used Heating Type of fuel, third history																				
+CookingMethod_3			Specifies the participant Used Cooking Type of fuel, third history																				
+WorkEverWorkedFlag	subclass	occupation	Working for at least one year of full-time job																				
+WorkAgeBegan	subclass	occupation	Specifies participant start work age																				
+WorkCurrently	subclass	occupation	Specifies participant work now																				
+JobsStartAge	subclass	occupation	Age of starting the job for last history																				
+JobsEndAge	subclass	occupation	Age of quiting the job for last history																				
+JobsTitleOccupation	subclass	occupation	Name of the job																				
+JobsTitleOccupationCode	subclass	occupation	Code of the job (Appendix)																				
+JobsHoursPerDay	subclass	occupation	Number of working hours per day																				
+JobsIntensity	subclass	occupation	The intensity of physical activity during the job																				
+JobMonthPerYear	subclass	occupation	Number of working months per year																				
+HusbandOccupation			Code of the husband job (Appendix)	maybe family?																			
+FoodWatFoodPreserve			Specifies How to Preserve foods	is this lifestyle or diet?																			
+FoodWatBreadPreserve			Specifies How to Preserve bread																				
+FoodWatShallowFryVeg			Specifies Using vegetable in Small frying																				
+FoodWatShallowFryMeat			Specifies Using Meat in Small frying																				
+FoodWatShallowFryFish			Specifies Using Fish in Small frying																				
+FoodWatDeepFryVeg			Specifies Using vegetable in Deep frying																				
+FoodWatDeepFryMeat			Specifies Using Meat in Deep frying																				
+FoodWatDeepFryFish			Specifies Using Fish in Deep frying																				
+FoodWatBBQVeg			Specifies Using vegetable in BBQ																				
+FoodWatBBQMeat			Specifies Using Meat in BBQ																				
+FoodWatBBQFish			Specifies Using Fish in BBQ																				
+FoodWatBoilVeg			Specifies Using vegetable Boiling																				
+FoodWatBoilMeat			Specifies Using Meat Boiling																				
+FoodWatBoilFish			Specifies Using Fish Boiling																				
+FoodWatSteamVeg			Specifies Using vegetable Steaming																				
+FoodWatSteamMeat			Specifies Using Meat Steaming																				
+FoodWatSteamFish			Specifies Using Fish Steaming																				
+FoodWatOthVeg			Specifies Using vegetable by any Other method																				
+FoodWatOthMeat			Specifies Using Meat by any Other method																				
+FoodWatOthFish			Specifies Using Fish in by any Other method																				
+FoodWatFreshLocalFruitChange			Specifies the change in using Local Fruit from 1353																				
+FoodWatFreshImportedFruitChange			Specifies the change in using Imported Fruit from 1353																				
+FoodWatFreshVegChange			Specifies the change in using Fresh Vegetable from 1353																				
+FoodWatFreshMeatChange			Specifies the change in using Fresh Meat from 1353																				
+Homeownership			Specifies participant Homeownership status	is this lifestyle or sociodemographic? this is all talking about wealth																			
+house_nonowned			Specifies house owned or non-owned																				
+HomeSize			Specifies participant Home Area	residence?																			
+PropertyAutoOwned			If the participant has personal car select yes if no select no																				
+PropertyAutoYears			Specifies the length of time that the participant has a personal car(Year)																				
+PropertyMotorcycleOwned			If the participant has Motorcycle select yes if no select no																				
+PropertyMotorcycleYears			Specifies the length of time that the participant has Motorcycle(Year)																				
+PropertyColorTVOwned			If the participant has Color TV select yes if no select no																				
+PropertyColorTVYears			Specifies the length of time that the participant has Color TV(Year)																				
+PropertyBandWTVOwned			If the participant has BandW TV select yes if no select no																				
+PropertyBandWTVYears			Specifies the length of time that the participant has BandW TV(Year)																				
+PropertyIndoorBathOwned			If the participant has Indoor Bath room select yes if no select no																				
+PropertyIndoorBathYears			Specifies the length of time that the participant has Indoor Bath room(Year)																				
+PropertyVacuumOwned			If the participant has Vacuum cleaner select yes if no select no																				
+PropertyVacuumYears			Specifies the length of time that the participant has Vacuum cleaner(Year)																				
+PropertyWashMachOwned			If the participant has Washing machine select yes if no select no																				
+PropertyWashMachYears			Specifies the length of time that the participant has Washing machine(Year)																				
+PropertyRefrigeratorOwned			If the participant has Refrigerator select yes if no select no																				
+PropertyRefrigeratorYears			Specifies the length of time that the participant has Refrigerator(Year)																				
+PropertyFreezerOwned			If the participant has Freezer select yes if no select no																				
+PropertyFreezerYears			Specifies the length of time that the participant has Freezer(Year)																				
+PropertyComputerOwned			If the participant has Computer select yes if no select no																				
+PropertyComputerYears			Specifies the length of time that the participant has Computer(Year)																				
+HomeRooms			Number of rooms in the house																				
+HaveBath			Specifies if the household has bathroom																				
+HaveKitchen			Specifies if the household has kitchen																				
+MCA			Composite wealth score (Multiple Correspondence Analysis)	lifestyle or sociodemographic?																			
+NumberPregnancies		pregnancy history	Specifies the number of Pregnancies for women only																				
+NumberLiveBirths		pregnancy history	Specifies the number of live births for women only																				
+DisRheumaticHeartDx		diagnosis of heart disease	if the diagnosis of Rheumatic Heart Disease was made for participant by a physician																				
+DisRheumaticHeartAge		diagnosis of heart disease	participant age at Rheumatic Heart Disease diagnosis																				
+DisHeartDiseaseDx		diagnosis of heart disease	if the diagnosis of Heart Disease was made for participant by a physician																				
+DisHeartDiseaseAge		diagnosis of heart disease	participant age in first Heart Disease diagnosis																				
+DisStrokeDx		occurrence of stroke	if the diagnosis of Stroke was made for participant by a physician																				
+DisStrokeAge		occurrence of stroke	participant age in first Stroke diagnosis																				
+DisHypertensionDx		diagnosis of hypertension	if the diagnosis of Hypertension was made for participant by a physician																				
+DisHypertensionAge		diagnosis of hypertension	participant age in first Hypertension diagnosis																				
+DisDiabetesDx		diagnosis of diabetes	if the diagnosis of Diabetes was made for participant by a physician																				
+DisDiabetesAge		diagnosis of diabetes	participant age in first Diabetes diagnosis																				
+DisCOPDDx		diagnosis of chronic obstructive pulmonary disease	if the diagnosis of COPD was made for participant by a physician																				
+DisCOPDAge		diagnosis of chronic obstructive pulmonary disease	participant age in first COPD diagnosis																				
+DisRenalFailureDx		diagnosis of renal failure	if the diagnosis of Renal Failure was made for participant by a physician																				
+DisRenalFailureAge		diagnosis of renal failure	participant age in first RenalFailure diagnosis																				
+DisJaundiceDx		diagnosis of jaundice	if the diagnosis of Jaundice was made for participant by a physician																				
+DisJaundiceAge		diagnosis of jaundice	participant age in first Jaundice diagnosis																				
+DisLiverDx		diagnosis of liver failure	if the diagnosis of Chronic Liver Failure was made for participant by a physician																				
+DisLiverAge		diagnosis of liver failure	participant age in first Chronic liver failure diagnosis																				
+DisTBDx		diagnosis of tuberculosis	if the diagnosis of Tuberculosis was made for participant by a physician																				
+DisTBAge		diagnosis of tuberculosis	participant age in first Tuberculosis diagnosis																				
+SurgeryFlag		surgical interventions	If the participant had had any history of surgery																				
+SurgeryType		surgical interventions	Specifies the participant surgery Type																				
+SurgeryAge		surgical interventions	Specifies the participant age in surgery Time																				
+TransfusionFlag			if the participant has had Transfusion history																				
+TransfusionRecentFlag			if the participant has Transfusion history in last month																				
+SymRefluxFlag		occurrence of acid reflux	if the participant has Reflux Symptom history select yes if not select no																				
+SymRefluxWhen		occurrence of acid reflux	when Reflux Symptom happen in First time																				
+SymHeartburnFlag		occurrence of heartburn	if the participant has Heartburn Symptom history select yes if not select no																				
+SymHeartburnWhen		occurrence of heartburn	when Heartburn Symptom happen in First time																				
+SymDifficultSwallowingFlag		occurrence of difficulty swallowing	if the participant has Difficult Swallowing Symptom history select yes if not select no																				
+SymDifficultSwallowingWhen		occurrence of difficulty swallowing	when Difficult Swallowing Symptom happen in First time																				
+SymRefluxPastYearFreq		occurrence of acid reflux	if the participant has Reflux Symptom in past year select yes if not select no																				
+SymRefluxPastYearSeverity		occurrence of acid reflux	Severity Reflux Symptom in past year																				
+SymRefluxPriorYearsFreq		occurrence of acid reflux	if the participant has Reflux Symptom in Prior year select yes if not select no																				
+SymRefluxPriorYearsSeverity		occurrence of acid reflux	Severity Reflux Symptom in Prior year																				
+RefluxHeartburnTXFlag		medication	if participant used drug for Heartburn symptoms select yes if not select no and if participant doesn't have symtom selectLack of signage	should we create medication for heartburn?																			
+WeightLossFlag		clinical history	if the patient has Weightloss in past year select yes if not select no	should we be more specific here?																			
+WeightLossAmount		clinical history	Specifies the amount of weight loss																				
+WeightLossIntent		clinical history	if the patient has Intentional weight loss select Yes if not select no and doesn't have weight loss select I have no weight loss																				
+cancerdxflag		clinical history of cancer	Past history of cancer diagnosed by a physician?																				
+cancerdxage		clinical history of cancer	Year of diagnosis of cancer if detected in participant																				
+cancerdxsite		clinical history of cancer	Original site of cancer																				
+CancRelRelativeCode_1		clinical history of cancer	Specifies the relative of participants with a history of cancer																				
+CancRelAgeDiagnosis_1		clinical history of cancer	Specifies the age of relative when cancer was diagnosed																				
+CancRelSite_1		clinical history of cancer	Specifies the site of cancer in the relative of participant																				
+CancRelICD10_1		clinical history of cancer	Specifies the ICD-10 code of cancer in the relative of participant																				
+CancRelRelativeCode_2		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+CancRelAgeDiagnosis_2		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+CancRelSite_2		family clinical history	Specifies the site of cancer in the relative of participant																				
+CancRelICD10_2		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+CancRelRelativeCode_3		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+CancRelAgeDiagnosis_3		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+CancRelSite_3		family clinical history	Specifies the site of cancer in the relative of participant																				
+CancRelICD10_3		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+CancRelRelativeCode_4		family clinical history	Specifies the additional relative of participants with a history of cancer																				
+CancRelAgeDiagnosis_4		family clinical history	Specifies the age of relative when cancer was diagnosed																				
+CancRelSite_4		family clinical history	Specifies the site of cancer in the relative of participant																				
+CancRelICD10_4		family clinical history	Specifies the ICD-10 code of cancer in the relative of participant																				
+TobEverRegularFlag	subclass	tobacco	Specifies the participant used cigar for 6 Months																				
+TobCigsNow	subclass	tobacco	Specifies the participant uses cigar Now																				
+TobNonCigFlag	subclass	tobacco	Specifies the participant used tobacco other than cigar for 6 Months																				
+TobStartAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, first history																				
+TobEndAge_1	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, first history																				
+TobDuration_1	subclass	tobacco	Specifies the participant Used tobacco Duration, first history																				
+TobType_1	subclass	tobacco	Specifies the participant Used type of Tobacco, first history																				
+TobNumberPerDay_1	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, first history																				
+TobDaysPerWeek_1	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, first history																				
+CigNumPerDay_1	subclass	tobacco	Specifies the participant Used this cigar how many times per day, first history																				
+Cigpackyear_1	subclass	tobacco	Specifies the participant cumulative use, first history																				
+TobStartAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, second history																				
+TobEndAge_2	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, second history																				
+TobDuration_2	subclass	tobacco	Specifies the participant Used tobacco Duration, second history																				
+TobType_2	subclass	tobacco	Specifies the participant Used type of Tobacco, second history																				
+TobNumberPerDay_2	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, second history																				
+TobDaysPerWeek_2	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, second history																				
+CigNumPerDay_2	subclass	tobacco	Specifies the participant Used this cigar how many times per day, second history																				
+Cigpackyear_2	subclass	tobacco	Specifies the participant cumulative use, second history																				
+TobStartAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, third history																				
+TobEndAge_3	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, third history																				
+TobDuration_3	subclass	tobacco	Specifies the participant Used tobacco Duration, third history																				
+TobType_3	subclass	tobacco	Specifies the participant Used type of Tobacco, third history																				
+TobNumberPerDay_3	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, third history																				
+TobDaysPerWeek_3	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, third history																				
+CigNumPerDay_3	subclass	tobacco	Specifies the participant Used this cigar how many times per day, third history																				
+Cigpackyear_3	subclass	tobacco	Specifies the participant cumulative use, third history																				
+TobStartAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type From Age, fourth history																				
+TobEndAge_4	subclass	tobacco	Specifies the participant Used this Tobacco type To Age, fourth history																				
+TobDuration_4	subclass	tobacco	Specifies the participant Used tobacco Duration, fourth history																				
+TobType_4	subclass	tobacco	Specifies the participant Used type of Tobacco, fourth history																				
+TobNumberPerDay_4	subclass	tobacco	Specifies the participant Used this tobacco how many times per day, fourth history																				
+TobDaysPerWeek_4	subclass	tobacco	Specifies the participant Used this tobacco how many days in week, fourth history																				
+CigNumPerDay_4	subclass	tobacco	Specifies the participant Used this cigar how many times per day, fourth history																				
+Cigpackyear_4	subclass	tobacco	Specifies the participant cumulative use, fourth history																				
+total_packyear	subclass	tobacco	Specifies the participant total cumulative use																				
+OpiateEverRegularFlag		opiate use history	Specifies the participant ever used opiume for 6 Months																				
+OpiatePersonalChildhoodExp		opiate use history	Specifies the using opium in Childhood																				
+OpiateAdministeredToChildrenFlag			Specifies the participant gave opium to children	???																			
+OpiateType		opiate use history	Specifies the participant Used Opium type																				
+OpiateRoute		opiate use history	Specifies the route by which participant uses opium																				
+OpiateStartAge_1		opiate use history	Specifies the participant Used this Opium type From Age, first history																				
+OpiateEndAge_1		opiate use history	Specifies the participant Used this Opium type To Age, first history																				
+OpiateDuration_1		opiate use history	Specifies the participant Used this Opium Duration, first history																				
+OpiateNokhod_1		opiate use history	Specifies the participant Used this Opium amount in Pea size, first history																				
+OpiateDaysPerWeek_1		opiate use history	Specifies the participant Used this Opium day in week, first history																				
+OpiateAmountperDay_1		opiate use history	Specifies the participant Used this Opium Amount per day, first history																				
+Opiatecum_1		opiate use history	Specifies the participant cumulative use of Opium, first history																				
+OpiateStartAge_2		opiate use history	Specifies the participant Used this Opium type From Age, second history																				
+OpiateEndAge_2		opiate use history	Specifies the participant Used this Opium type To Age, second history																				
+OpiateDuration_2		opiate use history	Specifies the participant Used this Opium Duration, second history																				
+OpiateNokhod_2		opiate use history	Specifies the participant Used this Opium amount in Pea size, second history																				
+OpiateDaysPerWeek_2		opiate use history	Specifies the participant Used this Opium day in week, second history																				
+OpiateAmountperDay_2		opiate use history	Specifies the participant Used this Opium Amount per day, second history																				
+Opiatecum_2		opiate use history	Specifies the participant cumulative use of Opium, second history																				
+OpiateStartAge_3		opiate use history	Specifies the participant Used this Opium type From Age, third history																				
+OpiateEndAge_3		opiate use history	Specifies the participant Used this Opium type To Age, third history																				
+OpiateDuration_3		opiate use history	Specifies the participant Used this Opium Duration, third history																				
+OpiateNokhod_3		opiate use history	Specifies the participant Used this Opium amount in Pea size, third history																				
+OpiateDaysPerWeek_3		opiate use history	Specifies the participant Used this Opium day in week, third history																				
+OpiateAmountperDay_3		opiate use history	Specifies the participant Used this Opium Amount per day, third history																				
+Opiatecum_3		opiate use history	Specifies the participant cumulative use of Opium, third history																				
+OpiateStartAge_4		opiate use history	Specifies the participant Used this Opium type From Age, fourth history																				
+OpiateEndAge_4		opiate use history	Specifies the participant Used this Opium type To Age, fourth history																				
+OpiateDuration_4		opiate use history	Specifies the participant Used this Opium Duration, fourth history																				
+OpiateNokhod_4		opiate use history	Specifies the participant Used this Opium amount in Pea size, fourth history																				
+OpiateDaysPerWeek_4		opiate use history	Specifies the participant Used this Opium day in week, fourth history																				
+OpiateAmountperDay_4		opiate use history	Specifies the participant Used this Opium Amount per day, fourth history																				
+Opiatecum_4		opiate use history	Specifies the participant cumulative use of Opium, fourth history																				
+TotalNokhodDay		opiate use history	Specifies the participant total cumulative use of Opium																				
+AlcEverRegularFlag	subclass	alcohol	Specifies the participant ever used alcohol for 6 Months																				
+AlcStartAge_1	subclass	alcohol	Specifies the participant used alcohol From Age, first history																				
+AlcEndAge_1	subclass	alcohol	Specifies the participant used alcohol To Age, first history																				
+AlcType_1	subclass	alcohol	Specifies the participant alcohol used Type, first history																				
+AlcQuantityPerEpisode_1	subclass	alcohol	Specifies the average alcohol the participant used per episode, first history																				
+AlcEpisodesPerMonth_1	subclass	alcohol	Specifies the participant Alcohol episodes in month, first history																				
+AlcStartAge_2	subclass	alcohol	Specifies the participant used alcohol From Age, second history																				
+AlcEndAge_2	subclass	alcohol	Specifies the participant used alcohol To Age, second history																				
+AlcType_2	subclass	alcohol	Specifies the participant alcohol used Type, second history																				
+AlcQuantityPerEpisode_2	subclass	alcohol	Specifies the average alcohol the participant used per episode, second history																				
+AlcEpisodesPerMonth_2	subclass	alcohol	Specifies the participant Alcohol episodes in month, second history																				
+AlcStartAge_3	subclass	alcohol	Specifies the participant used alcohol From Age, third history																				
+AlcEndAge_3	subclass	alcohol	Specifies the participant used alcohol To Age, third history																				
+AlcType_3	subclass	alcohol	Specifies the participant alcohol used Type, third history																				
+AlcQuantityPerEpisode_3	subclass	alcohol	Specifies the average alcohol the participant used per episode, third history																				
+AlcEpisodesPerMonth_3	subclass	alcohol	Specifies the participant Alcohol episodes in month, third history																				
+DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
+antiHTN	subclass	history of medication for hypertension	Anti-hypertensive drugs: 1: diuretics 2: beta-blockers 3: ACE Inhibitors 4: ARBs 5: Alpha-adrenergic blockers 6: Calcium channel blockers 7:other anti-hypertensives																				
+antiDM	subclass	history of medication for diabetes	Anti-diabetic drugs: 1: Glibenclamide 2: metformin 3: insulin 4: other																				
+cardiac	subclass	history of medication for cardiac disease	Cardiac drugs: 1: Anti-platelets 2: statins 3: Beta-blockers 4: Nitrates 5: ACE Inhibitors 6: ARBs 7: Calcium Channel blockers 8: other																				
+antilipid	subclass	history of medication for high cholesterol	Lipid-lowering drugs: 1: Statins 2: Gemfibrozil 3: other																				
+mentaldrug	subclass	history of medication for mental disorder	Mental disorders: 1: Benzodiazepines 2: Sodium Valproate 3: Anti-epileptics 4: Antidepressants 5: Anti-anxiety medications 6: Psychoactive medications																				
+Corticosteroid	subclass	use of corticosteroids	Corticosteroids: 1: injection 2: oral 3: topical																				
+Gidrugs	subclass	history of medication for gastrointestinal disease	Gastrointestinal: 1: H2 Blockers 2: PPIs 3: Clindinium C																				
+antibiotics	subclass	use of antibiotics	Antibiotics: 1: Amoxicillin 2: Cefixime 3: Azithromycin 4: Metronidazole 5: other																				
+diuretic	subclass	use of diuretics	Diuretics																				
+betablocker	subclass	use of beta blockers	Beta Blockers																				
+ACEinhibitor	subclass	use of angiotensin convertin enzyme inhibitors	Angiotensin Converting Enzyme Inhibitors																				
+ARB	subclass	use of angiotensin receptor blockers	Angiotensin Receptor Blockers																				
+alphablocker	subclass	use of alpha adrenergic blockers	Alpha Adrenergic Blockers																				
+CCBlocker	subclass	use of calcium channel blockers	Calcium Channel Blockers																				
+Glibenclamide	subclass	use of glibenclamide	Glibenclamide																				
+Metformin	subclass	use of metformin	Metformin																				
+Insulin	subclass	use of insulin	Insulin																				
+Antiplatelets	subclass	use of antiplatelets	Anti-platelets																				
+Statins	subclass	use of statins	Statins																				
+Nitrates	subclass	use of nitrates	Nitrates																				
+Gemfibrozil	subclass	use of gemfibroxil	Gemfibrozil																				
+Acetaminophen	subclass	use of acetaminophen	Acetaminophen and Acetaminophen Codein																				
+Ibuprofen	subclass	use of ibuprofen	Ibuprofen																				
+Diclophenac	subclass	use of diclophenac	Diclophenac																				
+Indomethacin	subclass	use of indomethacin	Indomethacin																				
+Levothyroxin	subclass	use of levthyroxine	Levthyroxin																				
+Methotrexate	subclass	use of methotrexate	Methotrexate																				
+Other	subclass	medication history	Other																				
+DrugCurrentuse	subclass	medication history	Currently taking any medication?																				
+drugname_1	subclass	medication history	Name of drug 1	Could name fall under "prescription"?																			
+drugduration_1	subclass	medication history	Number of years being under treatment 1																				
+drugfrequency_1	subclass	posology	Frequency of drug consumption 1																				
+drugdose_1	subclass	posology	Dose of drug consumed 1																				
+drugname_2	subclass	medication history	Name of drug 2																				
+drugduration_2	subclass	medication history	Number of years being under treatment 2																				
+drugfrequency_2	subclass	posology	Frequency of drug consumption 2																				
+drugdose_2	subclass	posology	Dose of drug consumed 2																				
+drugname_3	subclass	medication history	Name of drug 3																				
+drugduration_3	subclass	medication history	Number of years being under treatment 3																				
+drugfrequency_3	subclass	posology	Frequency of drug consumption 3																				
+drugdose_3	subclass	posology	Dose of drug consumed 3																				
+drugname_4	subclass	medication history	Name of drug 4																				
+drugduration_4	subclass	medication history	Number of years being under treatment 4																				
+drugfrequency_4	subclass	posology	Frequency of drug consumption 4																				
+drugdose_4	subclass	posology	Dose of drug consumed 4																				
+drugname_5	subclass	medication history	Name of drug 5																				
+drugduration_5	subclass	medication history	Number of years being under treatment 5																				
+drugfrequency_5	subclass	posology	Frequency of drug consumption 5																				
+drugdose_5	subclass	posology	Dose of drug consumed 5																				
+drugname_6	subclass	medication history	Name of drug 6																				
+drugduration_6	subclass	medication history	Number of years being under treatment 6																				
+drugfrequency_6	subclass	posology	Frequency of drug consumption 6																				
+drugdose_6	subclass	posology	Dose of drug consumed 6																				
+drugname_7	subclass	medication history	Name of drug 7																				
+drugduration_7	subclass	medication history	Number of years being under treatment 7																				
+drugfrequency_7	subclass	posology	Frequency of drug consumption 7																				
+drugdose_7	subclass	posology	Dose of drug consumed 7																				
+drugname_8	subclass	medication history	Name of drug 8																				
+drugduration_8	subclass	medication history	Number of years being under treatment 8																				
+drugfrequency_8	subclass	posology	Frequency of drug consumption 8																				
+drugdose_8	subclass	posology	Dose of drug consumed 8																				
+drugname_9	subclass	medication history	Name of drug 9																				
+drugduration_9	subclass	medication history	Number of years being under treatment 9																				
+drugfrequency_9	subclass	posology	Frequency of drug consumption 9																				
+drugdose_9	subclass	posology	Dose of drug consumed 9																				
+drugname_10	subclass	medication history	Name of drug 10																				
+drugduration_10	subclass	medication history	Number of years being under treatment 10																				
+drugfrequency_10	subclass	posology	Frequency of drug consumption 10																				
+drugdose_10	subclass	posology	Dose of drug consumed 10																				
+OralPermanentTeethLossFlag	subclass	oral health history	Permanent Teeth Loss																				
+OralPermanentTeethAgeFirstLoss	subclass	oral health history	Specifies the age of first Permanent Teeth Loss																				
+OralUpperDentureFlag	subclass	oral health history	Specifies the participant used Upper Denture																				
+OralLowerDentureFlag	subclass	oral health history	Specifies the participant used Lower Denture																				
+OralUpperDentureUse	subclass	oral health history	Specifies the participant used Upper Denture during the day																				
+OralLowerDentureUse	subclass	oral health history	Specifies the participant used Lower Denture during the day																				
+OralAgeDentureUpper	subclass	oral health history	Specifies the age of participant first used Upper Denture																				
+OralAgeDentureLower	subclass	oral health history	Specifies the age of participant First used Lower Denture																				
+OralFreqBrushing	subclass	oral health history	Specifies the participant Brushing Frequency																				
+OralFoodDiscomfortFlag	subclass	oral health history	Specifies the frequency the participant experienced discomfort while eating food in Past Year																				
+OralFoodDiscomfortType	subclass	oral health history	Specifies the food that caused discomfort for the participant																				
+OralNumTeeth	subclass	oral health history	Specifies the participant Total number of teeth																				
+OralNumTeethDecayed	subclass	oral health history	Specifies the participant Total number of Decayed teeth																				
+OralNumTeethMissing	subclass	oral health history	Specifies the participant Total number of Missing teeth																				
+OralNumTeethFilled	subclass	oral health history	Specifies the participant Total number of Filled teeth																				
+OralMucosa	subclass	oral health history	Specifies the participant Mucosa Status																				
+TeaTempDegrees		information about diet	Specifies participant consumption of tea temperature	is this diet?																			
+TeaTempDescription		information about diet	Specifies participant used tea type																				
+TeaSteepingTime		information about diet	Specifies the duration between pouring and drinking the tea																				
+TeaSipOrGulp		information about diet	Specifies how participant drinks tea																				
+physactworkallyearflag	subclass	occupation|physical activity	Working all months of the year?																				
+physactworkmonths	subclass	occupation|physical activity	Number of working months in a year																				
+physactworkstrenuousflag	subclass	physical activity	Daily intensive physical activity?																				
+physactworkstrenuousfreq	subclass	physical activity	Number of working days in a week																				
+physactworkstrenuoushours	subclass	physical activity	Number of working hours in a day																				
+physactworkstrenuousyears	subclass	physical activity	Number of entire working years																				
+physacthouseworkflag	subclass	physical activity	Doing house work?																				
+physacthouseworkfreq	subclass	physical activity	Number of working days in a week																				
+physacthouseworkhours	subclass	physical activity	Number of working hours in a day																				
+physacthouseworkyears	subclass	physical activity	Number of entire working years																				
+physacthouseworkminsduringwork	subclass	physical activity	Doing house work: minutes during working times																				
+physacthouseworkminsnowork	subclass	physical activity	Doing house work: minutes during leasure times																				
+physactexmildminsduringwork	subclass	physical activity	Mild exercise such as jogging: minutes during working times																				
+physactexmildminsnowork	subclass	physical activity	Mild exercise such as jogging: minutes during leasure times																				
+physactexmodminsduringwork	subclass	physical activity	Moderate exercise such as volleyball: minutes during working times																				
+physactexmodminsnowork	subclass	physical activity	Moderate exercise such as volleyball: minutes during leasure times																				
+physactexstrenminsduringwork	subclass	physical activity	Intensive exercise such as horse riding: minutes during working times																				
+physactexstrenminsnowork	subclass	physical activity	Intensive exercise such as horse riding: minutes during leasure times																				
+physacttvminsduringwork	subclass	physical activity	Watching TV, resting, reading: minutes during working times																				
+physacttvminsnowork	subclass	physical activity	Watching TV, resting, reading: minutes during leasure times																				
+Metabolic Equivalent Task	subclass	physical activity	Energy cost of physical activities defined as the ratio of metabolic rate (and therefore the rate of energy consumption) during a specific physical activity to a reference metabolic rate																				
+AnimalStartAge_1		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, first history	not sure if this is correct - do we want to be more specific?																			
+AnimalEndAge_1		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, first history																				
+AnimalLevelOfContact_1		lifestyle and behaviours	The intensity of animal contact, first history																				
+AnimalType_1		lifestyle and behaviours	The type of animal, first history																				
+AnimalStartAge_2		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, second history																				
+AnimalEndAge_2		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, second history																				
+AnimalLevelOfContact_2		lifestyle and behaviours	The intensity of animal contact, second history																				
+AnimalType_2		lifestyle and behaviours	The type of animal, second history																				
+AnimalStartAge_3		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, third history																				
+AnimalEndAge_3		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, third history																				
+AnimalLevelOfContact_3		lifestyle and behaviours	The intensity of animal contact, third history																				
+AnimalType_3		lifestyle and behaviours	The type of animal, third history																				
+AnimalStartAge_4		lifestyle and behaviours	Specifies the age of the participants he had contact with animals, fourth history																				
+AnimalEndAge_4		lifestyle and behaviours	Specifies the age of the participants he didn't have contact with animals, fourth history																				
+AnimalLevelOfContact_4		lifestyle and behaviours	The intensity of animal contact, fourth history																				
+AnimalType_4		lifestyle and behaviours	The type of animal, fourth history																				
+bodyindicessizeage15	subclass	anthropometry	The body size participants assume they have had based on pictogram when they were 15 years old																				
+bodyindicessizeage30	subclass	anthropometry	The body size participants assume they have had based on pictogram when they wer3 30 years old																				
+bodyindicessizenow	subclass	anthropometry	The body size participants assume they have at the present time based on pictogram																				
+bodyindicesheight	equivalent	height	Height																				
+bodyindicesweight	equivalent	weight	Weight																				
+bodyindiceswaist	equivalent	waist circumference value	Waist circumference																				
+bodyindiceships	equivalent	hip circumference value	Hip circumference																				
+BMI	equivalent	body mass index value	Body mass index																				
+bpright1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the right arm																				
+bpright1dbp	subclass	diastolic blood pressure value	First measurement ofdiastolic blood pressure from the right arm																				
+bpright2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the right arm																				
+bpright2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the right arm																				
+bpleft1sbp	subclass	systolic blood pressure value	First measurement of systolic blood pressure from the left arm																				
+bpleft1dbp	subclass	diastolic blood pressure value	First measurement of diastolic blood pressure from the left arm																				
+bpleft2sbp	subclass	systolic blood pressure value	Second measurement of systolic blood pressure from the left arm																				
+bpleft2dbp	subclass	diastolic blood pressure value	Second measurement of diastolic blood pressure from the left arm																				
+m_sbp	subclass	systolic blood pressure value	Mean systolic blood pressure measured second time																				
+m_dbp	subclass	diastolic blood pressure value	Mean diastolic blood pressure measured second time																				
+high_sbp	subclass	systolic blood pressure value	Systolic blood pressure >= 140 mmHg	also high BP																			
+high_dbp	subclass	diastolic blood pressure value	Diastolic blood pressure >= 90 mmHg	also high BP																			
+htndrug		use of antihypertensive agents	Consumption of any anti-hypertensive medication for more than 6 months																				
+HTN		diagnosis of hypertension	Being hypertensive																				
+HTNcat		diagnosis of hypertension	Categorization of hypetrension																				
+preHTN		diagnosis of hypertension	SBP/DBP >=120/80 AND <140/90	how do we handle prehypertension?																			
+pulse_p		calculated blood pressure value	Difference between SBP and DBP																				
+mean_bp		calculated blood pressure value	mean value of SBP and DBP																				
+mid_bp		calculated blood pressure value	Mid value of SBP and DBP																				
+diffsbp_right_left		systolic blood pressure value	Difference in SBP between arms																				
+diffdbp_right_left		diastolic blood pressure value	Difference in DBP between arms																				
+Energy		information about diet	Amount consumed per day	do we want to be more specific?																			
+fat		information about diet	Amount consumed per day																				
+salt		information about diet	Amount consumed per day																				
+protein		information about diet	Amount consumed per day																				
+total saturated fat		information about diet	Amount consumed per day																				
+total trans fat		information about diet	Amount consumed per day																				
+hydrogenated oil		information about diet	Amount consumed per day																				
+carbohyderate		information about diet	Amount consumed per day																				
+red meat		information about diet	Amount consumed per day																				
+processed meat		information about diet	Amount consumed per day																				
+fruits		information about diet	Amount consumed per day																				
+vegetables		information about diet	Amount consumed per day																				
+dairy products		information about diet	Amount consumed per day																				
+milk		information about diet	Amount consumed per day																				
+dietary fiber		information about diet	Amount consumed per day																				
+Fish		information about diet	Amount consumed per day																				
+Chicken		information about diet	Amount consumed per day																				
+SodiumNa		information about diet	Amount consumed per day																				
+Calcium		information about diet	Amount consumed per day																				
+Fe		information about diet	Amount consumed per day																				
+Magnesium		information about diet	Amount consumed per day																				
+Phosphorus		information about diet	Amount consumed per day																				
+Potassium		information about diet	Amount consumed per day																				
+Zinc		information about diet	Amount consumed per day																				
+Folate		information about diet	Amount consumed per day																				
+Vitamin D		information about diet	Amount consumed per day																				
+Vitamin A		information about diet	Amount consumed per day																				
+Vitamin B1		information about diet	Amount consumed per day																				
+Vitamin B2		information about diet	Amount consumed per day																				
+Vitamin B12		information about diet	Amount consumed per day																				
+Vitamin C		information about diet	Amount consumed per day																				
+Niacin		information about diet	Amount consumed per day																				
+Glycemic load		information about diet	Amount consumed per day																				
+Glycemic Index		information about diet	Amount consumed per day																				
+Sugar intake		information about diet	Amount consumed per day																				
+Nuts		information about diet	Amount consumed per day																				
+tea		information about diet	Amount consumed per day																				
+Coffee		information about diet	Amount consumed per day																				
+fbg	equivalent	blood fasting glucose level value	Fasting Blood Glucose																				
+urea			Urea																				
+creatinine			Creatinine																				
+cholesterol			Total Cholesterol																				
+triglycerides			Triglycerides																				
+hdl			High Density Lipoprotein																				
+ast			Aspartate Transaminase																				
+alt			Alanine Transaminase																				
+alkalinep			Alkaline Phosphatase																				
+ldl			Low Density Lipoprotein																				
+ldlhdl			LDL to HDL ratio																				
+gamma			Gamma Glutamyle Transpeptidase																				
+hbsag			HBsAg																				
+hbsab			HBsAb																				
+hbcab			HBcAb																				
+hbv			HBV DNA																				
+hcv			HCV Antibody																				
+wbc			White Blood Cell																				
+rbc			Red Blood Cell																				
+hb			Hemoglobin																				
+hct			Hematocrit																				
+plt		plateletcrit value	Platelet	maybe? not sure if this is the same																			
+mcv			Mean Corpuscular Volume																				
+mch			Mean Corpuscular Hemoglobin																				
+mchc			Mean Corpuscular Hemoglobin Concentration																				
+rdw	equivalent	red blood cell distribution width value	Red Cell Distribution Width																				
+BloodType	equivalent	blood type determination value	Specifies patient Blood Group																				
+Rh	equivalent	rheumatoid factor measurement value	Specifies patient Blood Rh																				
+BioSampHairAvailFlag			if patient has hair sample select YES if not Selct No																				
+BioSampNailAvailFlag			if patient has nail sample select YES if not Selct No																				
+BioSampBloodAvailFlag	equivalent	blood	if patient has Blood sample select YES if not Selct No																				
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							
+																							

--- a/mappings/genomics-england-mapping.tsv
+++ b/mappings/genomics-england-mapping.tsv
@@ -1,1254 +1,1253 @@
-Label	Class Type	GECKO Label	GE Parents	Comment																				
-LABEL	CLASS_TYPE	C % SPLIT=|																						
-System Data		Genomics England																						
-Augmented/critical care period		history of augmented care|timeline																						
-Diagnosis		Genomics England																						
-Patient Data		Genomics England																						
-Admissions; Period of Care		Genomics England		 ?																				
-Psychiatric		Genomics England																						
-Maternity		Genomics England																						
-Geographical		Genomics England																						
-Episodes and spells; Period of care		Genomics England																						
-Clinical		Genomics England																						
-Clinical; Period of Care		Genomics England																						
-Practitioner		Genomics England																						
-Organisation		Genomics England																						
-Discharges; Period of Care		Genomics England																						
-Healthcare resource groups (HRG) data		Genomics England																						
-Patient Pathway		Genomics England																						
-Socio-economic		Genomics England																						
-Procedure		Genomics England																						
-Organisation data		Genomics England																						
-System data		Genomics England																						
-EPISODE MATCH RANK			Administrative																					
-episode_matched			Administrative																					
-Gender			Administrative																					
-HESID Matched			Administrative																					
-Hesid Rank			Administrative																					
-modified_date			Administrative																					
-patient_death			Administrative																					
-Procedure Revision Flag			Administrative																					
-Proms Procedure Code			Administrative																					
-proms_proc_group			Administrative																					
-proms_serial_no			Administrative																					
-Date of admission		life stage/time point	Admissions; Period of Care																					
-Method of admission			Admissions; Period of Care	waiting list or not waiting list																				
-Admission source			Admissions; Period of Care	where patient was prior to admission (hotel, home, court, psychiatrict, etc.)																				
-Date of decision to admit		life stage/time point	Admissions; Period of Care	date and time-related or timeline?																				
-Duration of elective wait (submitted)		life stage/time point	Admissions; Period of Care	date decided to admit -> actual admission date for elective admission - date and time-related or timeline?																				
-Calculation of Elecdur		life stage/time point	Admissions; Period of Care	above for waiting list or booked admissions 																				
-First regular day or night admission			Admissions; Period of Care																					
-Financial Year			Admissions; Period of Care|Appointments|Administrative																					
-Age Band 10 years		age/birthdate	Age Bands																					
-ic_age17_60		age/birthdate	Age Bands																					
-ic_age17_64		age/birthdate	Age Bands																					
-Age Band 5 years		age/birthdate	Age Bands																					
-ic_age50_74		age/birthdate	Age Bands																					
-ic_agechild		age/birthdate	Age Bands																					
-Appointment date			Appointments																					
-Attendance type			Appointments																					
-Attended or did not attend			Appointments																					
-Location Class			Appointments																					
-Location Tyoe			Appointments																					
-Outcome of attendance			Appointments																					
-Priority type			Appointments																					
-Service type requested			Appointments																					
-Medical staff type seeing patient			Appointments																					
-Code of patient‚Äö√Ñ√¥s registered or referring general medical practitioner			Appointments|Practitioner data																					
-Arrival mode			Attendances																					
-Attendances excluding planned			Attendances																					
-Attendance category			Attendances																					
-Attendance disposal			Attendances																					
-Department type			Attendances																					
-Incident location type			Attendances																					
-Patient group			Attendances																					
-Source of referral for A&E			Attendances																					
-Arrival date			Attendances																					
-Arrival time			Attendances																					
-Duration to conclusion			Attendances																					
-Conclusion time			Attendances																					
-Duration to departure			Attendances																					
-Departure time			Attendances																					
-Duration to assessment			Attendances																					
-Initial assessment time			Attendances																					
-Duration to treatment			Attendances																					
-Time seen for treatment			Attendances																					
-ACPDISP_N		history of augmented care	Augmented/critical care period	destination of discharged patient (e.g. ICU, home, death, etc.)																				
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDISP_N		history of augmented care	Augmented/critical care period																					
-ACPDQIND_N			Augmented/critical care period	quality of data																				
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period	end date of augmented care																				
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period	location of augmented care																				
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPLOC_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period	order of an episode during augmented care																				
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPN_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period	death and organ donation																				
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPOUT_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period	was augmented care planned before admission?																				
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPPLAN_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period	location of patient before augmented care (e.g. ICU, recovery, ER, etc.)																				
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-ACPSOUR_N		history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period	speciality of consultant managing the augmented care																				
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
-High-dependency care level			Augmented/critical care period	number of days of high-dependency care during augmented care (is this life support?)																				
-depdays_2			Augmented/critical care period																					
-depdays_3			Augmented/critical care period																					
-depdays_4			Augmented/critical care period																					
-depdays_5			Augmented/critical care period																					
-depdays_6			Augmented/critical care period																					
-depdays_7			Augmented/critical care period																					
-depdays_8			Augmented/critical care period																					
-depdays_9			Augmented/critical care period																					
-Intensive care level days		history of intensive care	Augmented/critical care period																					
-intdays_2		history of intensive care	Augmented/critical care period																					
-intdays_3		history of intensive care	Augmented/critical care period																					
-intdays_4		history of intensive care	Augmented/critical care period																					
-intdays_5		history of intensive care	Augmented/critical care period																					
-intdays_6		history of intensive care	Augmented/critical care period																					
-intdays_7		history of intensive care	Augmented/critical care period																					
-intdays_8		history of intensive care	Augmented/critical care period																					
-intdays_9		history of intensive care	Augmented/critical care period																					
-Number of augmented care periods within episode		history of augmented care	Augmented/critical care period																					
-Number of organ systems supported		history of organ support	Augmented/critical care period																					
-orgsup_2		history of organ support	Augmented/critical care period																					
-orgsup_3		history of organ support	Augmented/critical care period																					
-orgsup_4		history of organ support	Augmented/critical care period																					
-orgsup_5		history of organ support	Augmented/critical care period																					
-orgsup_6		history of organ support	Augmented/critical care period																					
-orgsup_7		history of organ support	Augmented/critical care period																					
-orgsup_8		history of organ support	Augmented/critical care period																					
-orgsup_9		history of organ support	Augmented/critical care period																					
-Early cancer diagnosis		oncological	Cancer diagnosis																					
-CCG Code			CCG	clinical commission group																				
-CCG Name			CCG	clinical commission group																				
-Cause Code			Clinical	cause of injury or poisoning																				
-diag_13			Clinical	should be under Clinical diagnoses - this can be disease or trauma																				
-diag_14			Clinical																					
-diag_15			Clinical																					
-diag_16			Clinical																					
-diag_17			Clinical																					
-diag_18			Clinical																					
-diag_19			Clinical																					
-diag_20			Clinical																					
-Date of procedure		surgical interventions	Clinical																					
-opdate_02		surgical interventions	Clinical																					
-opdate_03		surgical interventions	Clinical																					
-opdate_04		surgical interventions	Clinical																					
-opdate_05		surgical interventions	Clinical																					
-opdate_06		surgical interventions	Clinical																					
-opdate_07		surgical interventions	Clinical																					
-opdate_08		surgical interventions	Clinical																					
-opdate_09		surgical interventions	Clinical																					
-opdate_10		surgical interventions	Clinical																					
-opdate_11		surgical interventions	Clinical																					
-opdate_12		surgical interventions	Clinical																					
-opdate_13		surgical interventions	Clinical																					
-opdate_14		surgical interventions	Clinical																					
-opdate_15		surgical interventions	Clinical																					
-opdate_16		surgical interventions	Clinical																					
-opdate_17		surgical interventions	Clinical																					
-opdate_18		surgical interventions	Clinical																					
-opdate_19		surgical interventions	Clinical																					
-opdate_20		surgical interventions	Clinical																					
-opdate_21		surgical interventions	Clinical																					
-opdate_22		surgical interventions	Clinical																					
-opdate_23		surgical interventions	Clinical																					
-opdate_24		surgical interventions	Clinical																					
-Operation status code		surgical interventions	Clinical																					
-Operative procedure		surgical interventions	Clinical																					
-opertn_02		surgical interventions	Clinical																					
-opertn_03		surgical interventions	Clinical																					
-opertn_04		surgical interventions	Clinical																					
-opertn_05		surgical interventions	Clinical																					
-opertn_06		surgical interventions	Clinical																					
-opertn_07		surgical interventions	Clinical																					
-opertn_08		surgical interventions	Clinical																					
-opertn_09		surgical interventions	Clinical																					
-opertn_10		surgical interventions	Clinical																					
-opertn_11		surgical interventions	Clinical																					
-opertn_12		surgical interventions	Clinical																					
-opertn_13		surgical interventions	Clinical																					
-opertn_14		surgical interventions	Clinical																					
-opertn_15		surgical interventions	Clinical																					
-opertn_16		surgical interventions	Clinical																					
-opertn_17		surgical interventions	Clinical																					
-opertn_18		surgical interventions	Clinical																					
-opertn_19		surgical interventions	Clinical																					
-opertn_20		surgical interventions	Clinical																					
-opertn_21		surgical interventions	Clinical																					
-opertn_22		surgical interventions	Clinical																					
-opertn_23		surgical interventions	Clinical																					
-opertn_24		surgical interventions	Clinical																					
-Count of procedures		surgical interventions	Clinical																					
-Post-operative duration		surgical interventions	Clinical																					
-Pre-operative duration		surgical interventions	Clinical																					
-Waiting calculation indicator			Clinical	if and how 'Days Waiting' was calculated - timeline?																				
-A&E diagnosis: 2 character			Clinical diagnoses	disease or trauma																				
-diag2_02			Clinical diagnoses																					
-diag2_03			Clinical diagnoses																					
-diag2_04			Clinical diagnoses																					
-diag2_05			Clinical diagnoses																					
-diag2_06			Clinical diagnoses																					
-diag2_07			Clinical diagnoses																					
-diag2_08			Clinical diagnoses																					
-diag2_09			Clinical diagnoses																					
-diag2_10			Clinical diagnoses																					
-diag2_11			Clinical diagnoses																					
-diag2_12			Clinical diagnoses																					
-A&E diagnosis - anatomical area			Clinical Diagnoses	disease or trauma																				
-diaga_02			Clinical Diagnoses																					
-diaga_03			Clinical Diagnoses																					
-diaga_04			Clinical Diagnoses																					
-diaga_05			Clinical Diagnoses																					
-diaga_06			Clinical Diagnoses																					
-diaga_07			Clinical Diagnoses																					
-diaga_08			Clinical Diagnoses																					
-diaga_09			Clinical Diagnoses																					
-diaga_10			Clinical Diagnoses																					
-diaga_11			Clinical Diagnoses																					
-diaga_12			Clinical Diagnoses																					
-A&E diagnosis - anatomical side			Clinical Diagnoses	disease or trauma																				
-diags_02			Clinical Diagnoses																					
-diags_03			Clinical Diagnoses																					
-diags_04			Clinical Diagnoses																					
-diags_05			Clinical Diagnoses																					
-diags_06			Clinical Diagnoses																					
-diags_07			Clinical Diagnoses																					
-diags_08			Clinical Diagnoses																					
-diags_09			Clinical Diagnoses																					
-diags_10			Clinical Diagnoses																					
-diags_11			Clinical Diagnoses																					
-diags_12			Clinical Diagnoses																					
-Diagnosis Scheme in Use			Clinical diagnoses	e.g. ICD-10																				
-Number of Procedures		surgical interventions	Clinical Diagnosis																					
-Number of Diagnoses			Clinical Diagnosis|Clinical diagnoses	disease or trauma																				
-A&E investigation		laboratory measures|physiological measurements	Clinical Investigations	should I use OR or just two parents?																				
-invest_02		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_03		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_04		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_05		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_06		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_07		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_08		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_09		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_10		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_11		laboratory measures|physiological measurements	Clinical Investigations																					
-invest_12		laboratory measures|physiological measurements	Clinical Investigations																					
-A&E Investigation: 2 character		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_02		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_03		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_04		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_05		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_06		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_07		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_08		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_09		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_10		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_11		laboratory measures|physiological measurements	Clinical Investigations																					
-invest2_12		laboratory measures|physiological measurements	Clinical Investigations																					
-Number of Investigations		laboratory measures|physiological measurements	Clinical Investigations																					
-Number of Treatments		medication|non-pharmacological interventions	Clinical Treatments																					
-A&E treatment		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_02		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_03		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_04		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_05		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_06		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_07		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_08		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_09		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_10		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_11		medication|non-pharmacological interventions	Clinical Treatments																					
-treat_12		medication|non-pharmacological interventions	Clinical Treatments																					
-A&E Treatment: 2 character		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_02		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_03		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_04		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_05		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_06		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_07		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_08		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_09		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_10		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_11		medication|non-pharmacological interventions	Clinical Treatments																					
-treat2_12		medication|non-pharmacological interventions	Clinical Treatments																					
-Patient classification			Clinical; Period of Care	ordinary, day, night, delivery, etc.																				
-Intended management			Clinical; Period of Care	what was planned to happen in hospital																				
-Treatment specialty		physician/practitioner info	Clinical; Period of Care																					
-Main specialty		physician/practitioner info	Clinical; Period of Care|Clinical																					
-diag_02			Clinical|Clinical diagnoses	disease or trauma																				
-diag_03			Clinical|Clinical diagnoses																					
-diag_04			Clinical|Clinical diagnoses																					
-diag_05			Clinical|Clinical diagnoses																					
-diag_06			Clinical|Clinical diagnoses																					
-diag_07			Clinical|Clinical diagnoses																					
-diag_08			Clinical|Clinical diagnoses																					
-diag_09			Clinical|Clinical diagnoses																					
-diag_10			Clinical|Clinical diagnoses																					
-diag_11			Clinical|Clinical diagnoses																					
-diag_12			Clinical|Clinical diagnoses																					
-All Diagnosis codes			Clinical|Clinical Diagnosis|Clinical diagnoses	diagnosis codes for ER attendance (could be disease or trauma)																				
-Organisation code (patient pathway ID issuer)		unique identifiers	Clinical|Patient Pathway																					
-Commissioning Organisation Code			Commissioning Organisation																					
-Commissioning Organisation Name			Commissioning Organisation																					
-Last DNA or patient cancelled date			Count of diagnoses	this parent is not right? patient offered appt and missed date without advance notice																				
-ccsorcloc		history of intensive care	Critical care admission and discharge data	type of location patient in prior to start of critical care (recorvery, imaging, ER, etc.)																				
-acardsupdays		history of cardiovascular support	Critical care adult activity data																					
-aressupdays		history of respiratory support	Critical care adult activity data																					
-bcardsupdays		history of cardiovascular support	Critical care adult activity data																					
-bressupdays		history of respiratory support	Critical care adult activity data																					
-cclev2days		history of intensive care	Critical care adult activity data																					
-cclev3days		history of intensive care	Critical care adult activity data																					
-dermsupdays		history of dermatological support	Critical care adult activity data																					
-gisupdays		history of gastrointestinal support	Critical care adult activity data																					
-liversupdays		history of liver support	Critical care adult activity data																					
-neurosupdays		history of neurological support	Critical care adult activity data																					
-orgsupmax		history of organ support	Critical care adult activity data																					
-rensupdays		history of renal support	Critical care adult activity data																					
-ccadmisorc		history of intensive care	Critical care adult admission and discharge data	source of patient (same hospital, different hospital, etc.)																				
-ccadmitype		history of intensive care	Critical care adult admission and discharge data	was critical care result of non-emergency?																				
-ccdisdate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	dicharge date if alive or date of death																				
-ccdisdest		history of intensive care	Critical care adult admission and discharge data	destination of critical care discharge (same hospital, different hospital, etc.)																				
-ccdisloc		history of intensive care	Critical care adult admission and discharge data	location for further care at end of critical care																				
-ccdisrdydate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	date declared ready for discharge or transfer																				
-ccdisrdytime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	time declared ready for discharge or transfer																				
-ccdisstat		history of intensive care	Critical care adult admission and discharge data	discharge status (e.g. early discharge, continuing care in another location, died, etc.)																				
-ccdistime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	discharge time																				
-unitbedconfig			Critical care adult admission and discharge data	level 2 beds, level 3 beds, or flexible - in unit																				
-bestmatch			Critical care period of care	selects the best match for mulitple rows of critical care dates - this is just a Y/N flag																				
-ccapcrel			Critical care period of care	used to select bestmatch - derived from episode start date and discharge date																				
-ccstarttime		history of intensive care|life stage/time point	Critical care period of care	time critical care started																				
-ccunitfun			Critical care period of care	principal service provided in ward patient was admitted to for critical care (e.g. cardiac, thoracic, burns, etc.)																				
-ccstartdate		history of intensive care|life stage/time point	Critical care start date	critical care start date																				
-Ambulatory Care Sensitive Condition Flag			Diagnosis																					
-Principal alcohol related diagnosis		alcohol	Diagnosis																					
-Principal alcohol related diagnosis		alcohol	Diagnosis																					
-Principal alcohol related fraction		alcohol	Diagnosis																					
-Count of diagnoses			Diagnosis	disease or trauma																				
-Diagnostic Test Request Date			Diagnostic Test Dates	diagnostic tests could be physiological measurements or laboratory measures																				
-Diagnostic Test Request Received Date			Diagnostic Test Dates																					
-Diagnostic Test Date			Diagnostic Test Dates																					
-Month of Test			Diagnostic Test Dates																					
-Year of Test			Diagnostic Test Dates																					
-Service Report Issue Date			Diagnostic Test Dates																					
-Date of discharge		life stage/time point	Discharges; Period of Care																					
-Destination on discharge			Discharges; Period of Care																					
-Method of discharge			Discharges; Period of Care																					
-Discharge ready date		life stage/time point	Discharges; Period of Care																					
-Bed days within the year			Episodes and spells; Period of care																					
-Episode duration		life stage/time point	Episodes and spells; Period of care																					
-Date episode ended		life stage/time point	Episodes and spells; Period of care																					
-Episode order			Episodes and spells; Period of care	transfer to care of another consultant increases number of episode (1,2,3,4...)																				
-Date episode started		life stage/time point	Episodes and spells; Period of care																					
-Episode status			Episodes and spells; Period of care	was episode still occurring on Mar 31 (end of year)? date or timeline?																				
-Episode type			Episodes and spells; Period of care	general, delivery, birth, detained under mental health legisation or long-term psych patient, other deliver, other birth																				
-Finished Admission Episode			Episodes and spells; Period of care																					
-Finished Admission Episode, emergency classification			Episodes and spells; Period of care	admission from ER																				
-Finished Consultant Episode			Episodes and spells; Period of care	continuous period of care under one consultant																				
-Finished In-Year Discharge Episode			Episodes and spells; Period of care	(episodes and spells; period of care) patient was discharged at end of episode before end of year																				
-Beginning of spell indicator			Episodes and spells; Period of care																					
-Duration of spell			Episodes and spells; Period of care																					
-End of spell indicator			Episodes and spells; Period of care																					
-Ward type at start of episode			Episodes and spells; Period of care																					
-Year and month of HES dataset			Episodes and spells; Period of care|Appointments																					
-Ethnic Category Code		ethnicity/race	Ethnic Category																					
-Ethnic Category Group		ethnicity/race	Ethnic Category																					
-Ethnic Category Description		ethnicity/race	Ethnic Category																					
-Fetal ID		unique identifiers	Fetal																					
-Gender Code		gender	Gender																					
-Gender Description		gender	Gender																					
-Area Team of GP Practice			Geographical																					
-Area Team of Residence			Geographical																					
-Area Team of Treatment			Geographical																					
-Cancer network		residence	Geographical																					
-Cancer registry		residence	Geographical																					
-CCG of GP Practice		location|physician/practitioner info	Geographical																					
-CCG of Residence		residence	Geographical																					
-CCG of Residence		residence	Geographical																					
-Origin of CCG of Responsibility			Geographical	how CCG responsibility was assigned																				
-CCG of Treatment		location	Geographical	CCG where patient was treated																				
-Origin of CCG of Treatment			Geographical	how CCG treament was assigned																				
-Commissioning Region of GP Practice		location	Geographical																					
-Commissioning Region of Residence		residence	Geographical																					
-Commissioning Region of Treatment		location	Geographical																					
-Current electoral ward		residence	Geographical																					
-Current electoral ward (ONS)		residence	Geographical																					
-Government office region of treatment			Geographical																					
-Local authority district in 1998			Geographical																					
-Lower Super Output Area			Geographical																					
-Lower Super Output Area			Geographical																					
-Middle Super Output Area, 2011			Geographical																					
-Westminster parliamentary constituency			Geographical																					
-Westminster parliamentary constituency (ONS)			Geographical																					
-County of residence (ONS)		residence	Geographical																					
-Government Office region of residence		residence	Geographical																					
-Government office region of residence (ONS)		residence	Geographical																					
-Health Authority of residence		residence	Geographical																					
-Local authority district of residence		residence	Geographical																					
-Local authority district of residence (ONS)		residence	Geographical																					
-PCT of residence - mapped according to data year		residence	Geographical																					
-PCT of residence (2006)		residence	Geographical																					
-Regional Office of residence		residence	Geographical																					
-SHA of residence		residence	Geographical																					
-SHA of residence (2006)		residence	Geographical																					
-Regional Office of treatment			Geographical																					
-Rural/Urban Indicator			Geographical																					
-Electoral ward in 1991			Geographical																					
-Electoral ward in 1998			Geographical																					
-Census Output Area, 2011			Geographical																					
-Census Output Area, 2011			Geographical																					
-Census output area, 2001 (6 character ward identifier)			Geographical																					
-primerecp			Geographical																					
-PCT of residence (2002)		residence	Geographical																					
-SHA of residence (2002)		residence	Geographical																					
-PCT of residence - mapped according to data year		residence	Geographical																					
-County of residence		residence	Geographical|Appointments																					
-SHA area of treatment			Geographical|Appointments																					
-Ordnance Survey grid reference			Geographical|Organisation data																					
-Middle Super Output Area, 2001			Geographical|Patient Data																					
-Site code of treatment			Geographical|Patient Data																					
-Primary Care Trust area of main provider			Geographical|System Data																					
-Trust derived dominant procedure			Healthcare resource groups (HRG) data	procedure code submitted to SUS - is this a surgical procedure?																				
-Trust derived HRG value v3.5			Healthcare resource groups (HRG) data																					
-Version No. of Trust derived HRG			Healthcare resource groups (HRG) data																					
-SUS generated Core Spell HRG			Healthcare resource groups (HRG) data																					
-SUS generated HRG			Healthcare resource groups (HRG) data																					
-SUS generated HRG version number			Healthcare resource groups (HRG) data																					
-SUS generated HRG for information			Healthcare resource groups (HRG) data																					
-Trust derived HRG value			Healthcare resource groups (HRG) data|Patient Data																					
-hr_score_expected_final_model3			Hip Replacement																					
-Q1-HR6			Hip Replacement - Q1																					
-Q1-HR9			Hip Replacement - Q1																					
-Q1-HR3			Hip Replacement - Q1																					
-Q1-HR1			Hip Replacement - Q1																					
-hr_q1_score			Hip Replacement - Q1																					
-hr_q1_score_complete			Hip Replacement - Q1																					
-Q1-HR7			Hip Replacement - Q1																					
-Q1-HR10			Hip Replacement - Q1																					
-Q1-HR11			Hip Replacement - Q1																					
-Q1-HR2			Hip Replacement - Q1																					
-Q1-HR5			Hip Replacement - Q1																					
-Q1-HR8			Hip Replacement - Q1																					
-Q1-HR4			Hip Replacement - Q1																					
-Q1-HR12			Hip Replacement - Q1																					
-Q2-HR6			Hip Replacement - Q2																					
-Q2-HR9			Hip Replacement - Q2																					
-Q2-HR3			Hip Replacement - Q2																					
-Q2-HR1			Hip Replacement - Q2																					
-hr_q2_score			Hip Replacement - Q2																					
-hr_q2_score_complete			Hip Replacement - Q2																					
-Q2-HR7			Hip Replacement - Q2																					
-Q2-HR10			Hip Replacement - Q2																					
-Q2-HR11			Hip Replacement - Q2																					
-Q2-HR2			Hip Replacement - Q2																					
-Q2-HR5			Hip Replacement - Q2																					
-Q2-HR8			Hip Replacement - Q2																					
-Q2-HR4			Hip Replacement - Q2																					
-Q2-HR12			Hip Replacement - Q2																					
-Imaging Code (NICIP)			Imaging Codes																					
-Imaging Code (NICIP) Description			Imaging Codes																					
-Imaging Code (SNOMED)			Imaging Codes																					
-Arthritis Indicator		diagnosis of arthritis	Indicators																					
-Cancer Indicator		oncological	Indicators																					
-Circulation			Indicators	leg pain due to poor circulation																				
-Complete			Indicators	indicator if Q1 and Q2 are complete																				
-Depression		diagnosis of depression	Indicators																					
-Diabetes		diagnosis of diabetes	Indicators																					
-Heart Disease Indicator		diagnosis of heart disease	Indicators																					
-High Blood Pressiure Indicator		occurrence of high blood pressure	Indicators																					
-Kidney Disease		diagnosis of renal disease	Indicators																					
-Liver Disease		diagnosis of liver disease	Indicators																					
-Lung Disease		respiratory system	Indicators																					
-nervous_system		nervous system	Indicators																					
-stroke		occurrence of stroke	Indicators																					
-Q1 - KR10		signs and symptoms	Knee Replacement - Q1	may be too broad?																				
-Q1 - KR8		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR7		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR2		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR1		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR11		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR12		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR6		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR4		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR3		signs and symptoms	Knee Replacement - Q1																					
-Q1-KR9		signs and symptoms	Knee Replacement - Q1																					
-Q2-KR10		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR8		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR7		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR2		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR1		signs and symptoms	Knee Replacement - Q2																					
-kr_q2_score_complete		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR11		signs and symptoms	Knee Replacement - Q2																					
-kr_q2_stairs		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR6		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR4		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR5		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR3		signs and symptoms	Knee Replacement - Q2																					
-Q2-KR9		signs and symptoms	Knee Replacement - Q2																					
-Location - LSOA		residence	Location	derived from residence post code																				
-Location - MSOA		residence	Location	derived from residence post code																				
-Gestation period in weeks at first antenatal assessment		pregnancy history	Maternity																					
-First antenatal assessment date		pregnancy history	Maternity																					
-Antenatal days of stay		pregnancy history	Maternity																					
-Resuscitation Method			Maternity	resusciation for baby - may be drugs or non-pharm																				
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-BIRESUS_N			Maternity																					
-Birth Order		pregnancy history	Maternity	?																				
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-BIRORDR_N			Maternity																					
-Birth Status		pregnancy history	Maternity	baby stillborn or alive - maybe pregnancy history? not sure																				
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-BIRSTAT_N			Maternity																					
-Birth Weight		pregnancy history|weight	Maternity	not sure if it's right to call this both																				
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-BIRWEIT_N			Maternity																					
-Delivery place change reason			Maternity	why delivery place was changed																				
-Delivery place (intended)		pregnancy history|location	Maternity																					
-Alternative Delivery method (Derived)		pregnancy history	Maternity	method of birth (e.g. breech, forceps, etc.) may involve surgical intervention																				
-delmeth_2		pregnancy history	Maternity																					
-delmeth_3		pregnancy history	Maternity																					
-delmeth_4		pregnancy history	Maternity																					
-delmeth_5		pregnancy history	Maternity																					
-delmeth_6		pregnancy history	Maternity																					
-delmeth_7		pregnancy history	Maternity																					
-delmeth_8		pregnancy history	Maternity																					
-delmeth_9		pregnancy history	Maternity																					
-Labour/delivery onset method		pregnancy history	Maternity	may involve drugs or surgical																				
-Delivery place (actual)		pregnancy history|location	Maternity																					
-delplac_2			Maternity																					
-delplac_3			Maternity																					
-delplac_4			Maternity																					
-delplac_5			Maternity																					
-delplac_6			Maternity																					
-delplac_7			Maternity																					
-delplac_8			Maternity																					
-delplac_9			Maternity																					
-Anaesthetic given post-labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
-Anaesthetic given during labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
-Status of person conducting delivery		physician/practitioner info	Maternity	is this also part of pregnancy history?																				
-delstat_2		physician/practitioner info	Maternity																					
-delstat_3		physician/practitioner info	Maternity																					
-delstat_4		physician/practitioner info	Maternity																					
-delstat_5		physician/practitioner info	Maternity																					
-delstat_6		physician/practitioner info	Maternity																					
-delstat_7		physician/practitioner info	Maternity																					
-delstat_8		physician/practitioner info	Maternity																					
-delstat_9		physician/practitioner info	Maternity																					
-Length of gestation			Maternity																					
-gestat_2			Maternity																					
-gestat_3			Maternity																					
-gestat_4			Maternity																					
-gestat_5			Maternity																					
-gestat_6			Maternity																					
-gestat_7			Maternity																					
-gestat_8			Maternity																					
-gestat_9			Maternity																					
-Healthly Neonate Indicator			Maternity																					
-Mother‚Äö√Ñ√¥s age at delivery			Maternity																					
-Episode Type - Maternity			Maternity																					
-Neonatal level of care			Maternity																					
-Age of baby in days			Maternity																					
-Number of babies		pregnancy history	Maternity																					
-Number of previous pregnancies		pregnancy history	Maternity																					
-Number of baby tails			Maternity																					
-Postnatal stay			Maternity																					
-Sex of baby		pregnancy history|biological sex	Maternity																					
-sexbaby_2		pregnancy history|biological sex	Maternity																					
-sexbaby_3		pregnancy history|biological sex	Maternity																					
-sexbaby_4		pregnancy history|biological sex	Maternity																					
-sexbaby_5		pregnancy history|biological sex	Maternity																					
-sexbaby_6		pregnancy history|biological sex	Maternity																					
-sexbaby_7		pregnancy history|biological sex	Maternity																					
-sexbaby_8		pregnancy history|biological sex	Maternity																					
-sexbaby_9		pregnancy history|biological sex	Maternity																					
-Well baby flag		pregnancy history	Maternity																					
-Modality ID			Modality	IDs that group procedures and methods																				
-Morphology ID			Morphology	categorizes imaging conducted on abnormalities																				
-Commissioning serial number			Organisation	identifies an NHS service agreement																				
-Health Authority area where patient‚Äö√Ñ√¥s GP is registered			Organisation	where GP is registered																				
-Regional Office area where patient‚Äö√Ñ√¥s GP was registered			Organisation	where GP is registered																				
-Primary care group			Organisation	PCG responsible for patient																				
-Provider code (5 character)			Organisation	code of organization acting as health care provider																				
-Commissioner code			Organisation	code of organization comissioning patient's care																				
-Commissioner‚Äö√Ñ√¥s Regional Office			Organisation	location of commissioner																				
-Commissioner‚Äö√Ñ√¥s Strategic Health Authority			Organisation	location of commissioner (SHA)																				
-Commissioner code status			Organisation	if commissioner's code is recognized by NHS																				
-Pseudonymised code of GP practice			Organisation	registered GP																				
-Organisation Code			Organisation	organization that submitted imaging record																				
-Organisation Code			Organisation	organization that submitted imaging record																				
-Organisation Name			Organisation	organization that submitted imaging record																				
-PCT of responsibility (2002)			Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
-Provider Code			Organisation data|Appointments	code of organization acting as health care provider																				
-Primary Care Trust area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (PCT)																				
-Strategic Health Authority area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (SHA)																				
-Provider code (3 character)			Organisation|Organisation data																					
-Provider code of treatment			Organisation|Organisation data	combo of 3 and 5 character codes																				
-Provider type			Organisation|Organisation data	provdier type of organization																				
-PCT of responsibility (2006)			Organisation|System Data|Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
-Age at activity date		age/birthdate	Patient Data																					
-Age on admission		age/birthdate	Patient Data																					
-ADMINCAT			Patient Data	what kind of patient (NHS, private, amenity, category II)																				
-Admin category at start of episode			Patient Data																					
-Administrative & legal status of patient			Patient Data	patient formally detained? e.g. psychiatric																				
-Age at end of episode		age/birthdate	Patient Data																					
-Ethnic category		ethnicity/race	Patient Data																					
-NHS Number valid flag			Patient Data																					
-Postcode Found			Patient Data																					
-Postcode district			Patient Data																					
-Age at start of episode			Patient Data																					
-Age at start of episode - babies decimalised			Patient Data																					
-Age on day of appointment			Patient Data																					
-Age on arrival - babies decimalised			Patient Data																					
-Ethnic category (audit version)			Patient Data																					
-Age on arrival			Patient Data																					
-Age on arrival - babies decimalised			Patient Data																					
-Date of birth - patient		age/birthdate	Patient Data|Appointments																					
-Sex of patient		biological sex	Patient Data|Appointments																					
-Earliest reasonable date offered			Patient Pathway	earliest date for appointment or admission - date and time-related or timeline?																				
-RTT period end date			Patient Pathway																					
-REFERRAL TO TREATMENT- RTT period start date			Patient Pathway																					
-RTT period status			Patient Pathway																					
-Method of Admission - Waiting List			Patient Pathway																					
-Days waiting			Patient Pathway																					
-Duration of wait (referral to treatment period)			Patient Pathway|Appointments																					
-Patient Source Setting Description			Patient Source Setting																					
-PostOp3			Post-Operative (Q2)																					
-q2_allergy			Post-Operative (Q2)																					
-PostOp5			Post-Operative (Q2)																					
-q2_assisted			Post-Operative (Q2)																					
-q2_assisted_by			Post-Operative (Q2)																					
-q2_bleeding			Post-Operative (Q2)																					
-q2_complete			Post-Operative (Q2)																					
-q2_completed_date			Post-Operative (Q2)																					
-q2_disability			Post-Operative (Q2)																					
-PostOp4			Post-Operative (Q2)																					
-q2_eq5d_health_scale			Post-Operative (Q2)																					
-q2_eq5d_index			Post-Operative (Q2)																					
-q2_eq5d_profile			Post-Operative (Q2)																					
-q2_eq5d_profile_complete			Post-Operative (Q2)																					
-q2_eq5d_scale_complete			Post-Operative (Q2)																					
-q2_form_version			Post-Operative (Q2)																					
-q2_further_surgery		pregnancy history	Post-Operative (Q2)																					
-q2_general_health			Post-Operative (Q2)																					
-q2_language			Post-Operative (Q2)																					
-q2_living_arrangements			Post-Operative (Q2)																					
-q2_mobility			Post-Operative (Q2)																					
-q2_readmitted			Post-Operative (Q2)																					
-q2_received_date			Post-Operative (Q2)																					
-q2_satisfaction			Post-Operative (Q2)																					
-q2_scan_date			Post-Operative (Q2)																					
-q2_self_care			Post-Operative (Q2)																					
-q2_success			Post-Operative (Q2)																					
-q2_surgery_date			Post-Operative (Q2)																					
-q2_urine			Post-Operative (Q2)																					
-q2_wound			Post-Operative (Q2)																					
-Consultant code		physician/practitioner info	Practitioner																					
-Referring organisation code			Practitioner																					
-Referrer code			Practitioner																					
-Referral request received date			Practitioner																					
-Code of GP practice			Practitioner|Geographical|Practitioner data																					
-PreOp3			Pre-Operative (Q1)	does pre-op fall under surgical?																				
-PreOp5			Pre-Operative (Q1)																					
-q1_assisted			Pre-Operative (Q1)																					
-q1_assisted_by			Pre-Operative (Q1)																					
-q1_complete			Pre-Operative (Q1)																					
-q1_completed_date			Pre-Operative (Q1)																					
-q1_disability			Pre-Operative (Q1)																					
-PO4			Pre-Operative (Q1)																					
-q1_eq5d_health_scale			Pre-Operative (Q1)																					
-q1_eq5d_index			Pre-Operative (Q1)																					
-q1_eq5d_profile			Pre-Operative (Q1)																					
-q1_eq5d_profile_complete			Pre-Operative (Q1)																					
-q1_eq5d_scale_complete			Pre-Operative (Q1)																					
-q1_form_version			Pre-Operative (Q1)																					
-q1_general_health			Pre-Operative (Q1)																					
-q1_language			Pre-Operative (Q1)																					
-q1_living_arrangements			Pre-Operative (Q1)																					
-q1_mobility			Pre-Operative (Q1)																					
-q1_previous_surgery			Pre-Operative (Q1)																					
-q1_procode			Pre-Operative (Q1)																					
-q1_received_date			Pre-Operative (Q1)																					
-q1_scan_date			Pre-Operative (Q1)																					
-q1_self_care			Pre-Operative (Q1)																					
-q1_symptom_period			Pre-Operative (Q1)																					
-opcs43			Procedure|Geographical																					
-Provider Name			Provider																					
-Provider SHA Code			Provider SHA																					
-Provider SHA Name			Provider SHA																					
-Provider Site Code			Provider Site																					
-Provider Site Name			Provider Site																					
-Psychiatric history on admission		mental and behaviour disorders	Psychiatric																					
-Duration of care to psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	period of time from admission date to psychiatric census																				
-Age at psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	age at psychiatric census																				
-Status of patient included in psychiatric census			Psychiatric	detained or not detained, long term																				
-Ward type at psychiatric census date			Psychiatric	characteristics of the ward																				
-Duration of detention		mental and behaviour disorders|life stage/time point	Psychiatric	days between detention and psychiatric cesus																				
-Date detention commenced		mental and behaviour disorders|life stage/time point	Psychiatric	when detention started (psychiatric)																				
-V code indicator			Psychiatric																					
-Marital status (psychiatric)		marital status value	Psychiatric|Clinical																					
-Care Support Indicator			Psychiatric|Patient Data	is care available to patient at home?																				
-Referrer Organisation code			Referrer Organisation																					
-Region ID			Region																					
-EQ5D HEALTH SCALE EXPECTED (MODEL1)			Scoring																					
-eq5d_index_change			Scoring																					
-EQ5D HEALTH SCALE EXPECTED (FINAL MODEL1)			Scoring																					
-EQ5D INDEX CHANGE			Scoring																					
-kr_q1_score_complete			Scoring																					
-kr_q2_score			Scoring																					
-kr_score_expected_final_model3			Scoring																					
-score_change			Scoring																					
-status			Scoring																					
-status_date			Scoring																					
-vv_q1_score			Scoring																					
-vv_q1_score_complete			Scoring																					
-vv_q1_total_score			Scoring																					
-vv_q2_score			Scoring																					
-vv_q2_score_complete			Scoring																					
-vv_q2_total_score			Scoring																					
-VV Score Final Predicted (Model 3)			Scoring																					
-IMD Index of Multiple Deprivation			Socio-economic|Geographical																					
-IMD Decile Group			Socio-economic|Geographical																					
-IMD Crime Domain			Socio-economic|Geographical																					
-IMD Education Training and Skills Domain			Socio-economic|Geographical																					
-IMD Employment Deprivation Domain			Socio-economic|Geographical																					
-IMD Health and Disability Domain			Socio-economic|Geographical																					
-IMD Barriers to Housing and Service Domain			Socio-economic|Geographical																					
-IMD Income Domain			Socio-economic|Geographical																					
-IMD Income affecting Adults Domain			Socio-economic|Geographical																					
-IMD Income affecting Children Domain			Socio-economic|Geographical																					
-IMD Living Environment Domain			Socio-economic|Geographical																					
-IMD Overall Rank			Socio-economic|Geographical																					
-Sub Modality ID			Sub Modality																					
-Sub Region ID			Sub Region																					
-Sub System ID			Sub System																					
-Sub-System Component ID			Sub-System Component																					
-System ID			System																					
-Patient identifier		unique identifiers	System Data																					
-NHS Patient identifier		unique identifiers	System Data																					
-match_rank			System Data																					
-Record identifier		unique identifiers	System Data																					
-CDS extract date			System Data	system data for updates																				
-CDS protocol identifier		unique identifiers	System Data	system data SUS																				
-CDS version number			System Data	system data SUS																				
-Ethnic character (audit version)		ethnicity/race	System Data																					
-NHS number status indicator			System Data																					
-Origin of primary care group			System Data																					
-Origin of primary care trust of responsibility			System Data																					
-Origin of PCT of responsibility (2006)			System Data																					
-CDS sender identity			System Data																					
-SUS generated spell identifier			System Data																					
-Record identifier			System Data																					
-Attendence Key Flag			System Data																					
-First attendance			System Data																					
-Origin of primary care trust of responsibility dependent on the data year			System Data																					
-AEKEY flag			System Data																					
-Net applicable date			System Data																					
-PCT of responsibility dependent on the data year			System Data																					
-Origin of PCT of responsibility (2002)			System Data																					
-Reporting period end date			System Data																					
-SUS generated HRG version number			System Data																					
-Record Identifier			System Data																					
-NHS Number Status			System Data																					
-NHS Number Status Description			System Data																					
-Record identifier		unique identifiers	System Data|Administrative																					
-PCT of responsibility dependent on the data year			System Data|Geographical																					
-Submission date			System Data|Geographical																					
-SUS loaded staging date			System Data|Healthcare resource groups (HRG) data																					
-Primary care trust			System Data|Organisation Data																					
-SUS record ID		unique identifiers	System Data|System data																					
-Q1-VV4		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV3		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV8		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV6		occurrence of varicose veins	Varicose Vein - Q1																					
-vv_q1_max_score		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV1		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV2		occurrence of varicose veins	Varicose Vein - Q1																					
-Q1-VV5		occurrence of varicose veins	Varicose Vein - Q1																					
-Q2-VV4		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV3		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV8		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV6		occurrence of varicose veins	Varicose Vein - Q2																					
-vv_q2_max_score		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV1		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
-Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
-Q1-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
-Q1-VV5		occurrence of varicose veins	Varicose Vein - Q2																					
-Critical care adult activity data		history of intensive care		critical care == life support ?																				
-Critical care period of care		history of intensive care																						
-Critical care adult admission and discharge data		history of intensive care																						
-Critical care admission and discharge data		history of intensive care																						
-Critical care start date		history of intensive care																						
-Appointments				outpatient appointments (broad)																				
-Clinical Diagnosis				might this also include non-disease diagnoses, e.g. trauma																				
-Organisation Data				details about the provider, health authority, etc. (Broad)																				
-Attendances				attendances to the ER (broad)																				
-Clinical diagnoses				diagnoses made at the ER (broad), could be disease or trauma?																				
-Practitioner data		physician/practitioner info																						
-Clinical Investigations				investigations made at the ER (broad)																				
-Clinical Treatments				treatments made at the ER (broad) - either pharmaceutical or non-pharmaceutical																				
-Diagnostic Test Dates				could be 'laboratory measures' but this isn't the actual test, just dates so 'timeline' might be better?																				
-Ethnic Category		ethnicity/race																						
-Imaging Codes		laboratory measures		standardized codes for imaging procedures																				
-Referrer Organisation		physician/practitioner info																						
-Age Bands				broader than 'age/birthdate' - this is a grouping category																				
-Cancer diagnosis		oncological																						
-CCG				clincial commision groups - this is broader than physcian?																				
-Location		location																						
-Commissioning Organisation																								
-Provider SHA		physician/practitioner info																						
-Provider		physician/practitioner info																						
-Provider Site		physician/practitioner info																						
-Indicators		diseases		indicators for diseases																				
-Administrative				not sure this maps to anything																				
-Scoring				not sure this maps to anything																				
-Hip Replacement - Q1				are these questions to determine if hip replacement is NEEDED (symptoms) or after hip replacement?																				
-Hip Replacement - Q2																								
-Hip Replacement																								
-Knee Replacement - Q1				are these questions to determine if knee replacement is NEEDED (symptoms) or after knee replacement?																				
-Knee Replacement - Q2																								
-Pre-Operative (Q1)				questions about QOL before surgery, does this fall under 'surgical'?																				
-Post-Operative (Q2)				questions about QOL after surgery, does this fall under 'surgical'?																				
-Varicose Vein - Q1		occurrence of varicose veins																						
-Varicose Vein - Q2		occurrence of varicose veins																						
-acpdqind_2																								
-acpdqind_3																								
-acpdqind_4																								
-acpdqind_5																								
-acpdqind_6																								
-acpdqind_7																								
-acpdqind_8																								
-acpdqind_9																								
-delmeth_d		pregnancy history																						
-primercp																								
-resstha_his																								
-Patient Source Setting																								
-did_snomedct_code																								
-Test Request to Test Request Received																								
-Test Request to Test																								
-Test Request to Service (Test) Report Issue																								
-Test Request Received to Test																								
-Test Request Received to Service (test) Report Issue																								
-Test to Service (Test) Report Issue																								
-Fetal																								
-Modality																								
-Morphology																								
-Referrer																								
-Referrer type																								
-Region																								
-Sub Early cancer diagnosis																								
-Sub Modality																								
-Sub Region																								
-Sub System																								
-Sub-System Component																								
-System																								
-hes_dids_version																								
-mhd_mhmds_person_id																								
-mhd_mhmds_spell_id																								
-ic_annual_id																								
-ic_inactive_timestamp																								
-ic_interim_ccg_code																								
-ic_rec_ccg																								
-ic_rec_endrp_aot_flag																								
-ic_rec_endrp_cluster_flag																								
-ic_rec_endrp_cluster_type																								
-ic_rec_endrp_cpa_epi_12_months																								
-ic_rec_endrp_cpa_flag																								
-ic_rec_endrp_cpa_review_within_12mnths																								
-ic_rec_endrp_eit_flag																								
-ic_rec_endrp_employment_status																								
-ic_rec_endrp_honos_assessment_within_12mnths																								
-ic_rec_endrp_hospital_spell_flag																								
-ic_rec_endrp_mha_flag																								
-ic_rec_endrp_pdiag_flag																								
-ic_rec_endrp_recall_flag																								
-ic_rec_endrp_sct_flag																								
-ic_rec_endrp_settled_accommodation_indicator																								
-ic_rec_ethnicity		ethnicity/race																						
-ic_rec_rp_admission																								
-ic_rec_rp_admission_formal																								
-ic_rec_rp_awol																								
-ic_rec_rp_commissioners																								
-ic_rec_rp_contacts																								
-ic_rec_rp_contacts_att																								
-ic_rec_rp_dayatt_contacts																								
-ic_rec_rp_dayatt_contacts_att																								
-ic_rec_rp_ddisc_days																								
-ic_rec_rp_disch_net_followup																								
-ic_rec_rp_discharges_gross																								
-ic_rec_rp_discharges_net																								
-ic_rec_rp_readmissions																								
-ic_rec_rp_wrdst_days_cleansed																								
-ic_rec_rp_wrdst_days_gross																								
-ic_rec_rp_wrdst_days_net																								
-ic_source_period_id																								
-ic_spell_rp_days																								
-mhd_age		age/birthdate																						
-mhd_ccg_of_gp_practice		physician/practitioner info																						
-mhd_ccg_of_residence																								
-mhd_code_of_commissioner																								
-mhd_code_of_gp_practice		physician/practitioner info																						
-mhd_county		residence																						
-mhd_crisisplancreat_date																								
-mhd_crisisplanupdate_date																								
-mhd_electoral_ward_of_usual_address																								
-mhd_emerpsych_date																								
-mhd_end_date_mhcs																								
-mhd_ethnicity		ethnicity/race																						
-mhd_gender		gender																						
-mhd_health_care_spell_end_reason																								
-mhd_lad_ua																								
-mhd_manpsych_date																								
-mhd_marital_status																								
-mhd_pct_of_gp_practice																								
-mhd_pct_of_residence																								
-mhd_postcode_district																								
-mhd_propsych_date																								
-mhd_provider_org_code																								
-mhd_psychpresc_date																								
-mhd_psychtreat_start_date																								
-mhd_start_date_mhcs																								
-mhd_valid_nhs_number_flag																								
-mhd_valid_postcode_flag																								
-mhd_year_of_first_known_psychiatric_care																								
-reportingperiod_enddate																								
-reportingperiod_startdate																								
-ic_eve_primarydiagnosis																								
-ic_eve_secondarydiagnosis																								
-mhd_abusequestion_indicator																								
-mhd_accomodation_status																								
-mhd_assessment																								
-mhd_attended_indicator																								
-mhd_carecluster_superclass_code																								
-mhd_carecoordinator_flag																								
-mhd_clusteringtool_assessment_reason																								
-mhd_consultmedium																								
-mhd_contact_location_code																								
-mhd_contact_subject																								
-mhd_duration																								
-mhd_employment_status																								
-mhd_event_id																								
-mhd_eventdate																								
-mhd_eventtype																								
-mhd_honos_flag																								
-mhd_honos_honosrating1_score																								
-mhd_honos_honosrating10_score																								
-mhd_honos_honosrating11_score																								
-mhd_honos_honosrating12_score																								
-mhd_honos_honosrating2_score																								
-mhd_honos_honosrating3_score																								
-mhd_honos_honosrating4_score																								
-mhd_honos_honosrating5_score																								
-mhd_honos_honosrating6_score																								
-mhd_honos_honosrating7_score																								
-mhd_honos_honosrating8_score																								
-mhd_honos_honosrating8_type																								
-mhd_honos_honosrating9_score																								
-mhd_honos_secure_flag																								
-mhd_honos65_flag																								
-mhd_honos65_rating1_score																								
-mhd_honos65_rating10_score																								
-mhd_honos65_rating11_score																								
-mhd_honos65_rating12_score																								
-mhd_honos65_rating2_score																								
-mhd_honos65_rating3_score																								
-mhd_honos65_rating4_score																								
-mhd_honos65_rating5_score																								
-mhd_honos65_rating6_score																								
-mhd_honos65_rating7_score																								
-mhd_honos65_rating8_score																								
-mhd_honos65_rating8_type																								
-mhd_honos65_rating9_score																								
-mhd_honosca_flag																								
-mhd_honoscarating1_score																								
-mhd_honoscarating10_score																								
-mhd_honoscarating11_score																								
-mhd_honoscarating12_score																								
-mhd_honoscarating13_score																								
-mhd_honoscarating14_score																								
-mhd_honoscarating15_score																								
-mhd_honoscarating2_score																								
-mhd_honoscarating3_score																								
-mhd_honoscarating4_score																								
-mhd_honoscarating5_score																								
-mhd_honoscarating6_score																								
-mhd_honoscarating7_score																								
-mhd_honoscarating8_score																								
-mhd_honoscarating9_score																								
-mhd_honossecureratinga_score																								
-mhd_honossecureratingb_score																								
-mhd_honossecureratingc_score																								
-mhd_honossecureratingd_score																								
-mhd_honossecureratinge_score																								
-mhd_honossecureratingf_score																								
-mhd_honossecureratingg_score																								
-mhd_jobrole																								
-mhd_mainspecialty																								
-mhd_mhc_team_type																								
-mhd_mhct_flag																								
-mhd_mhct_honosrating1_score																								
-mhd_mhct_honosrating10_score																								
-mhd_mhct_honosrating11_score																								
-mhd_mhct_honosrating12_score																								
-mhd_mhct_honosrating2_score																								
-mhd_mhct_honosrating3_score																								
-mhd_mhct_honosrating4_score																								
-mhd_mhct_honosrating5_score																								
-mhd_mhct_honosrating6_score																								
-mhd_mhct_honosrating7_score																								
-mhd_mhct_honosrating8_score																								
-mhd_mhct_honosrating8_type																								
-mhd_mhct_honosrating9_score																								
-mhd_nhs_occupcode																								
-mhd_pbr_cluster																								
-mhd_phq9_q1_score																								
-mhd_phq9_q2_score																								
-mhd_phq9_q3_score																								
-mhd_phq9_q4_score																								
-mhd_phq9_q5_score																								
-mhd_phq9_q6_score																								
-mhd_phq9_q7_score																								
-mhd_phq9_q8_score																								
-mhd_phq9_q9_score																								
-mhd_phq9_total_score																								
-mhd_primarydiagnosis																								
-mhd_sacrating13_score																								
-mhd_sacratinga_score																								
-mhd_sacratingb_score																								
-mhd_sacratingc_score																								
-mhd_sacratingd_score																								
-mhd_sacratinge_score																								
-mhd_secondarydiagnosis																								
-mhd_settled_accommodation_indicator																								
-mhd_treat																								
-mhd_weekly_hours_worked																								
-ic_epi_rp_days																								
-ic_episode_epi_days																								
-mhd_admimet																								
-mhd_commissioner_code																								
-mhd_delayed_dischend_date																								
-mhd_delayed_dischreason																								
-mhd_delayed_dischstart_date																								
-mhd_dischdate																								
-mhd_dischmet																								
-mhd_dischreason																								
-mhd_endreason																								
-mhd_endtime																								
-mhd_epiend_date																								
-mhd_episode_id																								
-mhd_epistart_date																								
-mhd_epitype																								
-mhd_expirydate																								
-mhd_expirytime																								
-mhd_int_clincare_intensity_code																								
-mhd_intended_agegroup																								
-mhd_mencat07																								
-mhd_referral_request_status_date																								
-mhd_refrec_date																								
-mhd_sex_code		biological sex																						
-mhd_source_of_referral																								
-mhd_starttime																								
-mhd_status_of_service_request																								
-mhd_teamtype																								
-mhd_wardsec_level																								
-event_type																								
-event_date																								
-supplied_gender		gender																						
-supplied_date_of_birth		age/birthdate																						
-latest_gender		gender																						
-latest_date_of_birth		age/birthdate																						
-date_of_death		life stage/time point																						
-gender_of_deceased		gender																						
-date_of_birth		age/birthdate																						
-date_of_registration				maybe time point?																				
-icd9_underlying_cause				is this disease only, or disease and trauma?																				
-icd9_multiple_cause_code_1																								
-icd9_multiple_cause_code_2																								
-icd9_multiple_cause_code_3																								
-icd9_multiple_cause_code_4																								
-icd9_multiple_cause_code_5																								
-icd9_multiple_cause_code_6																								
-icd9_multiple_cause_code_7																								
-icd9_multiple_cause_code_8																								
-icd9_multiple_cause_code_9																								
-icd9_multiple_cause_code_10																								
-icd9_multiple_cause_code_11																								
-icd9_multiple_cause_code_12																								
-icd9_multiple_cause_code_13																								
-icd9_multiple_cause_code_14																								
-icd9_multiple_cause_code_15																								
-icd10_underlying_cause																								
-icd10_multiple_cause_code_1																								
-icd10_multiple_cause_code_2																								
-icd10_multiple_cause_code_3																								
-icd10_multiple_cause_code_4																								
-icd10_multiple_cause_code_5																								
-icd10_multiple_cause_code_6																								
-icd10_multiple_cause_code_7																								
-icd10_multiple_cause_code_8																								
-icd10_multiple_cause_code_9																								
-icd10_multiple_cause_code_10																								
-icd10_multiple_cause_code_11																								
-icd10_multiple_cause_code_12																								
-icd10_multiple_cause_code_13																								
-icd10_multiple_cause_code_14																								
-icd10_multiple_cause_code_15																								
-patient_pseudo_id																								
-tumour_pseudo_id																								
-nhs_number_status																								
-gender_current_clean		gender																						
-consultant_speciality_code		physician/practitioner info		provider specialty code for cancer treatment																				
-primary_diagnosis		oncological																						
-morphology_clean		oncological		morphology for cell type before cancer treatment - maybe physiological?																				
-stage_at_start		oncological		tumor/metastasis stage before treatment																				
-regimen_number				Chronological order of SACT drug regimen since commencement of patient's disease management																				
-programme_number				Chronological order of SACT drug programme since commencement of patient's disease management																				
-intent_of_treatment																								
-analysis_group																								
-benchmark_group																								
-height_at_start_of_regimen		height																						
-weight_at_start_of_regimen		weight																						
-perf_stat_start_of_reg_clean				activity/disability status																				
-comorbidity_adjustment		prescription		if patient's physical state was significant in deciding type of anti-cacer drugs																				
-date_decision_to_treat		life stage/time point																						
-start_date_of_regimen		life stage/time point																						
-clinical_trial				is patient part of clinical trial																				
-chemo_radiation		use of anti-cancer drugs|history of radiation treatment																						
-number_of_cycles_planned		use of anti-cancer drugs																						
-cycle_number		use of anti-cancer drugs																						
-start_date_of_cycle		life stage/time point																						
-weight_at_start_of_cycle		weight																						
-perf_stat_start_of_cycle_clean				activity/disability status																				
-opcs_procurement_code				OPCS code to identify procurement																				
-drug_group		use of anti-cancer drugs																						
-actual_dose_per_administration		posology																						
-administration_route		administration method																						
-administration_date		administration method																						
-opcs_delivery_code				OPCS code to identify delivery (of baby?)																				
-date_of_final_treatment		use of anti-cancer drugs																						
-regimen_mod_dose_reduction		posology																						
-regimen_mod_time_delay		use of anti-cancer drugs		extending time between administration - is this prescription or admin method?																				
-regimen_mod_stopped_early		use of anti-cancer drugs																						
-regimen_outcome_summary		use of anti-cancer drugs		anti cancer drug program completed or not																				
-																								
+ID	Label	Class Type	GECKO Label	GE Parents	Comment																				
+ID		CLASS_TYPE	C % SPLIT=|		A comment																				
+GE:diaga_01	A&E diagnosis - anatomical area			Clinical Diagnoses	disease or trauma																				
+GE:diags_01	A&E diagnosis - anatomical side			Clinical Diagnoses	disease or trauma																				
+GE:diag2_01	A&E diagnosis: 2 character			Clinical diagnoses	disease or trauma																				
+GE:invest_01	A&E investigation		laboratory measures|physiological measurements	Clinical Investigations	should I use OR or just two parents?																				
+GE:invest2_01	A&E Investigation: 2 character		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:treat_01	A&E treatment		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_01	A&E Treatment: 2 character		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:acardsupdays	acardsupdays		history of cardiovascular support	Critical care adult activity data																					
+GE:acpdisp_1	ACPDISP_N		history of augmented care	Augmented/critical care period	destination of discharged patient (e.g. ICU, home, death, etc.)																				
+GE:acpdisp_2	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_3	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_4	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_5	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_6	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_7	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_8	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdisp_9	ACPDISP_N		history of augmented care	Augmented/critical care period																					
+GE:acpdqind_2	acpdqind_2		Genomics England																						
+GE:acpdqind_3	acpdqind_3		Genomics England																						
+GE:acpdqind_4	acpdqind_4		Genomics England																						
+GE:acpdqind_5	acpdqind_5		Genomics England																						
+GE:acpdqind_6	acpdqind_6		Genomics England																						
+GE:acpdqind_7	acpdqind_7		Genomics England																						
+GE:acpdqind_8	acpdqind_8		Genomics England																						
+GE:acpdqind_9	acpdqind_9		Genomics England																						
+GE:acpdqind_1	ACPDQIND_N			Augmented/critical care period	quality of data																				
+GE:acpend_1	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period	end date of augmented care																				
+GE:acpend_2	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_3	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_4	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_5	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_6	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_7	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_8	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpend_9	ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acploc_1	ACPLOC_N		history of augmented care	Augmented/critical care period	location of augmented care																				
+GE:acploc_2	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_3	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_4	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_5	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_6	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_7	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_8	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acploc_9	ACPLOC_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_1	ACPN_N		history of augmented care	Augmented/critical care period	order of an episode during augmented care																				
+GE:acpn_2	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_3	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_4	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_5	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_6	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_7	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_8	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpn_9	ACPN_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_1	ACPOUT_N		history of augmented care	Augmented/critical care period	death and organ donation																				
+GE:acpout_2	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_3	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_4	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_5	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_6	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_7	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_8	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpout_9	ACPOUT_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_1	ACPPLAN_N		history of augmented care	Augmented/critical care period	was augmented care planned before admission?																				
+GE:acpplan_2	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_3	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_4	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_5	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_6	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_7	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_8	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpplan_9	ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_1	ACPSOUR_N		history of augmented care	Augmented/critical care period	location of patient before augmented care (e.g. ICU, recovery, ER, etc.)																				
+GE:acpsour_2	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_3	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_4	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_5	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_6	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_7	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_8	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:acpsour_9	ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+GE:actual_dose_per_administration	actual_dose_per_administration		posology																						
+GE:admincatst	Admin category at start of episode			Patient Data																					
+GE:admincat	ADMINCAT			Patient Data	what kind of patient (NHS, private, amenity, category II)																				
+GE:administration_date	administration_date		administration method of medication																						
+GE:administration_route	administration_route		administration method of medication																						
+GE:administrative	Administrative				not sure this maps to anything																				
+GE:category	Administrative & legal status of patient			Patient Data	patient formally detained? e.g. psychiatric																				
+GE:admisorc	Admission source			Admissions; Period of Care	where patient was prior to admission (hotel, home, court, psychiatrict, etc.)																				
+GE:admissions_period_of_care	Admissions; Period of Care		Genomics England		 ?																				
+GE:aekey_flag	AEKEY flag			System Data																					
+GE:activage	Age at activity date		age/birthdate	Patient Data																					
+GE:endage	Age at end of episode		age/birthdate	Patient Data																					
+GE:censage	Age at psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	age at psychiatric census																				
+GE:startage	Age at start of episode			Patient Data																					
+GE:startage_calc	Age at start of episode - babies decimalised			Patient Data																					
+GE:ic_age10	Age Band 10 years		age/birthdate	Age Bands																					
+GE:ic_age5	Age Band 5 years		age/birthdate	Age Bands																					
+GE:age_bands	Age Bands		Genomics England		broader than 'age/birthdate' - this is a grouping category																				
+GE:neodur	Age of baby in days			Maternity																					
+GE:admiage	Age on admission		age/birthdate	Patient Data																					
+GE:arrivalage	Age on arrival			Patient Data																					
+GE:apptage_calc	Age on arrival - babies decimalised			Patient Data																					
+GE:arrivalage_calc	Age on arrival - babies decimalised			Patient Data																					
+GE:apptage	Age on day of appointment			Patient Data																					
+GE:diag_01	All Diagnosis codes			Clinical|Clinical Diagnosis|Clinical diagnoses	diagnosis codes for ER attendance (could be disease or trauma)																				
+GE:delmeth_1	Alternative Delivery method (Derived)		pregnancy history	Maternity	method of birth (e.g. breech, forceps, etc.) may involve surgical intervention																				
+GE:acscflag	Ambulatory Care Sensitive Condition Flag			Diagnosis																					
+GE:delprean	Anaesthetic given during labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
+GE:delposan	Anaesthetic given post-labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
+GE:analysis_group	analysis_group		Genomics England																						
+GE:antedur	Antenatal days of stay		pregnancy history	Maternity																					
+GE:apptdate	Appointment date			Appointments																					
+GE:appointments	Appointments		Genomics England		outpatient appointments (broad)																				
+GE:at_gp_practice	Area Team of GP Practice			Geographical																					
+GE:at_residence	Area Team of Residence			Geographical																					
+GE:at_treatment	Area Team of Treatment			Geographical																					
+GE:aressupdays	aressupdays		history of respiratory support	Critical care adult activity data																					
+GE:arrivaldate	Arrival date			Attendances																					
+GE:aearrivalmode	Arrival mode			Attendances																					
+GE:arrivaltime	Arrival time			Attendances																					
+GE:arthritis	Arthritis Indicator		diagnosis of arthritis	Indicators																					
+GE:aeattendcat	Attendance category			Attendances																					
+GE:aeattenddisp	Attendance disposal			Attendances																					
+GE:atentype	Attendance type			Appointments																					
+GE:attendances	Attendances		Genomics England		attendances to the ER (broad)																				
+GE:aeattend_exc_planned	Attendances excluding planned			Attendances																					
+GE:attended	Attended or did not attend			Appointments																					
+GE:attendkey_flag	Attendence Key Flag			System Data																					
+GE:acpspef_1	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period	speciality of consultant managing the augmented care																				
+GE:acpspef_2	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_3	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_4	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_5	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_6	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_7	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_8	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpspef_9	Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+GE:acpstar_1	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_2	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_3	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_4	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_5	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_6	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_7	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_8	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:acpstar_9	Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+GE:augmented_critical_care_period	Augmented/critical care period		history of augmented care|timeline																						
+GE:bcardsupdays	bcardsupdays		history of cardiovascular support	Critical care adult activity data																					
+GE:bedyear	Bed days within the year			Episodes and spells; Period of care																					
+GE:spelbgin	Beginning of spell indicator			Episodes and spells; Period of care																					
+GE:benchmark_group	benchmark_group		Genomics England																						
+GE:bestmatch	bestmatch			Critical care period of care	selects the best match for mulitple rows of critical care dates - this is just a Y/N flag																				
+GE:biresus_2	BIRESUS_N			Maternity																					
+GE:biresus_3	BIRESUS_N			Maternity																					
+GE:biresus_4	BIRESUS_N			Maternity																					
+GE:biresus_5	BIRESUS_N			Maternity																					
+GE:biresus_6	BIRESUS_N			Maternity																					
+GE:biresus_7	BIRESUS_N			Maternity																					
+GE:biresus_8	BIRESUS_N			Maternity																					
+GE:biresus_9	BIRESUS_N			Maternity																					
+GE:birordr_2	BIRORDR_N			Maternity																					
+GE:birordr_3	BIRORDR_N			Maternity																					
+GE:birordr_4	BIRORDR_N			Maternity																					
+GE:birordr_5	BIRORDR_N			Maternity																					
+GE:birordr_6	BIRORDR_N			Maternity																					
+GE:birordr_7	BIRORDR_N			Maternity																					
+GE:birordr_8	BIRORDR_N			Maternity																					
+GE:birordr_9	BIRORDR_N			Maternity																					
+GE:birstat_2	BIRSTAT_N			Maternity																					
+GE:birstat_3	BIRSTAT_N			Maternity																					
+GE:birstat_4	BIRSTAT_N			Maternity																					
+GE:birstat_5	BIRSTAT_N			Maternity																					
+GE:birstat_6	BIRSTAT_N			Maternity																					
+GE:birstat_7	BIRSTAT_N			Maternity																					
+GE:birstat_8	BIRSTAT_N			Maternity																					
+GE:birstat_9	BIRSTAT_N			Maternity																					
+GE:birordr_1	Birth Order		pregnancy history	Maternity	?																				
+GE:birstat_1	Birth Status		pregnancy history	Maternity	baby stillborn or alive - maybe pregnancy history? not sure																				
+GE:birweit_1	Birth Weight		pregnancy history|weight	Maternity	not sure if it's right to call this both																				
+GE:birweit_2	BIRWEIT_N			Maternity																					
+GE:birweit_3	BIRWEIT_N			Maternity																					
+GE:birweit_4	BIRWEIT_N			Maternity																					
+GE:birweit_5	BIRWEIT_N			Maternity																					
+GE:birweit_6	BIRWEIT_N			Maternity																					
+GE:birweit_7	BIRWEIT_N			Maternity																					
+GE:birweit_8	BIRWEIT_N			Maternity																					
+GE:birweit_9	BIRWEIT_N			Maternity																					
+GE:bressupdays	bressupdays		history of respiratory support	Critical care adult activity data																					
+GE:elecdur_calc	Calculation of Elecdur		life stage/time point	Admissions; Period of Care	above for waiting list or booked admissions 																				
+GE:cancer_diagnosis	Cancer diagnosis		oncological																						
+GE:cancer	Cancer Indicator		oncological	Indicators																					
+GE:cannet	Cancer network		residence	Geographical																					
+GE:canreg	Cancer registry		residence	Geographical																					
+GE:carersi	Care Support Indicator			Psychiatric|Patient Data	is care available to patient at home?																				
+GE:cause	Cause Code			Clinical	cause of injury or poisoning																				
+GE:ccadmisorc	ccadmisorc		history of intensive care	Critical care adult admission and discharge data	source of patient (same hospital, different hospital, etc.)																				
+GE:ccadmitype	ccadmitype		history of intensive care	Critical care adult admission and discharge data	was critical care result of non-emergency?																				
+GE:ccapcrel	ccapcrel			Critical care period of care	used to select bestmatch - derived from episode start date and discharge date																				
+GE:ccdisdate	ccdisdate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	dicharge date if alive or date of death																				
+GE:ccdisdest	ccdisdest		history of intensive care	Critical care adult admission and discharge data	destination of critical care discharge (same hospital, different hospital, etc.)																				
+GE:ccdisloc	ccdisloc		history of intensive care	Critical care adult admission and discharge data	location for further care at end of critical care																				
+GE:ccdisrdydate	ccdisrdydate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	date declared ready for discharge or transfer																				
+GE:ccdisrdytime	ccdisrdytime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	time declared ready for discharge or transfer																				
+GE:ccdisstat	ccdisstat		history of intensive care	Critical care adult admission and discharge data	discharge status (e.g. early discharge, continuing care in another location, died, etc.)																				
+GE:ccdistime	ccdistime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	discharge time																				
+GE:ccg	CCG		Genomics England		clincial commision groups - this is broader than physcian?																				
+GE:ic_ccgcode	CCG Code			CCG	clinical commission group																				
+GE:ic_ccgname	CCG Name			CCG	clinical commission group																				
+GE:ccg_gp_practice	CCG of GP Practice		location|physician/practitioner info	Geographical																					
+GE:ccg_residence	CCG of Residence		residence	Geographical																					
+GE:ccg_responsibility	CCG of Residence		residence	Geographical																					
+GE:ccg_treatment	CCG of Treatment		location	Geographical	CCG where patient was treated																				
+GE:cclev2days	cclev2days		history of intensive care	Critical care adult activity data																					
+GE:cclev3days	cclev3days		history of intensive care	Critical care adult activity data																					
+GE:ccsorcloc	ccsorcloc		history of intensive care	Critical care admission and discharge data	type of location patient in prior to start of critical care (recorvery, imaging, ER, etc.)																				
+GE:ccstartdate	ccstartdate		history of intensive care|life stage/time point	Critical care start date	critical care start date																				
+GE:ccstarttime	ccstarttime		history of intensive care|life stage/time point	Critical care period of care	time critical care started																				
+GE:ccunitfun	ccunitfun			Critical care period of care	principal service provided in ward patient was admitted to for critical care (e.g. cardiac, thoracic, burns, etc.)																				
+GE:cdsextdate	CDS extract date			System Data	system data for updates																				
+GE:cdsverprotid	CDS protocol identifier		unique identifiers	System Data	system data SUS																				
+GE:sender	CDS sender identity			System Data																					
+GE:cdsversion	CDS version number			System Data	system data SUS																				
+GE:oacode6	Census output area, 2001 (6 character ward identifier)			Geographical																					
+GE:oacode01	Census Output Area, 2011			Geographical																					
+GE:oacode11	Census Output Area, 2011			Geographical																					
+GE:chemo_radiation	chemo_radiation		use of anti-cancer drugs|history of radiation treatment																						
+GE:circulation	Circulation			Indicators	leg pain due to poor circulation																				
+GE:clinical	Clinical		Genomics England																						
+GE:clinical_diagnoses	Clinical Diagnosis		Genomics England		might this also include non-disease diagnoses, e.g. trauma																				
+GE:clinical_investigations	Clinical Investigations		Genomics England		investigations made at the ER (broad)																				
+GE:clinical_treatments	Clinical Treatments		Genomics England		treatments made at the ER (broad) - either pharmaceutical or non-pharmaceutical																				
+GE:clinical_trial	clinical_trial		Genomics England		is patient part of clinical trial																				
+GE:clinical_period_of_care	Clinical; Period of Care		Genomics England																						
+GE:gpprac	Code of GP practice			Practitioner|Geographical|Practitioner data																					
+GE:reggmp	Code of patient‚Äö√Ñ√¥s registered or referring general medical practitioner			Appointments|Practitioner data																					
+GE:purcode	Commissioner code			Organisation	code of organization comissioning patient's care																				
+GE:purval	Commissioner code status			Organisation	if commissioner's code is recognized by NHS																				
+GE:purro	Commissioner‚Äö√Ñ√¥s Regional Office			Organisation	location of commissioner																				
+GE:purstha	Commissioner‚Äö√Ñ√¥s Strategic Health Authority			Organisation	location of commissioner (SHA)																				
+GE:commissioning_organisation	Commissioning Organisation		Genomics England																						
+GE:ic_pctcode	Commissioning Organisation Code			Commissioning Organisation																					
+GE:ic_pctname	Commissioning Organisation Name			Commissioning Organisation																					
+GE:cr_gp_practice	Commissioning Region of GP Practice		location	Geographical																					
+GE:cr_residence	Commissioning Region of Residence		residence	Geographical																					
+GE:cr_treatment	Commissioning Region of Treatment		location	Geographical																					
+GE:csnum	Commissioning serial number			Organisation	identifies an NHS service agreement																				
+GE:comorbidity_adjustment	comorbidity_adjustment		prescription		if patient's physical state was significant in deciding type of anti-cacer drugs																				
+GE:complete	Complete			Indicators	indicator if Q1 and Q2 are complete																				
+GE:concltime	Conclusion time			Attendances																					
+GE:consult	Consultant code		physician/practitioner info	Practitioner																					
+GE:consultant_speciality_code	consultant_speciality_code		physician/practitioner info		provider specialty code for cancer treatment																				
+GE:diag_count	Count of diagnoses			Diagnosis	disease or trauma																				
+GE:opertn_count	Count of procedures		surgical interventions	Clinical																					
+GE:rescty	County of residence		residence	Geographical|Appointments																					
+GE:rescty_ons	County of residence (ONS)		residence	Geographical																					
+GE:critical_care_admission_and_discharge_data	Critical care admission and discharge data		history of intensive care																						
+GE:critical_care_adult_activity_data	Critical care adult activity data		history of intensive care		critical care == life support ?																				
+GE:critical_care_adult_admission_and_discharge_data	Critical care adult admission and discharge data		history of intensive care																						
+GE:critical_care_period_of_care	Critical care period of care		history of intensive care																						
+GE:critical_care_start_date	Critical care start date		history of intensive care																						
+GE:currward	Current electoral ward		residence	Geographical																					
+GE:currward_ons	Current electoral ward (ONS)		residence	Geographical																					
+GE:cycle_number	cycle_number		use of anti-cancer drugs																						
+GE:detndate	Date detention commenced		mental and behaviour disorders|life stage/time point	Psychiatric	when detention started (psychiatric)																				
+GE:epiend	Date episode ended		life stage/time point	Episodes and spells; Period of care																					
+GE:epistart	Date episode started		life stage/time point	Episodes and spells; Period of care																					
+GE:admidate	Date of admission		life stage/time point	Admissions; Period of Care																					
+GE:dob	Date of birth - patient		age/birthdate	Patient Data|Appointments																					
+GE:elecdate	Date of decision to admit		life stage/time point	Admissions; Period of Care	date and time-related or timeline?																				
+GE:disdate	Date of discharge		life stage/time point	Discharges; Period of Care																					
+GE:opdate_01	Date of procedure		surgical interventions	Clinical																					
+GE:date_decision_to_treat	date_decision_to_treat		life stage/time point																						
+GE:date_of_birth	date_of_birth		age/birthdate																						
+GE:date_of_death	date_of_death		life stage/time point																						
+GE:date_of_final_treatment	date_of_final_treatment		use of anti-cancer drugs																						
+GE:date_of_registration	date_of_registration		Genomics England		maybe time point?																				
+GE:waiting	Days waiting			Patient Pathway																					
+GE:delplac_1	Delivery place (actual)		pregnancy history|location	Maternity																					
+GE:delinten	Delivery place (intended)		pregnancy history|location	Maternity																					
+GE:delchang	Delivery place change reason			Maternity	why delivery place was changed																				
+GE:delmeth_2	delmeth_2		pregnancy history	Maternity																					
+GE:delmeth_3	delmeth_3		pregnancy history	Maternity																					
+GE:delmeth_4	delmeth_4		pregnancy history	Maternity																					
+GE:delmeth_5	delmeth_5		pregnancy history	Maternity																					
+GE:delmeth_6	delmeth_6		pregnancy history	Maternity																					
+GE:delmeth_7	delmeth_7		pregnancy history	Maternity																					
+GE:delmeth_8	delmeth_8		pregnancy history	Maternity																					
+GE:delmeth_9	delmeth_9		pregnancy history	Maternity																					
+GE:delmeth_d	delmeth_d		pregnancy history																						
+GE:delplac_2	delplac_2			Maternity																					
+GE:delplac_3	delplac_3			Maternity																					
+GE:delplac_4	delplac_4			Maternity																					
+GE:delplac_5	delplac_5			Maternity																					
+GE:delplac_6	delplac_6			Maternity																					
+GE:delplac_7	delplac_7			Maternity																					
+GE:delplac_8	delplac_8			Maternity																					
+GE:delplac_9	delplac_9			Maternity																					
+GE:delstat_2	delstat_2		physician/practitioner info	Maternity																					
+GE:delstat_3	delstat_3		physician/practitioner info	Maternity																					
+GE:delstat_4	delstat_4		physician/practitioner info	Maternity																					
+GE:delstat_5	delstat_5		physician/practitioner info	Maternity																					
+GE:delstat_6	delstat_6		physician/practitioner info	Maternity																					
+GE:delstat_7	delstat_7		physician/practitioner info	Maternity																					
+GE:delstat_8	delstat_8		physician/practitioner info	Maternity																					
+GE:delstat_9	delstat_9		physician/practitioner info	Maternity																					
+GE:aedepttype	Department type			Attendances																					
+GE:deptime	Departure time			Attendances																					
+GE:depdays_2	depdays_2			Augmented/critical care period																					
+GE:depdays_3	depdays_3			Augmented/critical care period																					
+GE:depdays_4	depdays_4			Augmented/critical care period																					
+GE:depdays_5	depdays_5			Augmented/critical care period																					
+GE:depdays_6	depdays_6			Augmented/critical care period																					
+GE:depdays_7	depdays_7			Augmented/critical care period																					
+GE:depdays_8	depdays_8			Augmented/critical care period																					
+GE:depdays_9	depdays_9			Augmented/critical care period																					
+GE:depression	Depression		diagnosis of depression	Indicators																					
+GE:dermsupdays	dermsupdays		history of dermatological support	Critical care adult activity data																					
+GE:disdest	Destination on discharge			Discharges; Period of Care																					
+GE:diabetes	Diabetes		diagnosis of diabetes	Indicators																					
+GE:diag_02	diag_02			Clinical|Clinical diagnoses	disease or trauma																				
+GE:diag_03	diag_03			Clinical|Clinical diagnoses																					
+GE:diag_04	diag_04			Clinical|Clinical diagnoses																					
+GE:diag_05	diag_05			Clinical|Clinical diagnoses																					
+GE:diag_06	diag_06			Clinical|Clinical diagnoses																					
+GE:diag_07	diag_07			Clinical|Clinical diagnoses																					
+GE:diag_08	diag_08			Clinical|Clinical diagnoses																					
+GE:diag_09	diag_09			Clinical|Clinical diagnoses																					
+GE:diag_10	diag_10			Clinical|Clinical diagnoses																					
+GE:diag_11	diag_11			Clinical|Clinical diagnoses																					
+GE:diag_12	diag_12			Clinical|Clinical diagnoses																					
+GE:diag_13	diag_13			Clinical	should be under Clinical diagnoses - this can be disease or trauma																				
+GE:diag_14	diag_14			Clinical																					
+GE:diag_15	diag_15			Clinical																					
+GE:diag_16	diag_16			Clinical																					
+GE:diag_17	diag_17			Clinical																					
+GE:diag_18	diag_18			Clinical																					
+GE:diag_19	diag_19			Clinical																					
+GE:diag_20	diag_20			Clinical																					
+GE:diag2_02	diag2_02			Clinical diagnoses																					
+GE:diag2_03	diag2_03			Clinical diagnoses																					
+GE:diag2_04	diag2_04			Clinical diagnoses																					
+GE:diag2_05	diag2_05			Clinical diagnoses																					
+GE:diag2_06	diag2_06			Clinical diagnoses																					
+GE:diag2_07	diag2_07			Clinical diagnoses																					
+GE:diag2_08	diag2_08			Clinical diagnoses																					
+GE:diag2_09	diag2_09			Clinical diagnoses																					
+GE:diag2_10	diag2_10			Clinical diagnoses																					
+GE:diag2_11	diag2_11			Clinical diagnoses																					
+GE:diag2_12	diag2_12			Clinical diagnoses																					
+GE:diaga_02	diaga_02			Clinical Diagnoses																					
+GE:diaga_03	diaga_03			Clinical Diagnoses																					
+GE:diaga_04	diaga_04			Clinical Diagnoses																					
+GE:diaga_05	diaga_05			Clinical Diagnoses																					
+GE:diaga_06	diaga_06			Clinical Diagnoses																					
+GE:diaga_07	diaga_07			Clinical Diagnoses																					
+GE:diaga_08	diaga_08			Clinical Diagnoses																					
+GE:diaga_09	diaga_09			Clinical Diagnoses																					
+GE:diaga_10	diaga_10			Clinical Diagnoses																					
+GE:diaga_11	diaga_11			Clinical Diagnoses																					
+GE:diaga_12	diaga_12			Clinical Diagnoses																					
+GE:diagnosis	Diagnosis		Genomics England																						
+GE:diagscheme	Diagnosis Scheme in Use			Clinical diagnoses	e.g. ICD-10																				
+GE:did_date3	Diagnostic Test Date			Diagnostic Test Dates																					
+GE:diagnostic_test_dates	Diagnostic Test Dates		Genomics England		could be 'laboratory measures' but this isn't the actual test, just dates so 'timeline' might be better?																				
+GE:did_date1	Diagnostic Test Request Date			Diagnostic Test Dates	diagnostic tests could be physiological measurements or laboratory measures																				
+GE:did_date2	Diagnostic Test Request Received Date			Diagnostic Test Dates																					
+GE:diags_02	diags_02			Clinical Diagnoses																					
+GE:diags_03	diags_03			Clinical Diagnoses																					
+GE:diags_04	diags_04			Clinical Diagnoses																					
+GE:diags_05	diags_05			Clinical Diagnoses																					
+GE:diags_06	diags_06			Clinical Diagnoses																					
+GE:diags_07	diags_07			Clinical Diagnoses																					
+GE:diags_08	diags_08			Clinical Diagnoses																					
+GE:diags_09	diags_09			Clinical Diagnoses																					
+GE:diags_10	diags_10			Clinical Diagnoses																					
+GE:diags_11	diags_11			Clinical Diagnoses																					
+GE:diags_12	diags_12			Clinical Diagnoses																					
+GE:did_snomedct_code	did_snomedct_code		Genomics England																						
+GE:disreadydate	Discharge ready date		life stage/time point	Discharges; Period of Care																					
+GE:discharges_period_of_care	Discharges; Period of Care		Genomics England																						
+GE:drug_group	drug_group		use of anti-cancer drugs																						
+GE:cendur	Duration of care to psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	period of time from admission date to psychiatric census																				
+GE:detdur	Duration of detention		mental and behaviour disorders|life stage/time point	Psychiatric	days between detention and psychiatric cesus																				
+GE:elecdur	Duration of elective wait (submitted)		life stage/time point	Admissions; Period of Care	date decided to admit -> actual admission date for elective admission - date and time-related or timeline?																				
+GE:speldur	Duration of spell			Episodes and spells; Period of care																					
+GE:waitdays	Duration of wait (referral to treatment period)			Patient Pathway|Appointments																					
+GE:initdur	Duration to assessment			Attendances																					
+GE:concldur	Duration to conclusion			Attendances																					
+GE:depdur	Duration to departure			Attendances																					
+GE:tretdur	Duration to treatment			Attendances																					
+GE:earldatoff	Earliest reasonable date offered			Patient Pathway	earliest date for appointment or admission - date and time-related or timeline?																				
+GE:ic_cancer_desc	Early cancer diagnosis		oncological	Cancer diagnosis																					
+GE:ward91	Electoral ward in 1991			Geographical																					
+GE:ward98	Electoral ward in 1998			Geographical																					
+GE:spelend	End of spell indicator			Episodes and spells; Period of care																					
+GE:epidur	Episode duration		life stage/time point	Episodes and spells; Period of care																					
+GE:episode_match_rank	EPISODE MATCH RANK			Administrative																					
+GE:epiorder	Episode order			Episodes and spells; Period of care	transfer to care of another consultant increases number of episode (1,2,3,4...)																				
+GE:epistat	Episode status			Episodes and spells; Period of care	was episode still occurring on Mar 31 (end of year)? date or timeline?																				
+GE:epitype	Episode type			Episodes and spells; Period of care	general, delivery, birth, detained under mental health legisation or long-term psych patient, other deliver, other birth																				
+GE:maternity_episode_type	Episode Type - Maternity			Maternity																					
+GE:episode_matched	episode_matched			Administrative																					
+GE:episodes_and_spells_period_of_care	Episodes and spells; Period of care		Genomics England																						
+GE:eq5d_index_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (FINAL MODEL1)			Scoring																					
+GE:eq5d_health_scale_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (MODEL1)			Scoring																					
+GE:eq5d_scale_change	EQ5D INDEX CHANGE			Scoring																					
+GE:eq5d_index_change	eq5d_index_change			Scoring																					
+GE:ethnic_category	Ethnic category		ethnicity/race	Patient Data																					
+GE:ethnos	Ethnic Category		ethnicity/race																						
+GE:ethrawl	Ethnic category (audit version)			Patient Data																					
+GE:did_ethcat	Ethnic Category Code		ethnicity/race	Ethnic Category																					
+GE:ic_ethcat_desc	Ethnic Category Description		ethnicity/race	Ethnic Category																					
+GE:did_ethcat_grp	Ethnic Category Group		ethnicity/race	Ethnic Category																					
+GE:ethraw	Ethnic character (audit version)		ethnicity/race	System Data																					
+GE:event_date	event_date		Genomics England																						
+GE:event_type	event_type		Genomics England																						
+GE:ic_fetal_desc	Fetal		Genomics England																						
+GE:ic_fetal_id	Fetal ID		unique identifiers	Fetal																					
+GE:lad98	Financial Year			Admissions; Period of Care|Appointments|Administrative																					
+GE:resladst_ons	Finished Admission Episode			Episodes and spells; Period of care																					
+GE:fyear	Finished Admission Episode, emergency classification			Episodes and spells; Period of care	admission from ER																				
+GE:fae	Finished Consultant Episode			Episodes and spells; Period of care	continuous period of care under one consultant																				
+GE:fae_emergency	Finished In-Year Discharge Episode			Episodes and spells; Period of care	(episodes and spells; period of care) patient was discharged at end of episode before end of year																				
+GE:fce	First antenatal assessment date		pregnancy history	Maternity																					
+GE:fde	First attendance			System Data																					
+GE:anasdate	First regular day or night admission			Admissions; Period of Care																					
+GE:firstatt	Gender			Administrative																					
+GE:firstreg	Gender Code		gender	Gender																					
+GE:gender	Gender Description		gender	Gender																					
+GE:did_gender_code	gender_current_clean		gender																						
+GE:ic_gender_desc	gender_of_deceased		gender																						
+GE:gender_current_clean	Geographical		Genomics England																						
+GE:gender_of_deceased	gestat_2			Maternity																					
+GE:geographical	gestat_3			Maternity																					
+GE:gestat_2	gestat_4			Maternity																					
+GE:gestat_3	gestat_5			Maternity																					
+GE:gestat_4	gestat_6			Maternity																					
+GE:gestat_5	gestat_7			Maternity																					
+GE:gestat_6	gestat_8			Maternity																					
+GE:gestat_7	gestat_9			Maternity																					
+GE:gestat_8	Gestation period in weeks at first antenatal assessment		pregnancy history	Maternity																					
+GE:gestat_9	gisupdays		history of gastrointestinal support	Critical care adult activity data																					
+GE:anagest	Government Office region of residence		residence	Geographical																					
+GE:gisupdays	Government office region of residence (ONS)		residence	Geographical																					
+GE:resgor	Government office region of treatment			Geographical																					
+GE:resgor_ons	Health Authority area where patient‚Äö√Ñ√¥s GP is registered			Organisation	where GP is registered																				
+GE:gortreat	Health Authority of residence		residence	Geographical																					
+GE:gppracha	Healthcare resource groups (HRG) data		Genomics England																						
+GE:resha	Healthly Neonate Indicator			Maternity																					
+GE:healthcare_resource_groups_hrg_data	Heart Disease Indicator		diagnosis of heart disease	Indicators																					
+GE:hneoind	height_at_start_of_regimen		height																						
+GE:heart_disease	hes_dids_version		Genomics England																						
+GE:height_at_start_of_regimen	HESID Matched			Administrative																					
+GE:hes_dids_version	Hesid Rank			Administrative																					
+GE:hesid_matched	High Blood Pressiure Indicator		occurrence of high blood pressure	Indicators																					
+GE:hesid_rank	High-dependency care level			Augmented/critical care period	number of days of high-dependency care during augmented care (is this life support?)																				
+GE:high_bp	Hip Replacement		Genomics England																						
+GE:depdays_1	Hip Replacement - Q1		Genomics England		are these questions to determine if hip replacement is NEEDED (symptoms) or after hip replacement?																				
+GE:hip_replacement	Hip Replacement - Q2		Genomics England																						
+GE:hip_replacement_q1	hr_q1_score			Hip Replacement - Q1																					
+GE:hip_replacement_q2	hr_q1_score_complete			Hip Replacement - Q1																					
+GE:hr_q1_score	hr_q2_score			Hip Replacement - Q2																					
+GE:hr_q1_score_complete	hr_q2_score_complete			Hip Replacement - Q2																					
+GE:hr_q2_score	hr_score_expected_final_model3			Hip Replacement																					
+GE:hr_q2_score_complete	ic_age17_60		age/birthdate	Age Bands																					
+GE:hr_score_expected_final_model3	ic_age17_64		age/birthdate	Age Bands																					
+GE:ic_age17_60	ic_age50_74		age/birthdate	Age Bands																					
+GE:ic_age17_64	ic_agechild		age/birthdate	Age Bands																					
+GE:ic_age50_74	ic_annual_id		Genomics England																						
+GE:ic_agechild	ic_epi_rp_days		Genomics England																						
+GE:ic_annual_id	ic_episode_epi_days		Genomics England																						
+GE:ic_epi_rp_days	ic_eve_primarydiagnosis		Genomics England																						
+GE:ic_episode_epi_days	ic_eve_secondarydiagnosis		Genomics England																						
+GE:ic_eve_primarydiagnosis	ic_inactive_timestamp		Genomics England																						
+GE:ic_eve_secondarydiagnosis	ic_interim_ccg_code		Genomics England																						
+GE:ic_inactive_timestamp	ic_rec_ccg		Genomics England																						
+GE:ic_interim_ccg_code	ic_rec_endrp_aot_flag		Genomics England																						
+GE:ic_rec_ccg	ic_rec_endrp_cluster_flag		Genomics England																						
+GE:ic_rec_endrp_aot_flag	ic_rec_endrp_cluster_type		Genomics England																						
+GE:ic_rec_endrp_cluster_flag	ic_rec_endrp_cpa_epi_12_months		Genomics England																						
+GE:ic_rec_endrp_cluster_type	ic_rec_endrp_cpa_flag		Genomics England																						
+GE:ic_rec_endrp_cpa_epi_12_months	ic_rec_endrp_cpa_review_within_12mnths		Genomics England																						
+GE:ic_rec_endrp_cpa_flag	ic_rec_endrp_eit_flag		Genomics England																						
+GE:ic_rec_endrp_cpa_review_within_12mnths	ic_rec_endrp_employment_status		Genomics England																						
+GE:ic_rec_endrp_eit_flag	ic_rec_endrp_honos_assessment_within_12mnths		Genomics England																						
+GE:ic_rec_endrp_employment_status	ic_rec_endrp_hospital_spell_flag		Genomics England																						
+GE:ic_rec_endrp_honos_assessment_within_12mnths	ic_rec_endrp_mha_flag		Genomics England																						
+GE:ic_rec_endrp_hospital_spell_flag	ic_rec_endrp_pdiag_flag		Genomics England																						
+GE:ic_rec_endrp_mha_flag	ic_rec_endrp_recall_flag		Genomics England																						
+GE:ic_rec_endrp_pdiag_flag	ic_rec_endrp_sct_flag		Genomics England																						
+GE:ic_rec_endrp_recall_flag	ic_rec_endrp_settled_accommodation_indicator		Genomics England																						
+GE:ic_rec_endrp_sct_flag	ic_rec_ethnicity		ethnicity/race																						
+GE:ic_rec_endrp_settled_accommodation_indicator	ic_rec_rp_admission		Genomics England																						
+GE:ic_rec_ethnicity	ic_rec_rp_admission_formal		Genomics England																						
+GE:ic_rec_rp_admission	ic_rec_rp_awol		Genomics England																						
+GE:ic_rec_rp_admission_formal	ic_rec_rp_commissioners		Genomics England																						
+GE:ic_rec_rp_awol	ic_rec_rp_contacts		Genomics England																						
+GE:ic_rec_rp_commissioners	ic_rec_rp_contacts_att		Genomics England																						
+GE:ic_rec_rp_contacts	ic_rec_rp_dayatt_contacts		Genomics England																						
+GE:ic_rec_rp_contacts_att	ic_rec_rp_dayatt_contacts_att		Genomics England																						
+GE:ic_rec_rp_dayatt_contacts	ic_rec_rp_ddisc_days		Genomics England																						
+GE:ic_rec_rp_dayatt_contacts_att	ic_rec_rp_disch_net_followup		Genomics England																						
+GE:ic_rec_rp_ddisc_days	ic_rec_rp_discharges_gross		Genomics England																						
+GE:ic_rec_rp_disch_net_followup	ic_rec_rp_discharges_net		Genomics England																						
+GE:ic_rec_rp_discharges_gross	ic_rec_rp_readmissions		Genomics England																						
+GE:ic_rec_rp_discharges_net	ic_rec_rp_wrdst_days_cleansed		Genomics England																						
+GE:ic_rec_rp_readmissions	ic_rec_rp_wrdst_days_gross		Genomics England																						
+GE:ic_rec_rp_wrdst_days_cleansed	ic_rec_rp_wrdst_days_net		Genomics England																						
+GE:ic_rec_rp_wrdst_days_gross	ic_source_period_id		Genomics England																						
+GE:ic_rec_rp_wrdst_days_net	ic_spell_rp_days		Genomics England																						
+GE:ic_source_period_id	icd10_multiple_cause_code_1		Genomics England																						
+GE:ic_spell_rp_days	icd10_multiple_cause_code_10		Genomics England																						
+GE:icd10_multiple_cause_code_1	icd10_multiple_cause_code_11		Genomics England																						
+GE:icd10_multiple_cause_code_10	icd10_multiple_cause_code_12		Genomics England																						
+GE:icd10_multiple_cause_code_11	icd10_multiple_cause_code_13		Genomics England																						
+GE:icd10_multiple_cause_code_12	icd10_multiple_cause_code_14		Genomics England																						
+GE:icd10_multiple_cause_code_13	icd10_multiple_cause_code_15		Genomics England																						
+GE:icd10_multiple_cause_code_14	icd10_multiple_cause_code_2		Genomics England																						
+GE:icd10_multiple_cause_code_15	icd10_multiple_cause_code_3		Genomics England																						
+GE:icd10_multiple_cause_code_2	icd10_multiple_cause_code_4		Genomics England																						
+GE:icd10_multiple_cause_code_3	icd10_multiple_cause_code_5		Genomics England																						
+GE:icd10_multiple_cause_code_4	icd10_multiple_cause_code_6		Genomics England																						
+GE:icd10_multiple_cause_code_5	icd10_multiple_cause_code_7		Genomics England																						
+GE:icd10_multiple_cause_code_6	icd10_multiple_cause_code_8		Genomics England																						
+GE:icd10_multiple_cause_code_7	icd10_multiple_cause_code_9		Genomics England																						
+GE:icd10_multiple_cause_code_8	icd10_underlying_cause		Genomics England																						
+GE:icd10_multiple_cause_code_9	icd9_multiple_cause_code_1		Genomics England																						
+GE:icd10_underlying_cause	icd9_multiple_cause_code_10		Genomics England																						
+GE:icd9_multiple_cause_code_1	icd9_multiple_cause_code_11		Genomics England																						
+GE:icd9_multiple_cause_code_10	icd9_multiple_cause_code_12		Genomics England																						
+GE:icd9_multiple_cause_code_11	icd9_multiple_cause_code_13		Genomics England																						
+GE:icd9_multiple_cause_code_12	icd9_multiple_cause_code_14		Genomics England																						
+GE:icd9_multiple_cause_code_13	icd9_multiple_cause_code_15		Genomics England																						
+GE:icd9_multiple_cause_code_14	icd9_multiple_cause_code_2		Genomics England																						
+GE:icd9_multiple_cause_code_15	icd9_multiple_cause_code_3		Genomics England																						
+GE:icd9_multiple_cause_code_2	icd9_multiple_cause_code_4		Genomics England																						
+GE:icd9_multiple_cause_code_3	icd9_multiple_cause_code_5		Genomics England																						
+GE:icd9_multiple_cause_code_4	icd9_multiple_cause_code_6		Genomics England																						
+GE:icd9_multiple_cause_code_5	icd9_multiple_cause_code_7		Genomics England																						
+GE:icd9_multiple_cause_code_6	icd9_multiple_cause_code_8		Genomics England																						
+GE:icd9_multiple_cause_code_7	icd9_multiple_cause_code_9		Genomics England																						
+GE:icd9_multiple_cause_code_8	icd9_underlying_cause		Genomics England		is this disease only, or disease and trauma?																				
+GE:icd9_multiple_cause_code_9	Imaging Code (NICIP)			Imaging Codes																					
+GE:icd9_underlying_cause	Imaging Code (NICIP) Description			Imaging Codes																					
+GE:did_nicip_code	Imaging Code (SNOMED)			Imaging Codes																					
+GE:ic_nicip_desc	Imaging Codes		laboratory measures		standardized codes for imaging procedures																				
+GE:ic_snomedct_desc	IMD Barriers to Housing and Service Domain			Socio-economic|Geographical																					
+GE:imaging_codes	IMD Crime Domain			Socio-economic|Geographical																					
+GE:imd04hs	IMD Decile Group			Socio-economic|Geographical																					
+GE:imd04c	IMD Education Training and Skills Domain			Socio-economic|Geographical																					
+GE:imd04_decile	IMD Employment Deprivation Domain			Socio-economic|Geographical																					
+GE:imd04ed	IMD Health and Disability Domain			Socio-economic|Geographical																					
+GE:imd04em	IMD Income affecting Adults Domain			Socio-economic|Geographical																					
+GE:imd04hd	IMD Income affecting Children Domain			Socio-economic|Geographical																					
+GE:imd04ia	IMD Income Domain			Socio-economic|Geographical																					
+GE:imd04ic	IMD Index of Multiple Deprivation			Socio-economic|Geographical																					
+GE:imd04i	IMD Living Environment Domain			Socio-economic|Geographical																					
+GE:imd04	IMD Overall Rank			Socio-economic|Geographical																					
+GE:imd04le	Incident location type			Attendances																					
+GE:imd04rk	Indicators		diseases		indicators for diseases																				
+GE:aeincloctype	Initial assessment time			Attendances																					
+GE:indicators	intdays_2		history of intensive care	Augmented/critical care period																					
+GE:inittime	intdays_3		history of intensive care	Augmented/critical care period																					
+GE:intdays_2	intdays_4		history of intensive care	Augmented/critical care period																					
+GE:intdays_3	intdays_5		history of intensive care	Augmented/critical care period																					
+GE:intdays_4	intdays_6		history of intensive care	Augmented/critical care period																					
+GE:intdays_5	intdays_7		history of intensive care	Augmented/critical care period																					
+GE:intdays_6	intdays_8		history of intensive care	Augmented/critical care period																					
+GE:intdays_7	intdays_9		history of intensive care	Augmented/critical care period																					
+GE:intdays_8	Intended management			Clinical; Period of Care	what was planned to happen in hospital																				
+GE:intdays_9	Intensive care level days		history of intensive care	Augmented/critical care period																					
+GE:intmanig	intent_of_treatment		Genomics England																						
+GE:intdays_1	invest_02		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:intent_of_treatment	invest_03		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_02	invest_04		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_03	invest_05		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_04	invest_06		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_05	invest_07		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_06	invest_08		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_07	invest_09		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_08	invest_10		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_09	invest_11		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_10	invest_12		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_11	invest2_02		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest_12	invest2_03		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_02	invest2_04		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_03	invest2_05		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_04	invest2_06		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_05	invest2_07		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_06	invest2_08		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_07	invest2_09		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_08	invest2_10		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_09	invest2_11		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_10	invest2_12		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:invest2_11	Kidney Disease		diagnosis of renal disease	Indicators																					
+GE:invest2_12	Knee Replacement - Q1		Genomics England		are these questions to determine if knee replacement is NEEDED (symptoms) or after knee replacement?																				
+GE:kidney_disease	Knee Replacement - Q2		Genomics England																						
+GE:knee_replacement_q1	kr_q1_score_complete			Scoring																					
+GE:knee_replacement_q2	kr_q2_score			Scoring																					
+GE:kr_q1_score_complete	kr_q2_score_complete		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_score	kr_q2_stairs		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_score_complete	kr_score_expected_final_model3			Scoring																					
+GE:kr_q2_stairs	Labour/delivery onset method		pregnancy history	Maternity	may involve drugs or surgical																				
+GE:kr_score_expected_final_model3	Last DNA or patient cancelled date			Count of diagnoses	this parent is not right? patient offered appt and missed date without advance notice																				
+GE:delonset	latest_date_of_birth		age/birthdate																						
+GE:dnadate	latest_gender		gender																						
+GE:latest_date_of_birth	Length of gestation			Maternity																					
+GE:latest_gender	Liver Disease		diagnosis of liver disease	Indicators																					
+GE:gestat_1	liversupdays		history of liver support	Critical care adult activity data																					
+GE:liver_disease	Local authority district in 1998			Geographical																					
+GE:liversupdays	Local authority district of residence		residence	Geographical																					
+GE:resladst	Local authority district of residence (ONS)		residence	Geographical																					
+GE:location	Location		location																						
+GE:ic_lsoa	Location - LSOA		residence	Location	derived from residence post code																				
+GE:ic_msoa	Location - MSOA		residence	Location	derived from residence post code																				
+GE:locclass	Location Class			Appointments																					
+GE:loctype	Location Tyoe			Appointments																					
+GE:lsoa01	Lower Super Output Area			Geographical																					
+GE:lsoa11	Lower Super Output Area			Geographical																					
+GE:lung_disease	Lung Disease		respiratory system	Indicators																					
+GE:mainspef	Main specialty		physician/practitioner info	Clinical; Period of Care|Clinical																					
+GE:marstat	Marital status (psychiatric)		marital status value	Psychiatric|Clinical																					
+GE:match_rank	match_rank			System Data																					
+GE:maternity	Maternity		Genomics England																						
+GE:stafftyp	Medical staff type seeing patient			Appointments																					
+GE:admimeth	Method of admission			Admissions; Period of Care	waiting list or not waiting list																				
+GE:waitlist	Method of Admission - Waiting List			Patient Pathway																					
+GE:dismeth	Method of discharge			Discharges; Period of Care																					
+GE:mhd_abusequestion_indicator	mhd_abusequestion_indicator		Genomics England																						
+GE:mhd_accomodation_status	mhd_accomodation_status		Genomics England																						
+GE:mhd_admimet	mhd_admimet		Genomics England																						
+GE:mhd_age	mhd_age		age/birthdate																						
+GE:mhd_assessment	mhd_assessment		Genomics England																						
+GE:mhd_attended_indicator	mhd_attended_indicator		Genomics England																						
+GE:mhd_carecluster_superclass_code	mhd_carecluster_superclass_code		Genomics England																						
+GE:mhd_carecoordinator_flag	mhd_carecoordinator_flag		Genomics England																						
+GE:mhd_ccg_of_gp_practice	mhd_ccg_of_gp_practice		physician/practitioner info																						
+GE:mhd_ccg_of_residence	mhd_ccg_of_residence		Genomics England																						
+GE:mhd_clusteringtool_assessment_reason	mhd_clusteringtool_assessment_reason		Genomics England																						
+GE:mhd_code_of_commissioner	mhd_code_of_commissioner		Genomics England																						
+GE:mhd_code_of_gp_practice	mhd_code_of_gp_practice		physician/practitioner info																						
+GE:mhd_commissioner_code	mhd_commissioner_code		Genomics England																						
+GE:mhd_consultmedium	mhd_consultmedium		Genomics England																						
+GE:mhd_contact_location_code	mhd_contact_location_code		Genomics England																						
+GE:mhd_contact_subject	mhd_contact_subject		Genomics England																						
+GE:mhd_county	mhd_county		residence																						
+GE:mhd_crisisplancreat_date	mhd_crisisplancreat_date		Genomics England																						
+GE:mhd_crisisplanupdate_date	mhd_crisisplanupdate_date		Genomics England																						
+GE:mhd_delayed_dischend_date	mhd_delayed_dischend_date		Genomics England																						
+GE:mhd_delayed_dischreason	mhd_delayed_dischreason		Genomics England																						
+GE:mhd_delayed_dischstart_date	mhd_delayed_dischstart_date		Genomics England																						
+GE:mhd_dischdate	mhd_dischdate		Genomics England																						
+GE:mhd_dischmet	mhd_dischmet		Genomics England																						
+GE:mhd_dischreason	mhd_dischreason		Genomics England																						
+GE:mhd_duration	mhd_duration		Genomics England																						
+GE:mhd_electoral_ward_of_usual_address	mhd_electoral_ward_of_usual_address		Genomics England																						
+GE:mhd_emerpsych_date	mhd_emerpsych_date		Genomics England																						
+GE:mhd_employment_status	mhd_employment_status		Genomics England																						
+GE:mhd_end_date_mhcs	mhd_end_date_mhcs		Genomics England																						
+GE:mhd_endreason	mhd_endreason		Genomics England																						
+GE:mhd_endtime	mhd_endtime		Genomics England																						
+GE:mhd_epiend_date	mhd_epiend_date		Genomics England																						
+GE:mhd_episode_id	mhd_episode_id		Genomics England																						
+GE:mhd_epistart_date	mhd_epistart_date		Genomics England																						
+GE:mhd_epitype	mhd_epitype		Genomics England																						
+GE:mhd_ethnicity	mhd_ethnicity		ethnicity/race																						
+GE:mhd_event_id	mhd_event_id		Genomics England																						
+GE:mhd_eventdate	mhd_eventdate		Genomics England																						
+GE:mhd_eventtype	mhd_eventtype		Genomics England																						
+GE:mhd_expirydate	mhd_expirydate		Genomics England																						
+GE:mhd_expirytime	mhd_expirytime		Genomics England																						
+GE:mhd_gender	mhd_gender		gender																						
+GE:mhd_health_care_spell_end_reason	mhd_health_care_spell_end_reason		Genomics England																						
+GE:mhd_honos_flag	mhd_honos_flag		Genomics England																						
+GE:mhd_honos_honosrating1_score	mhd_honos_honosrating1_score		Genomics England																						
+GE:mhd_honos_honosrating10_score	mhd_honos_honosrating10_score		Genomics England																						
+GE:mhd_honos_honosrating11_score	mhd_honos_honosrating11_score		Genomics England																						
+GE:mhd_honos_honosrating12_score	mhd_honos_honosrating12_score		Genomics England																						
+GE:mhd_honos_honosrating2_score	mhd_honos_honosrating2_score		Genomics England																						
+GE:mhd_honos_honosrating3_score	mhd_honos_honosrating3_score		Genomics England																						
+GE:mhd_honos_honosrating4_score	mhd_honos_honosrating4_score		Genomics England																						
+GE:mhd_honos_honosrating5_score	mhd_honos_honosrating5_score		Genomics England																						
+GE:mhd_honos_honosrating6_score	mhd_honos_honosrating6_score		Genomics England																						
+GE:mhd_honos_honosrating7_score	mhd_honos_honosrating7_score		Genomics England																						
+GE:mhd_honos_honosrating8_score	mhd_honos_honosrating8_score		Genomics England																						
+GE:mhd_honos_honosrating8_type	mhd_honos_honosrating8_type		Genomics England																						
+GE:mhd_honos_honosrating9_score	mhd_honos_honosrating9_score		Genomics England																						
+GE:mhd_honos_secure_flag	mhd_honos_secure_flag		Genomics England																						
+GE:mhd_honos65_flag	mhd_honos65_flag		Genomics England																						
+GE:mhd_honos65_rating1_score	mhd_honos65_rating1_score		Genomics England																						
+GE:mhd_honos65_rating10_score	mhd_honos65_rating10_score		Genomics England																						
+GE:mhd_honos65_rating11_score	mhd_honos65_rating11_score		Genomics England																						
+GE:mhd_honos65_rating12_score	mhd_honos65_rating12_score		Genomics England																						
+GE:mhd_honos65_rating2_score	mhd_honos65_rating2_score		Genomics England																						
+GE:mhd_honos65_rating3_score	mhd_honos65_rating3_score		Genomics England																						
+GE:mhd_honos65_rating4_score	mhd_honos65_rating4_score		Genomics England																						
+GE:mhd_honos65_rating5_score	mhd_honos65_rating5_score		Genomics England																						
+GE:mhd_honos65_rating6_score	mhd_honos65_rating6_score		Genomics England																						
+GE:mhd_honos65_rating7_score	mhd_honos65_rating7_score		Genomics England																						
+GE:mhd_honos65_rating8_score	mhd_honos65_rating8_score		Genomics England																						
+GE:mhd_honos65_rating8_type	mhd_honos65_rating8_type		Genomics England																						
+GE:mhd_honos65_rating9_score	mhd_honos65_rating9_score		Genomics England																						
+GE:mhd_honosca_flag	mhd_honosca_flag		Genomics England																						
+GE:mhd_honoscarating1_score	mhd_honoscarating1_score		Genomics England																						
+GE:mhd_honoscarating10_score	mhd_honoscarating10_score		Genomics England																						
+GE:mhd_honoscarating11_score	mhd_honoscarating11_score		Genomics England																						
+GE:mhd_honoscarating12_score	mhd_honoscarating12_score		Genomics England																						
+GE:mhd_honoscarating13_score	mhd_honoscarating13_score		Genomics England																						
+GE:mhd_honoscarating14_score	mhd_honoscarating14_score		Genomics England																						
+GE:mhd_honoscarating15_score	mhd_honoscarating15_score		Genomics England																						
+GE:mhd_honoscarating2_score	mhd_honoscarating2_score		Genomics England																						
+GE:mhd_honoscarating3_score	mhd_honoscarating3_score		Genomics England																						
+GE:mhd_honoscarating4_score	mhd_honoscarating4_score		Genomics England																						
+GE:mhd_honoscarating5_score	mhd_honoscarating5_score		Genomics England																						
+GE:mhd_honoscarating6_score	mhd_honoscarating6_score		Genomics England																						
+GE:mhd_honoscarating7_score	mhd_honoscarating7_score		Genomics England																						
+GE:mhd_honoscarating8_score	mhd_honoscarating8_score		Genomics England																						
+GE:mhd_honoscarating9_score	mhd_honoscarating9_score		Genomics England																						
+GE:mhd_honossecureratinga_score	mhd_honossecureratinga_score		Genomics England																						
+GE:mhd_honossecureratingb_score	mhd_honossecureratingb_score		Genomics England																						
+GE:mhd_honossecureratingc_score	mhd_honossecureratingc_score		Genomics England																						
+GE:mhd_honossecureratingd_score	mhd_honossecureratingd_score		Genomics England																						
+GE:mhd_honossecureratinge_score	mhd_honossecureratinge_score		Genomics England																						
+GE:mhd_honossecureratingf_score	mhd_honossecureratingf_score		Genomics England																						
+GE:mhd_honossecureratingg_score	mhd_honossecureratingg_score		Genomics England																						
+GE:mhd_int_clincare_intensity_code	mhd_int_clincare_intensity_code		Genomics England																						
+GE:mhd_intended_agegroup	mhd_intended_agegroup		Genomics England																						
+GE:mhd_jobrole	mhd_jobrole		Genomics England																						
+GE:mhd_lad_ua	mhd_lad_ua		Genomics England																						
+GE:mhd_mainspecialty	mhd_mainspecialty		Genomics England																						
+GE:mhd_manpsych_date	mhd_manpsych_date		Genomics England																						
+GE:mhd_marital_status	mhd_marital_status		Genomics England																						
+GE:mhd_mencat07	mhd_mencat07		Genomics England																						
+GE:mhd_mhc_team_type	mhd_mhc_team_type		Genomics England																						
+GE:mhd_mhct_flag	mhd_mhct_flag		Genomics England																						
+GE:mhd_mhct_honosrating1_score	mhd_mhct_honosrating1_score		Genomics England																						
+GE:mhd_mhct_honosrating10_score	mhd_mhct_honosrating10_score		Genomics England																						
+GE:mhd_mhct_honosrating11_score	mhd_mhct_honosrating11_score		Genomics England																						
+GE:mhd_mhct_honosrating12_score	mhd_mhct_honosrating12_score		Genomics England																						
+GE:mhd_mhct_honosrating2_score	mhd_mhct_honosrating2_score		Genomics England																						
+GE:mhd_mhct_honosrating3_score	mhd_mhct_honosrating3_score		Genomics England																						
+GE:mhd_mhct_honosrating4_score	mhd_mhct_honosrating4_score		Genomics England																						
+GE:mhd_mhct_honosrating5_score	mhd_mhct_honosrating5_score		Genomics England																						
+GE:mhd_mhct_honosrating6_score	mhd_mhct_honosrating6_score		Genomics England																						
+GE:mhd_mhct_honosrating7_score	mhd_mhct_honosrating7_score		Genomics England																						
+GE:mhd_mhct_honosrating8_score	mhd_mhct_honosrating8_score		Genomics England																						
+GE:mhd_mhct_honosrating8_type	mhd_mhct_honosrating8_type		Genomics England																						
+GE:mhd_mhct_honosrating9_score	mhd_mhct_honosrating9_score		Genomics England																						
+GE:mhd_mhmds_person_id	mhd_mhmds_person_id		Genomics England																						
+GE:mhd_mhmds_spell_id	mhd_mhmds_spell_id		Genomics England																						
+GE:mhd_nhs_occupcode	mhd_nhs_occupcode		Genomics England																						
+GE:mhd_pbr_cluster	mhd_pbr_cluster		Genomics England																						
+GE:mhd_pct_of_gp_practice	mhd_pct_of_gp_practice		Genomics England																						
+GE:mhd_pct_of_residence	mhd_pct_of_residence		Genomics England																						
+GE:mhd_phq9_q1_score	mhd_phq9_q1_score		Genomics England																						
+GE:mhd_phq9_q2_score	mhd_phq9_q2_score		Genomics England																						
+GE:mhd_phq9_q3_score	mhd_phq9_q3_score		Genomics England																						
+GE:mhd_phq9_q4_score	mhd_phq9_q4_score		Genomics England																						
+GE:mhd_phq9_q5_score	mhd_phq9_q5_score		Genomics England																						
+GE:mhd_phq9_q6_score	mhd_phq9_q6_score		Genomics England																						
+GE:mhd_phq9_q7_score	mhd_phq9_q7_score		Genomics England																						
+GE:mhd_phq9_q8_score	mhd_phq9_q8_score		Genomics England																						
+GE:mhd_phq9_q9_score	mhd_phq9_q9_score		Genomics England																						
+GE:mhd_phq9_total_score	mhd_phq9_total_score		Genomics England																						
+GE:mhd_postcode_district	mhd_postcode_district		Genomics England																						
+GE:mhd_primarydiagnosis	mhd_primarydiagnosis		Genomics England																						
+GE:mhd_propsych_date	mhd_propsych_date		Genomics England																						
+GE:mhd_provider_org_code	mhd_provider_org_code		Genomics England																						
+GE:mhd_psychpresc_date	mhd_psychpresc_date		Genomics England																						
+GE:mhd_psychtreat_start_date	mhd_psychtreat_start_date		Genomics England																						
+GE:mhd_referral_request_status_date	mhd_referral_request_status_date		Genomics England																						
+GE:mhd_refrec_date	mhd_refrec_date		Genomics England																						
+GE:mhd_sacrating13_score	mhd_sacrating13_score		Genomics England																						
+GE:mhd_sacratinga_score	mhd_sacratinga_score		Genomics England																						
+GE:mhd_sacratingb_score	mhd_sacratingb_score		Genomics England																						
+GE:mhd_sacratingc_score	mhd_sacratingc_score		Genomics England																						
+GE:mhd_sacratingd_score	mhd_sacratingd_score		Genomics England																						
+GE:mhd_sacratinge_score	mhd_sacratinge_score		Genomics England																						
+GE:mhd_secondarydiagnosis	mhd_secondarydiagnosis		Genomics England																						
+GE:mhd_settled_accommodation_indicator	mhd_settled_accommodation_indicator		Genomics England																						
+GE:mhd_sex_code	mhd_sex_code		biological sex																						
+GE:mhd_source_of_referral	mhd_source_of_referral		Genomics England																						
+GE:mhd_start_date_mhcs	mhd_start_date_mhcs		Genomics England																						
+GE:mhd_starttime	mhd_starttime		Genomics England																						
+GE:mhd_status_of_service_request	mhd_status_of_service_request		Genomics England																						
+GE:mhd_teamtype	mhd_teamtype		Genomics England																						
+GE:mhd_treat	mhd_treat		Genomics England																						
+GE:mhd_valid_nhs_number_flag	mhd_valid_nhs_number_flag		Genomics England																						
+GE:mhd_valid_postcode_flag	mhd_valid_postcode_flag		Genomics England																						
+GE:mhd_wardsec_level	mhd_wardsec_level		Genomics England																						
+GE:mhd_weekly_hours_worked	mhd_weekly_hours_worked		Genomics England																						
+GE:mhd_year_of_first_known_psychiatric_care	mhd_year_of_first_known_psychiatric_care		Genomics England																						
+GE:msoa01	Middle Super Output Area, 2001			Geographical|Patient Data																					
+GE:msoa11	Middle Super Output Area, 2011			Geographical																					
+GE:ic_modality_desc	Modality		Genomics England																						
+GE:ic_modality_id	Modality ID			Modality	IDs that group procedures and methods																				
+GE:modified_date	modified_date			Administrative																					
+GE:did_date3_month	Month of Test			Diagnostic Test Dates																					
+GE:ic_morph_desc	Morphology		Genomics England																						
+GE:ic_morphology_id	Morphology ID			Morphology	categorizes imaging conducted on abnormalities																				
+GE:morphology_clean	morphology_clean		oncological		morphology for cell type before cancer treatment - maybe physiological?																				
+GE:matage	Mother‚Äö√Ñ√¥s age at delivery			Maternity																					
+GE:neocare	Neonatal level of care			Maternity																					
+GE:nervous_system	nervous_system		nervous system	Indicators																					
+GE:appdate	Net applicable date			System Data																					
+GE:neurosupdays	neurosupdays		history of neurological support	Critical care adult activity data																					
+GE:did_nhsnum_stat	NHS Number Status			System Data																					
+GE:ic_nhsnum_stat_desc	NHS Number Status Description			System Data																					
+GE:nhsnoind	NHS number status indicator			System Data																					
+GE:newnhsno_check	NHS Number valid flag			Patient Data																					
+GE:encrypted_hesid	NHS Patient identifier		unique identifiers	System Data																					
+GE:nhs_number_status	nhs_number_status		Genomics England																						
+GE:numacp	Number of augmented care periods within episode		history of augmented care	Augmented/critical care period																					
+GE:numbaby	Number of babies		pregnancy history	Maternity																					
+GE:numtailb	Number of baby tails			Maternity																					
+GE:nodiags	Number of Diagnoses			Clinical Diagnosis|Clinical diagnoses	disease or trauma																				
+GE:noinvests	Number of Investigations		laboratory measures|physiological measurements	Clinical Investigations																					
+GE:orgsup_1	Number of organ systems supported		history of organ support	Augmented/critical care period																					
+GE:numpreg	Number of previous pregnancies		pregnancy history	Maternity																					
+GE:noprocs	Number of Procedures		surgical interventions	Clinical Diagnosis																					
+GE:notreats	Number of Treatments		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:number_of_cycles_planned	number_of_cycles_planned		use of anti-cancer drugs																						
+GE:opcs_delivery_code	opcs_delivery_code		Genomics England		OPCS code to identify delivery (of baby?)																				
+GE:opcs_procurement_code	opcs_procurement_code		Genomics England		OPCS code to identify procurement																				
+GE:opcs43	opcs43			Procedure|Geographical																					
+GE:opdate_02	opdate_02		surgical interventions	Clinical																					
+GE:opdate_03	opdate_03		surgical interventions	Clinical																					
+GE:opdate_04	opdate_04		surgical interventions	Clinical																					
+GE:opdate_05	opdate_05		surgical interventions	Clinical																					
+GE:opdate_06	opdate_06		surgical interventions	Clinical																					
+GE:opdate_07	opdate_07		surgical interventions	Clinical																					
+GE:opdate_08	opdate_08		surgical interventions	Clinical																					
+GE:opdate_09	opdate_09		surgical interventions	Clinical																					
+GE:opdate_10	opdate_10		surgical interventions	Clinical																					
+GE:opdate_11	opdate_11		surgical interventions	Clinical																					
+GE:opdate_12	opdate_12		surgical interventions	Clinical																					
+GE:opdate_13	opdate_13		surgical interventions	Clinical																					
+GE:opdate_14	opdate_14		surgical interventions	Clinical																					
+GE:opdate_15	opdate_15		surgical interventions	Clinical																					
+GE:opdate_16	opdate_16		surgical interventions	Clinical																					
+GE:opdate_17	opdate_17		surgical interventions	Clinical																					
+GE:opdate_18	opdate_18		surgical interventions	Clinical																					
+GE:opdate_19	opdate_19		surgical interventions	Clinical																					
+GE:opdate_20	opdate_20		surgical interventions	Clinical																					
+GE:opdate_21	opdate_21		surgical interventions	Clinical																					
+GE:opdate_22	opdate_22		surgical interventions	Clinical																					
+GE:opdate_23	opdate_23		surgical interventions	Clinical																					
+GE:opdate_24	opdate_24		surgical interventions	Clinical																					
+GE:operstat	Operation status code		surgical interventions	Clinical																					
+GE:opertn_01	Operative procedure		surgical interventions	Clinical																					
+GE:opertn_02	opertn_02		surgical interventions	Clinical																					
+GE:opertn_03	opertn_03		surgical interventions	Clinical																					
+GE:opertn_04	opertn_04		surgical interventions	Clinical																					
+GE:opertn_05	opertn_05		surgical interventions	Clinical																					
+GE:opertn_06	opertn_06		surgical interventions	Clinical																					
+GE:opertn_07	opertn_07		surgical interventions	Clinical																					
+GE:opertn_08	opertn_08		surgical interventions	Clinical																					
+GE:opertn_09	opertn_09		surgical interventions	Clinical																					
+GE:opertn_10	opertn_10		surgical interventions	Clinical																					
+GE:opertn_11	opertn_11		surgical interventions	Clinical																					
+GE:opertn_12	opertn_12		surgical interventions	Clinical																					
+GE:opertn_13	opertn_13		surgical interventions	Clinical																					
+GE:opertn_14	opertn_14		surgical interventions	Clinical																					
+GE:opertn_15	opertn_15		surgical interventions	Clinical																					
+GE:opertn_16	opertn_16		surgical interventions	Clinical																					
+GE:opertn_17	opertn_17		surgical interventions	Clinical																					
+GE:opertn_18	opertn_18		surgical interventions	Clinical																					
+GE:opertn_19	opertn_19		surgical interventions	Clinical																					
+GE:opertn_20	opertn_20		surgical interventions	Clinical																					
+GE:opertn_21	opertn_21		surgical interventions	Clinical																					
+GE:opertn_22	opertn_22		surgical interventions	Clinical																					
+GE:opertn_23	opertn_23		surgical interventions	Clinical																					
+GE:opertn_24	opertn_24		surgical interventions	Clinical																					
+GE:hatreat	Ordnance Survey grid reference			Geographical|Organisation data																					
+GE:organisation	Organisation		Genomics England																						
+GE:ic_prov_orgcode	Organisation Code			Organisation	organization that submitted imaging record																				
+GE:ic_submit_orgcode	Organisation Code			Organisation	organization that submitted imaging record																				
+GE:orgpppid	Organisation code (patient pathway ID issuer)		unique identifiers	Clinical|Patient Pathway																					
+GE:organisation_data	Organisation data		Genomics England																						
+GE:organisation_data	Organisation Data		Genomics England		details about the provider, health authority, etc. (Broad)																				
+GE:ic_submit_orgname	Organisation Name			Organisation	organization that submitted imaging record																				
+GE:orgsup_2	orgsup_2		history of organ support	Augmented/critical care period																					
+GE:orgsup_3	orgsup_3		history of organ support	Augmented/critical care period																					
+GE:orgsup_4	orgsup_4		history of organ support	Augmented/critical care period																					
+GE:orgsup_5	orgsup_5		history of organ support	Augmented/critical care period																					
+GE:orgsup_6	orgsup_6		history of organ support	Augmented/critical care period																					
+GE:orgsup_7	orgsup_7		history of organ support	Augmented/critical care period																					
+GE:orgsup_8	orgsup_8		history of organ support	Augmented/critical care period																					
+GE:orgsup_9	orgsup_9		history of organ support	Augmented/critical care period																					
+GE:orgsupmax	orgsupmax		history of organ support	Critical care adult activity data																					
+GE:ccg_responsibility_origin	Origin of CCG of Responsibility			Geographical	how CCG responsibility was assigned																				
+GE:ccg_treatment_origin	Origin of CCG of Treatment			Geographical	how CCG treament was assigned																				
+GE:pctorig02	Origin of PCT of responsibility (2002)			System Data																					
+GE:pctorig06	Origin of PCT of responsibility (2006)			System Data																					
+GE:pcgorig	Origin of primary care group			System Data																					
+GE:pctorig	Origin of primary care trust of responsibility			System Data																					
+GE:pctorig_his	Origin of primary care trust of responsibility dependent on the data year			System Data																					
+GE:outcome	Outcome of attendance			Appointments																					
+GE:classpat	Patient classification			Clinical; Period of Care	ordinary, day, night, delivery, etc.																				
+GE:patient_data	Patient Data		Genomics England																						
+GE:aepatgroup	Patient group			Attendances																					
+GE:participant_id	Patient identifier		unique identifiers	System Data																					
+GE:patient_pathway	Patient Pathway		Genomics England																						
+GE:did_patsource_code	Patient Source Setting		Genomics England																						
+GE:ic_patsource_desc	Patient Source Setting Description			Patient Source Setting																					
+GE:patient_death	patient_death			Administrative																					
+GE:patient_pseudo_id	patient_pseudo_id		Genomics England																						
+GE:respct	PCT of residence - mapped according to data year		residence	Geographical																					
+GE:respct_his	PCT of residence - mapped according to data year		residence	Geographical																					
+GE:respct02	PCT of residence (2002)		residence	Geographical																					
+GE:respct06	PCT of residence (2006)		residence	Geographical																					
+GE:pctcode02	PCT of responsibility (2002)			Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
+GE:pctcode06	PCT of responsibility (2006)			Organisation|System Data|Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
+GE:pctcode	PCT of responsibility dependent on the data year			System Data																					
+GE:pctcode_his	PCT of responsibility dependent on the data year			System Data|Geographical																					
+GE:perf_stat_start_of_cycle_clean	perf_stat_start_of_cycle_clean		Genomics England		activity/disability status																				
+GE:perf_stat_start_of_reg_clean	perf_stat_start_of_reg_clean		Genomics England		activity/disability status																				
+GE:q1_discomfort	PO4			Pre-Operative (Q1)																					
+GE:post_operative_q2	Post-Operative (Q2)		Genomics England		questions about QOL after surgery, does this fall under 'surgical'?																				
+GE:posopdur	Post-operative duration		surgical interventions	Clinical																					
+GE:postdist	Postcode district			Patient Data																					
+GE:pcfound	Postcode Found			Patient Data																					
+GE:postdur	Postnatal stay			Maternity																					
+GE:q2_activity	PostOp3			Post-Operative (Q2)																					
+GE:q2_discomfort	PostOp4			Post-Operative (Q2)																					
+GE:q2_anxiety	PostOp5			Post-Operative (Q2)																					
+GE:practitioner	Practitioner		Genomics England																						
+GE:practitioner_data	Practitioner data		physician/practitioner info																						
+GE:pre_operative_q1	Pre-Operative (Q1)		Genomics England		questions about QOL before surgery, does this fall under 'surgical'?																				
+GE:preopdur	Pre-operative duration		surgical interventions	Clinical																					
+GE:q1_activity	PreOp3			Pre-Operative (Q1)	does pre-op fall under surgical?																				
+GE:q1_anxiety	PreOp5			Pre-Operative (Q1)																					
+GE:pcgcode	Primary care group			Organisation	PCG responsible for patient																				
+GE:pctnhs	Primary care trust			System Data|Organisation Data																					
+GE:pcttreat	Primary Care Trust area of main provider			Geographical|System Data																					
+GE:gpprpct	Primary Care Trust area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (PCT)																				
+GE:primary_diagnosis	primary_diagnosis		oncological																						
+GE:primercp	primercp		Genomics England																						
+GE:primerecp	primerecp			Geographical																					
+GE:alcdiag	Principal alcohol related diagnosis		alcohol	Diagnosis																					
+GE:alcdiag_4	Principal alcohol related diagnosis		alcohol	Diagnosis																					
+GE:alcfrac	Principal alcohol related fraction		alcohol	Diagnosis																					
+GE:priority	Priority type			Appointments																					
+GE:procedure	Procedure		Genomics England																						
+GE:proc_revision_flag	Procedure Revision Flag			Administrative																					
+GE:programme_number	programme_number		Genomics England		Chronological order of SACT drug programme since commencement of patient's disease management																				
+GE:proms_proc_code	Proms Procedure Code			Administrative																					
+GE:proms_proc_group	proms_proc_group			Administrative																					
+GE:proms_serial_no	proms_serial_no			Administrative																					
+GE:provider	Provider		physician/practitioner info																						
+GE:procode	Provider Code			Organisation data|Appointments	code of organization acting as health care provider																				
+GE:procode3	Provider code (3 character)			Organisation|Organisation data																					
+GE:procode5	Provider code (5 character)			Organisation	code of organization acting as health care provider																				
+GE:procodet	Provider code of treatment			Organisation|Organisation data	combo of 3 and 5 character codes																				
+GE:ic_provname	Provider Name			Provider																					
+GE:provider_sha	Provider SHA		physician/practitioner info																						
+GE:ic_prov_shacode	Provider SHA Code			Provider SHA																					
+GE:ic_prov_shaname	Provider SHA Name			Provider SHA																					
+GE:provider_site	Provider Site		physician/practitioner info																						
+GE:ic_sitecode	Provider Site Code			Provider Site																					
+GE:ic_sitename	Provider Site Name			Provider Site																					
+GE:protype	Provider type			Organisation|Organisation data	provdier type of organization																				
+GE:pgpprac	Pseudonymised code of GP practice			Organisation	registered GP																				
+GE:psychiatric	Psychiatric		Genomics England																						
+GE:admistat	Psychiatric history on admission		mental and behaviour disorders	Psychiatric																					
+GE:kr_q1_confidence	Q1 - KR10		signs and symptoms	Knee Replacement - Q1	may be too broad?																				
+GE:kr_q1_kneeling	Q1 - KR8		signs and symptoms	Knee Replacement - Q1																					
+GE:q1_assisted	q1_assisted			Pre-Operative (Q1)																					
+GE:q1_assisted_by	q1_assisted_by			Pre-Operative (Q1)																					
+GE:q1_complete	q1_complete			Pre-Operative (Q1)																					
+GE:q1_completed_date	q1_completed_date			Pre-Operative (Q1)																					
+GE:q1_disability	q1_disability			Pre-Operative (Q1)																					
+GE:q1_eq5d_health_scale	q1_eq5d_health_scale			Pre-Operative (Q1)																					
+GE:q1_eq5d_index	q1_eq5d_index			Pre-Operative (Q1)																					
+GE:q1_eq5d_profile	q1_eq5d_profile			Pre-Operative (Q1)																					
+GE:q1_eq5d_profile_complete	q1_eq5d_profile_complete			Pre-Operative (Q1)																					
+GE:q1_eq5d_scale_complete	q1_eq5d_scale_complete			Pre-Operative (Q1)																					
+GE:q1_form_version	q1_form_version			Pre-Operative (Q1)																					
+GE:q1_general_health	q1_general_health			Pre-Operative (Q1)																					
+GE:q1_language	q1_language			Pre-Operative (Q1)																					
+GE:q1_living_arrangements	q1_living_arrangements			Pre-Operative (Q1)																					
+GE:q1_mobility	q1_mobility			Pre-Operative (Q1)																					
+GE:q1_previous_surgery	q1_previous_surgery			Pre-Operative (Q1)																					
+GE:q1_procode	q1_procode			Pre-Operative (Q1)																					
+GE:q1_received_date	q1_received_date			Pre-Operative (Q1)																					
+GE:q1_scan_date	q1_scan_date			Pre-Operative (Q1)																					
+GE:q1_self_care	q1_self_care			Pre-Operative (Q1)																					
+GE:q1_symptom_period	q1_symptom_period			Pre-Operative (Q1)																					
+GE:hr_q1_pain	Q1-HR1			Hip Replacement - Q1																					
+GE:hr_q1_stairs	Q1-HR10			Hip Replacement - Q1																					
+GE:hr_q1_standing	Q1-HR11			Hip Replacement - Q1																					
+GE:hr_q1_work	Q1-HR12			Hip Replacement - Q1																					
+GE:hr_q1_sudden_pain	Q1-HR2			Hip Replacement - Q1																					
+GE:hr_q1_night_pain	Q1-HR3			Hip Replacement - Q1																					
+GE:hr_q1_washing	Q1-HR4			Hip Replacement - Q1																					
+GE:hr_q1_transport	Q1-HR5			Hip Replacement - Q1																					
+GE:hr_q1_dressing	Q1-HR6			Hip Replacement - Q1																					
+GE:hr_q1_shopping	Q1-HR7			Hip Replacement - Q1																					
+GE:hr_q1_walking	Q1-HR8			Hip Replacement - Q1																					
+GE:hr_q1_limping	Q1-HR9			Hip Replacement - Q1																					
+GE:kr_q1_pain	Q1-KR1		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_shopping	Q1-KR11		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_stairs	Q1-KR12		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_night_pain	Q1-KR2		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_washing	Q1-KR3		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_transport	Q1-KR4		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_score	Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_walking	Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_standing	Q1-KR6		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_limping	Q1-KR7		signs and symptoms	Knee Replacement - Q1																					
+GE:kr_q1_work	Q1-KR9		signs and symptoms	Knee Replacement - Q1																					
+GE:vv_q1_right_support	Q1-VV		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_painkiller_days	Q1-VV1		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_itch	Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_itch	Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_discolour	Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_discolour	Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_rash	Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_rash	Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_ulcer	Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_ulcer	Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_swelling	Q1-VV2		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q2_swelling	Q1-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q1_concern	Q1-VV3		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_clothing	Q1-VV4		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_work	Q1-VV5		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q2_work	Q1-VV5		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q1_leisure	Q1-VV6		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_back_count	Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_front_count	Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_back_count	Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_front_count	Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_pain_days	Q1-VV8		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_left_support	Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_right_pain_days	Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:q2_allergy	q2_allergy			Post-Operative (Q2)																					
+GE:q2_assisted	q2_assisted			Post-Operative (Q2)																					
+GE:q2_assisted_by	q2_assisted_by			Post-Operative (Q2)																					
+GE:q2_bleeding	q2_bleeding			Post-Operative (Q2)																					
+GE:q2_complete	q2_complete			Post-Operative (Q2)																					
+GE:q2_completed_date	q2_completed_date			Post-Operative (Q2)																					
+GE:q2_disability	q2_disability			Post-Operative (Q2)																					
+GE:q2_eq5d_health_scale	q2_eq5d_health_scale			Post-Operative (Q2)																					
+GE:q2_eq5d_index	q2_eq5d_index			Post-Operative (Q2)																					
+GE:q2_eq5d_profile	q2_eq5d_profile			Post-Operative (Q2)																					
+GE:q2_eq5d_profile_complete	q2_eq5d_profile_complete			Post-Operative (Q2)																					
+GE:q2_eq5d_scale_complete	q2_eq5d_scale_complete			Post-Operative (Q2)																					
+GE:q2_form_version	q2_form_version			Post-Operative (Q2)																					
+GE:q2_further_surgery	q2_further_surgery		pregnancy history	Post-Operative (Q2)																					
+GE:q2_general_health	q2_general_health			Post-Operative (Q2)																					
+GE:q2_language	q2_language			Post-Operative (Q2)																					
+GE:q2_living_arrangements	q2_living_arrangements			Post-Operative (Q2)																					
+GE:q2_mobility	q2_mobility			Post-Operative (Q2)																					
+GE:q2_readmitted	q2_readmitted			Post-Operative (Q2)																					
+GE:q2_received_date	q2_received_date			Post-Operative (Q2)																					
+GE:q2_satisfaction	q2_satisfaction			Post-Operative (Q2)																					
+GE:q2_scan_date	q2_scan_date			Post-Operative (Q2)																					
+GE:q2_self_care	q2_self_care			Post-Operative (Q2)																					
+GE:q2_success	q2_success			Post-Operative (Q2)																					
+GE:q2_surgery_date	q2_surgery_date			Post-Operative (Q2)																					
+GE:q2_urine	q2_urine			Post-Operative (Q2)																					
+GE:q2_wound	q2_wound			Post-Operative (Q2)																					
+GE:hr_q2_pain	Q2-HR1			Hip Replacement - Q2																					
+GE:hr_q2_stairs	Q2-HR10			Hip Replacement - Q2																					
+GE:hr_q2_standing	Q2-HR11			Hip Replacement - Q2																					
+GE:hr_q2_work	Q2-HR12			Hip Replacement - Q2																					
+GE:hr_q2_sudden_pain	Q2-HR2			Hip Replacement - Q2																					
+GE:hr_q2_night_pain	Q2-HR3			Hip Replacement - Q2																					
+GE:hr_q2_washing	Q2-HR4			Hip Replacement - Q2																					
+GE:hr_q2_transport	Q2-HR5			Hip Replacement - Q2																					
+GE:hr_q2_dressing	Q2-HR6			Hip Replacement - Q2																					
+GE:hr_q2_shopping	Q2-HR7			Hip Replacement - Q2																					
+GE:hr_q2_walking	Q2-HR8			Hip Replacement - Q2																					
+GE:hr_q2_limping	Q2-HR9			Hip Replacement - Q2																					
+GE:kr_q2_pain	Q2-KR1		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_confidence	Q2-KR10		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_shopping	Q2-KR11		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_night_pain	Q2-KR2		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_washing	Q2-KR3		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_transport	Q2-KR4		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_walking	Q2-KR5		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_standing	Q2-KR6		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_limping	Q2-KR7		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_kneeling	Q2-KR8		signs and symptoms	Knee Replacement - Q2																					
+GE:kr_q2_work	Q2-KR9		signs and symptoms	Knee Replacement - Q2																					
+GE:vv_q2_right_support	Q2-VV		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_painkiller_days	Q2-VV1		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_itch	Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_itch	Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_discolour	Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_discolour	Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_rash	Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_rash	Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_ulcer	Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_ulcer	Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_visible	Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_visible	Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_concern	Q2-VV3		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_clothing	Q2-VV4		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_leisure	Q2-VV6		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_back_count	Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_front_count	Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_back_count	Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_front_count	Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_pain_days	Q2-VV8		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_left_support	Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_right_pain_days	Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:epikey	Record identifier		unique identifiers	System Data																					
+GE:aekey	Record identifier			System Data																					
+GE:attendkey	Record Identifier			System Data																					
+GE:submissiondataid	Record identifier		unique identifiers	System Data|Administrative																					
+GE:reqdate	Referral request received date			Practitioner																					
+GE:rttperstart	REFERRAL TO TREATMENT- RTT period start date			Patient Pathway																					
+GE:ic_refer_orgname	Referrer		Genomics England																						
+GE:referrer	Referrer code			Practitioner																					
+GE:referrer_organisation	Referrer Organisation		physician/practitioner info																						
+GE:did_refer_orgcode	Referrer Organisation code			Referrer Organisation																					
+GE:ic_reftype_desc	Referrer type		Genomics England																						
+GE:referorg	Referring organisation code			Practitioner																					
+GE:regimen_mod_dose_reduction	regimen_mod_dose_reduction		posology																						
+GE:regimen_mod_stopped_early	regimen_mod_stopped_early		use of anti-cancer drugs																						
+GE:regimen_mod_time_delay	regimen_mod_time_delay		use of anti-cancer drugs		extending time between administration - is this prescription or admin method?																				
+GE:regimen_number	regimen_number				Chronological order of SACT drug regimen since commencement of patient's disease management																				
+GE:regimen_outcome_summary	regimen_outcome_summary		use of anti-cancer drugs		anti cancer drug program completed or not																				
+GE:ic_region_desc	Region		Genomics England																						
+GE:ic_region_id	Region ID			Region																					
+GE:gppracro	Regional Office area where patient‚Äö√Ñ√¥s GP was registered			Organisation	where GP is registered																				
+GE:resro	Regional Office of residence		residence	Geographical																					
+GE:rotreat	Regional Office of treatment			Geographical																					
+GE:rensupdays	rensupdays		history of renal support	Critical care adult activity data																					
+GE:perend	Reporting period end date			System Data																					
+GE:reportingperiod_enddate	reportingperiod_enddate		Genomics England																						
+GE:reportingperiod_startdate	reportingperiod_startdate		Genomics England																						
+GE:resstha_his	resstha_his		Genomics England																						
+GE:biresus_1	Resuscitation Method			Maternity	resusciation for baby - may be drugs or non-pharm																				
+GE:rttperend	RTT period end date			Patient Pathway																					
+GE:rttperstat	RTT period status			Patient Pathway																					
+GE:rururb_ind	Rural/Urban Indicator			Geographical																					
+GE:score_change	score_change			Scoring																					
+GE:scoring	Scoring		Genomics England		not sure this maps to anything																				
+GE:did_date4	Service Report Issue Date			Diagnostic Test Dates																					
+GE:servtype	Service type requested			Appointments																					
+GE:sexbaby_1	Sex of baby		pregnancy history|biological sex	Maternity																					
+GE:sex	Sex of patient		biological sex	Patient Data|Appointments																					
+GE:sexbaby_2	sexbaby_2		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_3	sexbaby_3		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_4	sexbaby_4		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_5	sexbaby_5		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_6	sexbaby_6		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_7	sexbaby_7		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_8	sexbaby_8		pregnancy history|biological sex	Maternity																					
+GE:sexbaby_9	sexbaby_9		pregnancy history|biological sex	Maternity																					
+GE:sthatret	SHA area of treatment			Geographical|Appointments																					
+GE:resstha	SHA of residence		residence	Geographical																					
+GE:resstha02	SHA of residence (2002)		residence	Geographical																					
+GE:resstha06	SHA of residence (2006)		residence	Geographical																					
+GE:sitetret	Site code of treatment			Geographical|Patient Data																					
+GE:socio_economic	Socio-economic		Genomics England																						
+GE:aerefsource	Source of referral for A&E			Attendances																					
+GE:stage_at_start	stage_at_start		oncological		tumor/metastasis stage before treatment																				
+GE:start_date_of_cycle	start_date_of_cycle		life stage/time point																						
+GE:start_date_of_regimen	start_date_of_regimen		life stage/time point																						
+GE:status	status			Scoring																					
+GE:censtat	Status of patient included in psychiatric census			Psychiatric	detained or not detained, long term																				
+GE:delstat_1	Status of person conducting delivery		physician/practitioner info	Maternity	is this also part of pregnancy history?																				
+GE:status_date	status_date			Scoring																					
+GE:gpprstha	Strategic Health Authority area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (SHA)																				
+GE:stroke	stroke		occurrence of stroke	Indicators																					
+GE:ic_sub_cancer_desc	Sub Early cancer diagnosis		Genomics England																						
+GE:ic_sub_modality_desc	Sub Modality		Genomics England																						
+GE:ic_sub_modality_id	Sub Modality ID			Sub Modality																					
+GE:ic_sub_region_desc	Sub Region		Genomics England																						
+GE:ic_sub_region_id	Sub Region ID			Sub Region																					
+GE:ic_sub_sys_desc	Sub System		Genomics England																						
+GE:ic_sub_sys_id	Sub System ID			Sub System																					
+GE:ic_sub_syscomp_desc	Sub-System Component		Genomics England																						
+GE:ic_sub_syscomp_id	Sub-System Component ID			Sub-System Component																					
+GE:subdate	Submission date			System Data|Geographical																					
+GE:supplied_date_of_birth	supplied_date_of_birth		age/birthdate																						
+GE:supplied_gender	supplied_gender		gender																						
+GE:suscorehrg	SUS generated Core Spell HRG			Healthcare resource groups (HRG) data																					
+GE:sushrg	SUS generated HRG			Healthcare resource groups (HRG) data																					
+GE:sushrginfo	SUS generated HRG for information			Healthcare resource groups (HRG) data																					
+GE:sushrgvers	SUS generated HRG version number			Healthcare resource groups (HRG) data																					
+GE:sushrgverinfo	SUS generated HRG version number			System Data																					
+GE:susspellid	SUS generated spell identifier			System Data																					
+GE:suslddate	SUS loaded staging date			System Data|Healthcare resource groups (HRG) data																					
+GE:susrecid	SUS record ID		unique identifiers	System Data|System data																					
+GE:ic_system_desc	System		Genomics England																						
+GE:system_data	System Data		Genomics England																						
+GE:system_data	System data		Genomics England																						
+GE:ic_system_id	System ID			System																					
+GE:ic_date2_to_date4	Test Request Received to Service (test) Report Issue		Genomics England																						
+GE:ic_date2_to_date3	Test Request Received to Test		Genomics England																						
+GE:ic_date1_to_date4	Test Request to Service (Test) Report Issue		Genomics England																						
+GE:ic_date1_to_date3	Test Request to Test		Genomics England																						
+GE:ic_date1_to_date2	Test Request to Test Request Received		Genomics England																						
+GE:ic_date3_to_date4	Test to Service (Test) Report Issue		Genomics England																						
+GE:trettime	Time seen for treatment			Attendances																					
+GE:treat_02	treat_02		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_03	treat_03		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_04	treat_04		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_05	treat_05		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_06	treat_06		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_07	treat_07		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_08	treat_08		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_09	treat_09		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_10	treat_10		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_11	treat_11		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat_12	treat_12		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_02	treat2_02		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_03	treat2_03		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_04	treat2_04		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_05	treat2_05		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_06	treat2_06		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_07	treat2_07		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_08	treat2_08		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_09	treat2_09		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_10	treat2_10		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_11	treat2_11		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:treat2_12	treat2_12		medication history|non-pharmacological interventions	Clinical Treatments																					
+GE:tretspef	Treatment specialty		physician/practitioner info	Clinical; Period of Care																					
+GE:domproc	Trust derived dominant procedure			Healthcare resource groups (HRG) data	procedure code submitted to SUS - is this a surgical procedure?																				
+GE:hrgnhs	Trust derived HRG value			Healthcare resource groups (HRG) data|Patient Data																					
+GE:hrglate35	Trust derived HRG value v3.5			Healthcare resource groups (HRG) data																					
+GE:tumour_pseudo_id	tumour_pseudo_id		Genomics England																						
+GE:unitbedconfig	unitbedconfig			Critical care adult admission and discharge data	level 2 beds, level 3 beds, or flexible - in unit																				
+GE:vind	V code indicator			Psychiatric																					
+GE:varicose_vein_q1	Varicose Vein - Q1		occurrence of varicose veins																						
+GE:varicose_vein_q2	Varicose Vein - Q2		occurrence of varicose veins																						
+GE:hrgnhsvn	Version No. of Trust derived HRG			Healthcare resource groups (HRG) data																					
+GE:vv_score_expected_final_model3	VV Score Final Predicted (Model 3)			Scoring																					
+GE:vv_q1_max_score	vv_q1_max_score		occurrence of varicose veins	Varicose Vein - Q1																					
+GE:vv_q1_score	vv_q1_score			Scoring																					
+GE:vv_q1_score_complete	vv_q1_score_complete			Scoring																					
+GE:vv_q1_total_score	vv_q1_total_score			Scoring																					
+GE:vv_q2_max_score	vv_q2_max_score		occurrence of varicose veins	Varicose Vein - Q2																					
+GE:vv_q2_score	vv_q2_score			Scoring																					
+GE:vv_q2_score_complete	vv_q2_score_complete			Scoring																					
+GE:vv_q2_total_score	vv_q2_total_score			Scoring																					
+GE:wait_ind	Waiting calculation indicator			Clinical	if and how 'Days Waiting' was calculated - timeline?																				
+GE:cenward	Ward type at psychiatric census date			Psychiatric	characteristics of the ward																				
+GE:wardstrt	Ward type at start of episode			Episodes and spells; Period of care																					
+GE:weight_at_start_of_cycle	weight_at_start_of_cycle		weight																						
+GE:weight_at_start_of_regimen	weight_at_start_of_regimen		weight																						
+GE:well_baby_ind	Well baby flag		pregnancy history	Maternity																					
+GE:pcon	Westminster parliamentary constituency			Geographical																					
+GE:pcon_ons	Westminster parliamentary constituency (ONS)			Geographical																					
+GE:partyear	Year and month of HES dataset			Episodes and spells; Period of care|Appointments																					
+GE:did_date3_year	Year of Test			Diagnostic Test Dates																					
+																									

--- a/mappings/genomics-england-mapping.tsv
+++ b/mappings/genomics-england-mapping.tsv
@@ -1,1254 +1,1254 @@
-ID	Label	Class Type	GECKO Label	Comment																				
-ID	LABEL	CLASS_TYPE	C % SPLIT=|																					
-GE:system_data	System Data																							
-GE:augmented_critical_care_period	Augmented/critical care period																							
-GE:diagnosis	Diagnosis		diseases																					
-GE:patient_data	Patient Data																							
-GE:admissions_period_of_care	Admissions; Period of Care																							
-GE:psychiatric	Psychiatric																							
-GE:maternity	Maternity																							
-GE:geographical	Geographical																							
-GE:episodes_and_spells_period_of_care	Episodes and spells; Period of care																							
-GE:clinical	Clinical																							
-GE:clinical_period_of_care	Clinical; Period of Care																							
-GE:practitioner	Practitioner																							
-GE:organisation	Organisation																							
-GE:discharges_period_of_care	Discharges; Period of Care																							
-GE:healthcare_resource_groups_hrg_data	Healthcare resource groups (HRG) data																							
-GE:patient_pathway	Patient Pathway																							
-GE:socio_economic	Socio-economic																							
-GE:procedure	Procedure																							
-GE:organisation_data	Organisation data																							
-GE:system_data	System data																							
-GE:critical_care_adult_activity_data	Critical care adult activity data																							
-GE:critical_care_period_of_care	Critical care period of care																							
-GE:critical_care_adult_admission_and_discharge_data	Critical care adult admission and discharge data																							
-GE:critical_care_admission_and_discharge_data	Critical care admission and discharge data																							
-GE:critical_care_start_date	Critical care start date																							
-GE:appointments	Appointments																							
-GE:clinical_diagnosis	Clinical Diagnosis																							
-GE:organisation_data	Organisation Data																							
-GE:attendances	Attendances																							
-GE:clinical_diagnoses	Clinical diagnoses																							
-GE:clinical_diagnoses	Clinical Diagnoses																							
-GE:practitioner_data	Practitioner data																							
-GE:clinical_investigations	Clinical Investigations																							
-GE:clinical_treatments	Clinical Treatments																							
-GE:diagnostic_test_dates	Diagnostic Test Dates																							
-GE:ethnic_category	Ethnic Category																							
-GE:imaging_codes	Imaging Codes																							
-GE:referrer_organisation	Referrer Organisation																							
-GE:age_bands	Age Bands																							
-GE:cancer_diagnosis	Cancer diagnosis																							
-GE:ccg	CCG																							
-GE:location	Location																							
-GE:commissioning_organisation	Commissioning Organisation																							
-GE:provider_sha	Provider SHA																							
-GE:provider	Provider																							
-GE:provider_site	Provider Site																							
-GE:indicators	Indicators																							
-GE:administrative	Administrative																							
-GE:scoring	Scoring																							
-GE:hip_replacement_q1	Hip Replacement - Q1																							
-GE:hip_replacement_q2	Hip Replacement - Q2																							
-GE:hip_replacement	Hip Replacement																							
-GE:knee_replacement_q1	Knee Replacement - Q1																							
-GE:knee_replacement_q2	Knee Replacement - Q2																							
-GE:pre_operative_q1	Pre-Operative (Q1)																							
-GE:post_operative_q2	Post-Operative (Q2)																							
-GE:varicose_vein_q1	Varicose Vein - Q1																							
-GE:varicose_vein_q2	Varicose Vein - Q2																							
-GE:participant_id	Patient identifier																							
-GE:epikey	Record identifier																							
-GE:encrypted_hesid	NHS Patient identifier																							
-GE:match_rank	match_rank																							
-GE:susrecid	SUS record ID																							
-GE:acpdisp_1	ACPDISP_N																							
-GE:acpdisp_2	ACPDISP_N																							
-GE:acpdisp_3	ACPDISP_N																							
-GE:acpdisp_4	ACPDISP_N																							
-GE:acpdisp_5	ACPDISP_N																							
-GE:acpdisp_6	ACPDISP_N																							
-GE:acpdisp_7	ACPDISP_N																							
-GE:acpdisp_8	ACPDISP_N																							
-GE:acpdisp_9	ACPDISP_N																							
-GE:acpdqind_1	ACPDQIND_N																							
-GE:acpdqind_2	acpdqind_2																							
-GE:acpdqind_3	acpdqind_3																							
-GE:acpdqind_4	acpdqind_4																							
-GE:acpdqind_5	acpdqind_5																							
-GE:acpdqind_6	acpdqind_6																							
-GE:acpdqind_7	acpdqind_7																							
-GE:acpdqind_8	acpdqind_8																							
-GE:acpdqind_9	acpdqind_9																							
-GE:acpend_1	ACPEND_N																							
-GE:acpend_2	ACPEND_N																							
-GE:acpend_3	ACPEND_N																							
-GE:acpend_4	ACPEND_N																							
-GE:acpend_5	ACPEND_N																							
-GE:acpend_6	ACPEND_N																							
-GE:acpend_7	ACPEND_N																							
-GE:acpend_8	ACPEND_N																							
-GE:acpend_9	ACPEND_N																							
-GE:acploc_1	ACPLOC_N																							
-GE:acploc_2	ACPLOC_N																							
-GE:acploc_3	ACPLOC_N																							
-GE:acploc_4	ACPLOC_N																							
-GE:acploc_5	ACPLOC_N																							
-GE:acploc_6	ACPLOC_N																							
-GE:acploc_7	ACPLOC_N																							
-GE:acploc_8	ACPLOC_N																							
-GE:acploc_9	ACPLOC_N																							
-GE:acpn_1	ACPN_N																							
-GE:acpn_2	ACPN_N																							
-GE:acpn_3	ACPN_N																							
-GE:acpn_4	ACPN_N																							
-GE:acpn_5	ACPN_N																							
-GE:acpn_6	ACPN_N																							
-GE:acpn_7	ACPN_N																							
-GE:acpn_8	ACPN_N																							
-GE:acpn_9	ACPN_N																							
-GE:acpout_1	ACPOUT_N																							
-GE:acpout_2	ACPOUT_N																							
-GE:acpout_3	ACPOUT_N																							
-GE:acpout_4	ACPOUT_N																							
-GE:acpout_5	ACPOUT_N																							
-GE:acpout_6	ACPOUT_N																							
-GE:acpout_7	ACPOUT_N																							
-GE:acpout_8	ACPOUT_N																							
-GE:acpout_9	ACPOUT_N																							
-GE:acpplan_1	ACPPLAN_N																							
-GE:acpplan_2	ACPPLAN_N																							
-GE:acpplan_3	ACPPLAN_N																							
-GE:acpplan_4	ACPPLAN_N																							
-GE:acpplan_5	ACPPLAN_N																							
-GE:acpplan_6	ACPPLAN_N																							
-GE:acpplan_7	ACPPLAN_N																							
-GE:acpplan_8	ACPPLAN_N																							
-GE:acpplan_9	ACPPLAN_N																							
-GE:acpsour_1	ACPSOUR_N																							
-GE:acpsour_2	ACPSOUR_N																							
-GE:acpsour_3	ACPSOUR_N																							
-GE:acpsour_4	ACPSOUR_N																							
-GE:acpsour_5	ACPSOUR_N																							
-GE:acpsour_6	ACPSOUR_N																							
-GE:acpsour_7	ACPSOUR_N																							
-GE:acpsour_8	ACPSOUR_N																							
-GE:acpsour_9	ACPSOUR_N																							
-GE:acpspef_1	Augmented care period specialty function code																							
-GE:acpspef_2	Augmented care period specialty function code																							
-GE:acpspef_3	Augmented care period specialty function code																							
-GE:acpspef_4	Augmented care period specialty function code																							
-GE:acpspef_5	Augmented care period specialty function code																							
-GE:acpspef_6	Augmented care period specialty function code																							
-GE:acpspef_7	Augmented care period specialty function code																							
-GE:acpspef_8	Augmented care period specialty function code																							
-GE:acpspef_9	Augmented care period specialty function code																							
-GE:acpstar_1	Augmented care period start date																							
-GE:acpstar_2	Augmented care period start date																							
-GE:acpstar_3	Augmented care period start date																							
-GE:acpstar_4	Augmented care period start date																							
-GE:acpstar_5	Augmented care period start date																							
-GE:acpstar_6	Augmented care period start date																							
-GE:acpstar_7	Augmented care period start date																							
-GE:acpstar_8	Augmented care period start date																							
-GE:acpstar_9	Augmented care period start date																							
-GE:acscflag	Ambulatory Care Sensitive Condition Flag																							
-GE:activage	Age at activity date																							
-GE:admiage	Age on admission																							
-GE:admidate	Date of admission																							
-GE:admimeth	Method of admission																							
-GE:admincat	ADMINCAT																							
-GE:admincatst	Admin category at start of episode																							
-GE:admisorc	Admission source																							
-GE:admistat	Psychiatric history on admission																							
-GE:aekey	Record identifier																							
-GE:alcdiag	Principal alcohol related diagnosis																							
-GE:alcdiag_4	Principal alcohol related diagnosis																							
-GE:alcfrac	Principal alcohol related fraction																							
-GE:anagest	Gestation period in weeks at first antenatal assessment																							
-GE:anasdate	First antenatal assessment date																							
-GE:antedur	Antenatal days of stay																							
-GE:at_gp_practice	Area Team of GP Practice																							
-GE:at_residence	Area Team of Residence																							
-GE:at_treatment	Area Team of Treatment																							
-GE:bedyear	Bed days within the year																							
-GE:biresus_1	Resuscitation Method																							
-GE:biresus_2	BIRESUS_N																							
-GE:biresus_3	BIRESUS_N																							
-GE:biresus_4	BIRESUS_N																							
-GE:biresus_5	BIRESUS_N																							
-GE:biresus_6	BIRESUS_N																							
-GE:biresus_7	BIRESUS_N																							
-GE:biresus_8	BIRESUS_N																							
-GE:biresus_9	BIRESUS_N																							
-GE:birordr_1	Birth Order																							
-GE:birordr_2	BIRORDR_N																							
-GE:birordr_3	BIRORDR_N																							
-GE:birordr_4	BIRORDR_N																							
-GE:birordr_5	BIRORDR_N																							
-GE:birordr_6	BIRORDR_N																							
-GE:birordr_7	BIRORDR_N																							
-GE:birordr_8	BIRORDR_N																							
-GE:birordr_9	BIRORDR_N																							
-GE:birstat_1	Birth Status																							
-GE:birstat_2	BIRSTAT_N																							
-GE:birstat_3	BIRSTAT_N																							
-GE:birstat_4	BIRSTAT_N																							
-GE:birstat_5	BIRSTAT_N																							
-GE:birstat_6	BIRSTAT_N																							
-GE:birstat_7	BIRSTAT_N																							
-GE:birstat_8	BIRSTAT_N																							
-GE:birstat_9	BIRSTAT_N																							
-GE:birweit_1	Birth Weight																							
-GE:birweit_2	BIRWEIT_N																							
-GE:birweit_3	BIRWEIT_N																							
-GE:birweit_4	BIRWEIT_N																							
-GE:birweit_5	BIRWEIT_N																							
-GE:birweit_6	BIRWEIT_N																							
-GE:birweit_7	BIRWEIT_N																							
-GE:birweit_8	BIRWEIT_N																							
-GE:birweit_9	BIRWEIT_N																							
-GE:cannet	Cancer network																							
-GE:canreg	Cancer registry																							
-GE:carersi	Care Support Indicator																							
-GE:category	Administrative & legal status of patient																							
-GE:cause	Cause Code																							
-GE:ccg_gp_practice	CCG of GP Practice																							
-GE:ccg_residence	CCG of Residence																							
-GE:ccg_responsibility	CCG of Residence																							
-GE:ccg_responsibility_origin	Origin of CCG of Responsibility																							
-GE:ccg_treatment	CCG of Treatment																							
-GE:ccg_treatment_origin	Origin of CCG of Treatment																							
-GE:cdsextdate	CDS extract date																							
-GE:cdsverprotid	CDS protocol identifier																							
-GE:cdsversion	CDS version number																							
-GE:cendur	Duration of care to psychiatric census date																							
-GE:censage	Age at psychiatric census date																							
-GE:censtat	Status of patient included in psychiatric census																							
-GE:cenward	Ward type at psychiatric census date																							
-GE:classpat	Patient classification																							
-GE:consult	Consultant code																							
-GE:cr_gp_practice	Commissioning Region of GP Practice																							
-GE:cr_residence	Commissioning Region of Residence																							
-GE:cr_treatment	Commissioning Region of Treatment																							
-GE:csnum	Commissioning serial number																							
-GE:currward	Current electoral ward																							
-GE:currward_ons	Current electoral ward (ONS)																							
-GE:delchang	Delivery place change reason																							
-GE:delinten	Delivery place (intended)																							
-GE:delmeth_1	Alternative Delivery method (Derived)																							
-GE:delmeth_2	delmeth_2																							
-GE:delmeth_3	delmeth_3																							
-GE:delmeth_4	delmeth_4																							
-GE:delmeth_5	delmeth_5																							
-GE:delmeth_6	delmeth_6																							
-GE:delmeth_7	delmeth_7																							
-GE:delmeth_8	delmeth_8																							
-GE:delmeth_9	delmeth_9																							
-GE:delmeth_d	delmeth_d																							
-GE:delonset	Labour/delivery onset method																							
-GE:delplac_1	Delivery place (actual)																							
-GE:delplac_2	delplac_2																							
-GE:delplac_3	delplac_3																							
-GE:delplac_4	delplac_4																							
-GE:delplac_5	delplac_5																							
-GE:delplac_6	delplac_6																							
-GE:delplac_7	delplac_7																							
-GE:delplac_8	delplac_8																							
-GE:delplac_9	delplac_9																							
-GE:delposan	Anaesthetic given post-labour or delivery																							
-GE:delprean	Anaesthetic given during labour or delivery																							
-GE:delstat_1	Status of person conducting delivery																							
-GE:delstat_2	delstat_2																							
-GE:delstat_3	delstat_3																							
-GE:delstat_4	delstat_4																							
-GE:delstat_5	delstat_5																							
-GE:delstat_6	delstat_6																							
-GE:delstat_7	delstat_7																							
-GE:delstat_8	delstat_8																							
-GE:delstat_9	delstat_9																							
-GE:depdays_1	High-dependency care level																							
-GE:depdays_2	depdays_2																							
-GE:depdays_3	depdays_3																							
-GE:depdays_4	depdays_4																							
-GE:depdays_5	depdays_5																							
-GE:depdays_6	depdays_6																							
-GE:depdays_7	depdays_7																							
-GE:depdays_8	depdays_8																							
-GE:depdays_9	depdays_9																							
-GE:detdur	Duration of detention																							
-GE:detndate	Date detention commenced																							
-GE:diag_01	All Diagnosis codes																							
-GE:diag_02	diag_02																							
-GE:diag_03	diag_03																							
-GE:diag_04	diag_04																							
-GE:diag_05	diag_05																							
-GE:diag_06	diag_06																							
-GE:diag_07	diag_07																							
-GE:diag_08	diag_08																							
-GE:diag_09	diag_09																							
-GE:diag_10	diag_10																							
-GE:diag_11	diag_11																							
-GE:diag_12	diag_12																							
-GE:diag_13	diag_13																							
-GE:diag_14	diag_14																							
-GE:diag_15	diag_15																							
-GE:diag_16	diag_16																							
-GE:diag_17	diag_17																							
-GE:diag_18	diag_18																							
-GE:diag_19	diag_19																							
-GE:diag_20	diag_20																							
-GE:diag_count	Count of diagnoses																							
-GE:disdate	Date of discharge																							
-GE:disdest	Destination on discharge																							
-GE:dismeth	Method of discharge																							
-GE:disreadydate	Discharge ready date																							
-GE:dob	Date of birth - patient																							
-GE:domproc	Trust derived dominant procedure																							
-GE:earldatoff	Earliest reasonable date offered																							
-GE:elecdate	Date of decision to admit																							
-GE:elecdur	Duration of elective wait (submitted)																							
-GE:elecdur_calc	Calculation of Elecdur																							
-GE:endage	Age at end of episode																							
-GE:epidur	Episode duration																							
-GE:epiend	Date episode ended																							
-GE:epiorder	Episode order																							
-GE:epistart	Date episode started																							
-GE:epistat	Episode status																							
-GE:epitype	Episode type																							
-GE:ethnos	Ethnic category																							
-GE:ethraw	Ethnic character (audit version)																							
-GE:fae	Finished Admission Episode																							
-GE:fae_emergency	Finished Admission Episode, emergency classification																							
-GE:fce	Finished Consultant Episode																							
-GE:fde	Finished In-Year Discharge Episode																							
-GE:firstreg	First regular day or night admission																							
-GE:fyear	Financial Year																							
-GE:gestat_1	Length of gestation																							
-GE:gestat_2	gestat_2																							
-GE:gestat_3	gestat_3																							
-GE:gestat_4	gestat_4																							
-GE:gestat_5	gestat_5																							
-GE:gestat_6	gestat_6																							
-GE:gestat_7	gestat_7																							
-GE:gestat_8	gestat_8																							
-GE:gestat_9	gestat_9																							
-GE:gortreat	Government office region of treatment																							
-GE:gpprac	Code of GP practice																							
-GE:gppracha	Health Authority area where patient‚Äö√Ñ√¥s GP is registered																							
-GE:gppracro	Regional Office area where patient‚Äö√Ñ√¥s GP was registered																							
-GE:gpprpct	Primary Care Trust area where patient‚Äö√Ñ√¥s GP was registered																							
-GE:gpprstha	Strategic Health Authority area where patient‚Äö√Ñ√¥s GP was registered																							
-GE:hatreat	Ordnance Survey grid reference																							
-GE:hneoind	Healthly Neonate Indicator																							
-GE:hrglate35	Trust derived HRG value v3.5																							
-GE:hrgnhs	Trust derived HRG value																							
-GE:hrgnhsvn	Version No. of Trust derived HRG																							
-GE:imd04	IMD Index of Multiple Deprivation																							
-GE:imd04_decile	IMD Decile Group																							
-GE:imd04c	IMD Crime Domain																							
-GE:imd04ed	IMD Education Training and Skills Domain																							
-GE:imd04em	IMD Employment Deprivation Domain																							
-GE:imd04hd	IMD Health and Disability Domain																							
-GE:imd04hs	IMD Barriers to Housing and Service Domain																							
-GE:imd04i	IMD Income Domain																							
-GE:imd04ia	IMD Income affecting Adults Domain																							
-GE:imd04ic	IMD Income affecting Children Domain																							
-GE:imd04le	IMD Living Environment Domain																							
-GE:imd04rk	IMD Overall Rank																							
-GE:intdays_1	Intensive care level days																							
-GE:intdays_2	intdays_2																							
-GE:intdays_3	intdays_3																							
-GE:intdays_4	intdays_4																							
-GE:intdays_5	intdays_5																							
-GE:intdays_6	intdays_6																							
-GE:intdays_7	intdays_7																							
-GE:intdays_8	intdays_8																							
-GE:intdays_9	intdays_9																							
-GE:intmanig	Intended management																							
-GE:lad98	Local authority district in 1998																							
-GE:lsoa01	Lower Super Output Area																							
-GE:lsoa11	Lower Super Output Area																							
-GE:mainspef	Main specialty																							
-GE:marstat	Marital status (psychiatric)																							
-GE:matage	Mother‚Äö√Ñ√¥s age at delivery																							
-GE:maternity_episode_type	Episode Type - Maternity																							
-GE:msoa01	Middle Super Output Area, 2001																							
-GE:msoa11	Middle Super Output Area, 2011																							
-GE:neocare	Neonatal level of care																							
-GE:neodur	Age of baby in days																							
-GE:newnhsno_check	NHS Number valid flag																							
-GE:nhsnoind	NHS number status indicator																							
-GE:numacp	Number of augmented care periods within episode																							
-GE:numbaby	Number of babies		pregnancy history																					
-GE:numpreg	Number of previous pregnancies		pregnancy history																					
-GE:numtailb	Number of baby tails																							
-GE:opcs43	opcs43																							
-GE:opdate_01	Date of procedure		surgical interventions																					
-GE:opdate_02	opdate_02		surgical interventions																					
-GE:opdate_03	opdate_03		surgical interventions																					
-GE:opdate_04	opdate_04		surgical interventions																					
-GE:opdate_05	opdate_05		surgical interventions																					
-GE:opdate_06	opdate_06		surgical interventions																					
-GE:opdate_07	opdate_07		surgical interventions																					
-GE:opdate_08	opdate_08		surgical interventions																					
-GE:opdate_09	opdate_09		surgical interventions																					
-GE:opdate_10	opdate_10		surgical interventions																					
-GE:opdate_11	opdate_11		surgical interventions																					
-GE:opdate_12	opdate_12		surgical interventions																					
-GE:opdate_13	opdate_13		surgical interventions																					
-GE:opdate_14	opdate_14		surgical interventions																					
-GE:opdate_15	opdate_15		surgical interventions																					
-GE:opdate_16	opdate_16		surgical interventions																					
-GE:opdate_17	opdate_17		surgical interventions																					
-GE:opdate_18	opdate_18		surgical interventions																					
-GE:opdate_19	opdate_19		surgical interventions																					
-GE:opdate_20	opdate_20		surgical interventions																					
-GE:opdate_21	opdate_21		surgical interventions																					
-GE:opdate_22	opdate_22		surgical interventions																					
-GE:opdate_23	opdate_23		surgical interventions																					
-GE:opdate_24	opdate_24		surgical interventions																					
-GE:operstat	Operation status code		surgical interventions																					
-GE:opertn_01	Operative procedure		surgical interventions																					
-GE:opertn_02	opertn_02																							
-GE:opertn_03	opertn_03																							
-GE:opertn_04	opertn_04																							
-GE:opertn_05	opertn_05																							
-GE:opertn_06	opertn_06																							
-GE:opertn_07	opertn_07																							
-GE:opertn_08	opertn_08																							
-GE:opertn_09	opertn_09																							
-GE:opertn_10	opertn_10																							
-GE:opertn_11	opertn_11																							
-GE:opertn_12	opertn_12																							
-GE:opertn_13	opertn_13																							
-GE:opertn_14	opertn_14																							
-GE:opertn_15	opertn_15																							
-GE:opertn_16	opertn_16																							
-GE:opertn_17	opertn_17																							
-GE:opertn_18	opertn_18																							
-GE:opertn_19	opertn_19																							
-GE:opertn_20	opertn_20																							
-GE:opertn_21	opertn_21																							
-GE:opertn_22	opertn_22																							
-GE:opertn_23	opertn_23																							
-GE:opertn_24	opertn_24																							
-GE:opertn_count	Count of procedures																							
-GE:orgpppid	Organisation code (patient pathway ID issuer)																							
-GE:orgsup_1	Number of organ systems supported																							
-GE:orgsup_2	orgsup_2																							
-GE:orgsup_3	orgsup_3																							
-GE:orgsup_4	orgsup_4																							
-GE:orgsup_5	orgsup_5																							
-GE:orgsup_6	orgsup_6																							
-GE:orgsup_7	orgsup_7																							
-GE:orgsup_8	orgsup_8																							
-GE:orgsup_9	orgsup_9																							
-GE:partyear	Year and month of HES dataset																							
-GE:pcfound	Postcode Found																							
-GE:pcgcode	Primary care group																							
-GE:pcgorig	Origin of primary care group																							
-GE:pcon	Westminster parliamentary constituency																							
-GE:pcon_ons	Westminster parliamentary constituency (ONS)																							
-GE:pctcode	PCT of responsibility dependent on the data year																							
-GE:pctcode06	PCT of responsibility (2006)																							
-GE:pctnhs	Primary care trust																							
-GE:pctorig	Origin of primary care trust of responsibility																							
-GE:pctorig06	Origin of PCT of responsibility (2006)																							
-GE:pcttreat	Primary Care Trust area of main provider																							
-GE:posopdur	Post-operative duration																							
-GE:postdist	Postcode district																							
-GE:postdur	Postnatal stay																							
-GE:preopdur	Pre-operative duration																							
-GE:primercp	primercp																							
-GE:procode	Provider Code																							
-GE:procode3	Provider code (3 character)																							
-GE:procode5	Provider code (5 character)																							
-GE:procodet	Provider code of treatment																							
-GE:protype	Provider type																							
-GE:purcode	Commissioner code																							
-GE:purro	Commissioner‚Äö√Ñ√¥s Regional Office																							
-GE:purstha	Commissioner‚Äö√Ñ√¥s Strategic Health Authority																							
-GE:purval	Commissioner code status																							
-GE:referorg	Referring organisation code																							
-GE:rescty	County of residence																							
-GE:rescty_ons	County of residence (ONS)																							
-GE:resgor	Government Office region of residence																							
-GE:resgor_ons	Government office region of residence (ONS)																							
-GE:resha	Health Authority of residence																							
-GE:resladst	Local authority district of residence																							
-GE:resladst_ons	Local authority district of residence (ONS)																							
-GE:respct	PCT of residence - mapped according to data year																							
-GE:respct06	PCT of residence (2006)																							
-GE:resro	Regional Office of residence																							
-GE:resstha	SHA of residence																							
-GE:resstha06	SHA of residence (2006)																							
-GE:rotreat	Regional Office of treatment																							
-GE:rttperend	RTT period end date																							
-GE:rttperstart	REFERRAL TO TREATMENT- RTT period start date																							
-GE:rttperstat	RTT period status																							
-GE:rururb_ind	Rural/Urban Indicator																							
-GE:sender	CDS sender identity																							
-GE:sex	Sex of patient																							
-GE:sexbaby_1	Sex of baby																							
-GE:sexbaby_2	sexbaby_2																							
-GE:sexbaby_3	sexbaby_3																							
-GE:sexbaby_4	sexbaby_4																							
-GE:sexbaby_5	sexbaby_5																							
-GE:sexbaby_6	sexbaby_6																							
-GE:sexbaby_7	sexbaby_7																							
-GE:sexbaby_8	sexbaby_8																							
-GE:sexbaby_9	sexbaby_9																							
-GE:sitetret	Site code of treatment																							
-GE:spelbgin	Beginning of spell indicator																							
-GE:speldur	Duration of spell																							
-GE:spelend	End of spell indicator																							
-GE:startage	Age at start of episode																							
-GE:startage_calc	Age at start of episode - babies decimalised																							
-GE:sthatret	SHA area of treatment																							
-GE:subdate	Submission date																							
-GE:suscorehrg	SUS generated Core Spell HRG																							
-GE:sushrg	SUS generated HRG																							
-GE:sushrgvers	SUS generated HRG version number																							
-GE:suslddate	SUS loaded staging date																							
-GE:susspellid	SUS generated spell identifier																							
-GE:tretspef	Treatment specialty																							
-GE:vind	V code indicator																							
-GE:waitdays	Duration of wait (referral to treatment period)																							
-GE:waitlist	Method of Admission - Waiting List																							
-GE:ward91	Electoral ward in 1991																							
-GE:ward98	Electoral ward in 1998																							
-GE:wardstrt	Ward type at start of episode																							
-GE:well_baby_ind	Well baby flag																							
-GE:acardsupdays	acardsupdays																							
-GE:aressupdays	aressupdays																							
-GE:bcardsupdays	bcardsupdays																							
-GE:bestmatch	bestmatch																							
-GE:bressupdays	bressupdays																							
-GE:ccadmisorc	ccadmisorc																							
-GE:ccadmitype	ccadmitype																							
-GE:ccapcrel	ccapcrel																							
-GE:ccdisdate	ccdisdate																							
-GE:ccdisdest	ccdisdest																							
-GE:ccdisloc	ccdisloc																							
-GE:ccdisrdydate	ccdisrdydate																							
-GE:ccdisrdytime	ccdisrdytime																							
-GE:ccdisstat	ccdisstat																							
-GE:ccdistime	ccdistime																							
-GE:cclev2days	cclev2days																							
-GE:cclev3days	cclev3days																							
-GE:ccsorcloc	ccsorcloc																							
-GE:ccstartdate	ccstartdate																							
-GE:ccstarttime	ccstarttime																							
-GE:ccunitfun	ccunitfun																							
-GE:dermsupdays	dermsupdays																							
-GE:gisupdays	gisupdays																							
-GE:liversupdays	liversupdays																							
-GE:neurosupdays	neurosupdays																							
-GE:orgsupmax	orgsupmax																							
-GE:rensupdays	rensupdays																							
-GE:unitbedconfig	unitbedconfig																							
-GE:attendkey	Record identifier																							
-GE:apptage	Age on day of appointment																							
-GE:apptage_calc	Age on arrival - babies decimalised																							
-GE:apptdate	Appointment date																							
-GE:atentype	Attendance type																							
-GE:attended	Attended or did not attend																							
-GE:attendkey_flag	Attendence Key Flag																							
-GE:dnadate	Last DNA or patient cancelled date																							
-GE:ethrawl	Ethnic category (audit version)																							
-GE:firstatt	First attendance																							
-GE:locclass	Location Class																							
-GE:loctype	Location Tyoe																							
-GE:nodiags	Number of Diagnoses																							
-GE:noprocs	Number of Procedures																							
-GE:oacode01	Census Output Area, 2011																							
-GE:oacode11	Census Output Area, 2011																							
-GE:oacode6	Census output area, 2001 (6 character ward identifier)																							
-GE:outcome	Outcome of attendance																							
-GE:pctorig_his	Origin of primary care trust of responsibility dependent on the data year																							
-GE:pgpprac	Pseudonymised code of GP practice																							
-GE:primerecp	primerecp																							
-GE:priority	Priority type																							
-GE:referrer	Referrer code																							
-GE:reggmp	Code of patient‚Äö√Ñ√¥s registered or referring general medical practitioner																							
-GE:reqdate	Referral request received date																							
-GE:respct02	PCT of residence (2002)																							
-GE:resstha02	SHA of residence (2002)																							
-GE:servtype	Service type requested																							
-GE:stafftyp	Medical staff type seeing patient																							
-GE:wait_ind	Waiting calculation indicator																							
-GE:waiting	Days waiting																							
-GE:aearrivalmode	Arrival mode																							
-GE:aeattend_exc_planned	Attendances excluding planned																							
-GE:aeattendcat	Attendance category																							
-GE:aeattenddisp	Attendance disposal																							
-GE:aedepttype	Department type																							
-GE:aeincloctype	Incident location type																							
-GE:aekey_flag	AEKEY flag																							
-GE:aepatgroup	Patient group																							
-GE:aerefsource	Source of referral for A&E																							
-GE:appdate	Net applicable date																							
-GE:arrivalage	Age on arrival																							
-GE:arrivalage_calc	Age on arrival - babies decimalised																							
-GE:arrivaldate	Arrival date																							
-GE:arrivaltime	Arrival time																							
-GE:concldur	Duration to conclusion																							
-GE:concltime	Conclusion time																							
-GE:depdur	Duration to departure																							
-GE:deptime	Departure time																							
-GE:diag2_01	A&E diagnosis: 2 character																							
-GE:diag2_02	diag2_02																							
-GE:diag2_03	diag2_03																							
-GE:diag2_04	diag2_04																							
-GE:diag2_05	diag2_05																							
-GE:diag2_06	diag2_06																							
-GE:diag2_07	diag2_07																							
-GE:diag2_08	diag2_08																							
-GE:diag2_09	diag2_09																							
-GE:diag2_10	diag2_10																							
-GE:diag2_11	diag2_11																							
-GE:diag2_12	diag2_12																							
-GE:diaga_01	A&E diagnosis - anatomical area																							
-GE:diaga_02	diaga_02																							
-GE:diaga_03	diaga_03																							
-GE:diaga_04	diaga_04																							
-GE:diaga_05	diaga_05																							
-GE:diaga_06	diaga_06																							
-GE:diaga_07	diaga_07																							
-GE:diaga_08	diaga_08																							
-GE:diaga_09	diaga_09																							
-GE:diaga_10	diaga_10																							
-GE:diaga_11	diaga_11																							
-GE:diaga_12	diaga_12																							
-GE:diags_01	A&E diagnosis - anatomical side																							
-GE:diags_02	diags_02																							
-GE:diags_03	diags_03																							
-GE:diags_04	diags_04																							
-GE:diags_05	diags_05																							
-GE:diags_06	diags_06																							
-GE:diags_07	diags_07																							
-GE:diags_08	diags_08																							
-GE:diags_09	diags_09																							
-GE:diags_10	diags_10																							
-GE:diags_11	diags_11																							
-GE:diags_12	diags_12																							
-GE:diagscheme	Diagnosis Scheme in Use																							
-GE:initdur	Duration to assessment																							
-GE:inittime	Initial assessment time																							
-GE:invest_01	A&E investigation																							
-GE:invest_02	invest_02																							
-GE:invest_03	invest_03																							
-GE:invest_04	invest_04																							
-GE:invest_05	invest_05																							
-GE:invest_06	invest_06																							
-GE:invest_07	invest_07																							
-GE:invest_08	invest_08																							
-GE:invest_09	invest_09																							
-GE:invest_10	invest_10																							
-GE:invest_11	invest_11																							
-GE:invest_12	invest_12																							
-GE:invest2_01	A&E Investigation: 2 character																							
-GE:invest2_02	invest2_02																							
-GE:invest2_03	invest2_03																							
-GE:invest2_04	invest2_04																							
-GE:invest2_05	invest2_05																							
-GE:invest2_06	invest2_06																							
-GE:invest2_07	invest2_07																							
-GE:invest2_08	invest2_08																							
-GE:invest2_09	invest2_09																							
-GE:invest2_10	invest2_10																							
-GE:invest2_11	invest2_11																							
-GE:invest2_12	invest2_12																							
-GE:noinvests	Number of Investigations																							
-GE:notreats	Number of Treatments																							
-GE:pctcode_his	PCT of responsibility dependent on the data year																							
-GE:pctcode02	PCT of responsibility (2002)																							
-GE:pctorig02	Origin of PCT of responsibility (2002)																							
-GE:perend	Reporting period end date																							
-GE:respct_his	PCT of residence - mapped according to data year																							
-GE:resstha_his	resstha_his																							
-GE:sushrginfo	SUS generated HRG for information																							
-GE:sushrgverinfo	SUS generated HRG version number																							
-GE:treat_01	A&E treatment																							
-GE:treat_02	treat_02																							
-GE:treat_03	treat_03																							
-GE:treat_04	treat_04																							
-GE:treat_05	treat_05																							
-GE:treat_06	treat_06																							
-GE:treat_07	treat_07																							
-GE:treat_08	treat_08																							
-GE:treat_09	treat_09																							
-GE:treat_10	treat_10																							
-GE:treat_11	treat_11																							
-GE:treat_12	treat_12																							
-GE:treat2_01	A&E Treatment: 2 character																							
-GE:treat2_02	treat2_02																							
-GE:treat2_03	treat2_03																							
-GE:treat2_04	treat2_04																							
-GE:treat2_05	treat2_05																							
-GE:treat2_06	treat2_06																							
-GE:treat2_07	treat2_07																							
-GE:treat2_08	treat2_08																							
-GE:treat2_09	treat2_09																							
-GE:treat2_10	treat2_10																							
-GE:treat2_11	treat2_11																							
-GE:treat2_12	treat2_12																							
-GE:tretdur	Duration to treatment																							
-GE:trettime	Time seen for treatment																							
-GE:submissiondataid	Record Identifier																							
-GE:did_date1	Diagnostic Test Request Date																							
-GE:did_date2	Diagnostic Test Request Received Date																							
-GE:did_date3	Diagnostic Test Date																							
-GE:did_date3_month	Month of Test																							
-GE:did_date3_year	Year of Test																							
-GE:did_date4	Service Report Issue Date																							
-GE:did_ethcat	Ethnic Category Code																							
-GE:did_ethcat_grp	Ethnic Category Group																							
-GE:did_gender_code	Gender Code																							
-GE:did_nhsnum_stat	NHS Number Status																							
-GE:did_nicip_code	Imaging Code (NICIP)																							
-GE:did_patsource_code	Patient Source Setting																							
-GE:did_refer_orgcode	Referrer Organisation code																							
-GE:did_snomedct_code	did_snomedct_code																							
-GE:ic_age10	Age Band 10 years																							
-GE:ic_age17_60	ic_age17_60																							
-GE:ic_age17_64	ic_age17_64																							
-GE:ic_age5	Age Band 5 years																							
-GE:ic_age50_74	ic_age50_74																							
-GE:ic_agechild	ic_agechild																							
-GE:ic_cancer_desc	Early cancer diagnosis																							
-GE:ic_ccgcode	CCG Code																							
-GE:ic_ccgname	CCG Name																							
-GE:ic_date1_to_date2	Test Request to Test Request Received																							
-GE:ic_date1_to_date3	Test Request to Test																							
-GE:ic_date1_to_date4	Test Request to Service (Test) Report Issue																							
-GE:ic_date2_to_date3	Test Request Received to Test																							
-GE:ic_date2_to_date4	Test Request Received to Service (test) Report Issue																							
-GE:ic_date3_to_date4	Test to Service (Test) Report Issue																							
-GE:ic_ethcat_desc	Ethnic Category Description																							
-GE:ic_fetal_desc	Fetal																							
-GE:ic_fetal_id	Fetal ID																							
-GE:ic_gender_desc	Gender Description		gender																					
-GE:ic_lsoa	Location - LSOA																							
-GE:ic_modality_desc	Modality																							
-GE:ic_modality_id	Modality ID																							
-GE:ic_morphology_id	Morphology ID																							
-GE:ic_morph_desc	Morphology																							
-GE:ic_msoa	Location - MSOA																							
-GE:ic_nhsnum_stat_desc	NHS Number Status Description																							
-GE:ic_nicip_desc	Imaging Code (NICIP) Description																							
-GE:ic_patsource_desc	Patient Source Setting Description																							
-GE:ic_pctcode	Commissioning Organisation Code																							
-GE:ic_pctname	Commissioning Organisation Name																							
-GE:ic_prov_orgcode	Organisation Code																							
-GE:ic_prov_shacode	Provider SHA Code																							
-GE:ic_prov_shaname	Provider SHA Name																							
-GE:ic_provname	Provider Name																							
-GE:ic_refer_orgname	Referrer																							
-GE:ic_reftype_desc	Referrer type																							
-GE:ic_region_desc	Region																							
-GE:ic_region_id	Region ID																							
-GE:ic_sitecode	Provider Site Code																							
-GE:ic_sitename	Provider Site Name																							
-GE:ic_snomedct_desc	Imaging Code (SNOMED)																							
-GE:ic_sub_cancer_desc	Sub Early cancer diagnosis																							
-GE:ic_sub_modality_desc	Sub Modality																							
-GE:ic_sub_modality_id	Sub Modality ID																							
-GE:ic_sub_region_desc	Sub Region																							
-GE:ic_sub_region_id	Sub Region ID																							
-GE:ic_sub_sys_desc	Sub System																							
-GE:ic_sub_sys_id	Sub System ID																							
-GE:ic_sub_syscomp_desc	Sub-System Component																							
-GE:ic_sub_syscomp_id	Sub-System Component ID																							
-GE:ic_submit_orgcode	Organisation Code																							
-GE:ic_submit_orgname	Organisation Name																							
-GE:ic_system_desc	System																							
-GE:ic_system_id	System ID																							
-GE:hes_dids_version	hes_dids_version																							
-GE:arthritis	Arthritis Indicator																							
-GE:cancer	Cancer Indicator																							
-GE:circulation	Circulation																							
-GE:complete	Complete																							
-GE:depression	Depression																							
-GE:diabetes	Diabetes																							
-GE:episode_match_rank	EPISODE MATCH RANK																							
-GE:episode_matched	episode_matched																							
-GE:eq5d_health_scale_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (MODEL1)																							
-GE:eq5d_index_change	eq5d_index_change																							
-GE:eq5d_index_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (FINAL MODEL1)																							
-GE:eq5d_scale_change	EQ5D INDEX CHANGE																							
-GE:gender	Gender																							
-GE:heart_disease	Heart Disease Indicator																							
-GE:hesid_matched	HESID Matched																							
-GE:hesid_rank	Hesid Rank																							
-GE:high_bp	High Blood Pressiure Indicator																							
-GE:hr_q1_dressing	Q1-HR6																							
-GE:hr_q1_limping	Q1-HR9																							
-GE:hr_q1_night_pain	Q1-HR3																							
-GE:hr_q1_pain	Q1-HR1																							
-GE:hr_q1_score	hr_q1_score																							
-GE:hr_q1_score_complete	hr_q1_score_complete																							
-GE:hr_q1_shopping	Q1-HR7																							
-GE:hr_q1_stairs	Q1-HR10																							
-GE:hr_q1_standing	Q1-HR11																							
-GE:hr_q1_sudden_pain	Q1-HR2																							
-GE:hr_q1_transport	Q1-HR5																							
-GE:hr_q1_walking	Q1-HR8																							
-GE:hr_q1_washing	Q1-HR4																							
-GE:hr_q1_work	Q1-HR12																							
-GE:hr_q2_dressing	Q2-HR6																							
-GE:hr_q2_limping	Q2-HR9																							
-GE:hr_q2_night_pain	Q2-HR3																							
-GE:hr_q2_pain	Q2-HR1																							
-GE:hr_q2_score	hr_q2_score																							
-GE:hr_q2_score_complete	hr_q2_score_complete																							
-GE:hr_q2_shopping	Q2-HR7																							
-GE:hr_q2_stairs	Q2-HR10																							
-GE:hr_q2_standing	Q2-HR11																							
-GE:hr_q2_sudden_pain	Q2-HR2																							
-GE:hr_q2_transport	Q2-HR5																							
-GE:hr_q2_walking	Q2-HR8																							
-GE:hr_q2_washing	Q2-HR4																							
-GE:hr_q2_work	Q2-HR12																							
-GE:hr_score_expected_final_model3	hr_score_expected_final_model3																							
-GE:kidney_disease	Kidney Disease																							
-GE:kr_q1_confidence	Q1 - KR10																							
-GE:kr_q1_kneeling	Q1 - KR8																							
-GE:kr_q1_limping	Q1-KR7																							
-GE:kr_q1_night_pain	Q1-KR2																							
-GE:kr_q1_pain	Q1-KR1																							
-GE:kr_q1_score	Q1-KR5																							
-GE:kr_q1_score_complete	kr_q1_score_complete																							
-GE:kr_q1_shopping	Q1-KR11																							
-GE:kr_q1_stairs	Q1-KR12																							
-GE:kr_q1_standing	Q1-KR6																							
-GE:kr_q1_transport	Q1-KR4																							
-GE:kr_q1_walking	Q1-KR5																							
-GE:kr_q1_washing	Q1-KR3																							
-GE:kr_q1_work	Q1-KR9																							
-GE:kr_q2_confidence	Q2-KR10																							
-GE:kr_q2_kneeling	Q2-KR8																							
-GE:kr_q2_limping	Q2-KR7																							
-GE:kr_q2_night_pain	Q2-KR2																							
-GE:kr_q2_pain	Q2-KR1																							
-GE:kr_q2_score	kr_q2_score																							
-GE:kr_q2_score_complete	kr_q2_score_complete																							
-GE:kr_q2_shopping	Q2-KR11																							
-GE:kr_q2_stairs	kr_q2_stairs																							
-GE:kr_q2_standing	Q2-KR6																							
-GE:kr_q2_transport	Q2-KR4																							
-GE:kr_q2_walking	Q2-KR5																							
-GE:kr_q2_washing	Q2-KR3																							
-GE:kr_q2_work	Q2-KR9																							
-GE:kr_score_expected_final_model3	kr_score_expected_final_model3																							
-GE:liver_disease	Liver Disease																							
-GE:lung_disease	Lung Disease																							
-GE:modified_date	modified_date																							
-GE:nervous_system	nervous_system																							
-GE:patient_death	patient_death																							
-GE:proc_revision_flag	Procedure Revision Flag																							
-GE:proms_proc_code	Proms Procedure Code																							
-GE:proms_proc_group	proms_proc_group																							
-GE:proms_serial_no	proms_serial_no																							
-GE:q1_activity	PreOp3																							
-GE:q1_anxiety	PreOp5																							
-GE:q1_assisted	q1_assisted																							
-GE:q1_assisted_by	q1_assisted_by																							
-GE:q1_complete	q1_complete																							
-GE:q1_completed_date	q1_completed_date																							
-GE:q1_disability	q1_disability																							
-GE:q1_discomfort	PO4																							
-GE:q1_eq5d_health_scale	q1_eq5d_health_scale																							
-GE:q1_eq5d_index	q1_eq5d_index																							
-GE:q1_eq5d_profile	q1_eq5d_profile																							
-GE:q1_eq5d_profile_complete	q1_eq5d_profile_complete																							
-GE:q1_eq5d_scale_complete	q1_eq5d_scale_complete																							
-GE:q1_form_version	q1_form_version																							
-GE:q1_general_health	q1_general_health																							
-GE:q1_language	q1_language																							
-GE:q1_living_arrangements	q1_living_arrangements																							
-GE:q1_mobility	q1_mobility																							
-GE:q1_previous_surgery	q1_previous_surgery		pregnancy history																					
-GE:q1_procode	q1_procode																							
-GE:q1_received_date	q1_received_date																							
-GE:q1_scan_date	q1_scan_date																							
-GE:q1_self_care	q1_self_care																							
-GE:q1_symptom_period	q1_symptom_period																							
-GE:q2_activity	PostOp3																							
-GE:q2_allergy	q2_allergy																							
-GE:q2_anxiety	PostOp5																							
-GE:q2_assisted	q2_assisted																							
-GE:q2_assisted_by	q2_assisted_by																							
-GE:q2_bleeding	q2_bleeding																							
-GE:q2_complete	q2_complete																							
-GE:q2_completed_date	q2_completed_date																							
-GE:q2_disability	q2_disability																							
-GE:q2_discomfort	PostOp4																							
-GE:q2_eq5d_health_scale	q2_eq5d_health_scale																							
-GE:q2_eq5d_index	q2_eq5d_index																							
-GE:q2_eq5d_profile	q2_eq5d_profile																							
-GE:q2_eq5d_profile_complete	q2_eq5d_profile_complete																							
-GE:q2_eq5d_scale_complete	q2_eq5d_scale_complete																							
-GE:q2_form_version	q2_form_version																							
-GE:q2_further_surgery	q2_further_surgery		pregnancy history																					
-GE:q2_general_health	q2_general_health																							
-GE:q2_language	q2_language																							
-GE:q2_living_arrangements	q2_living_arrangements																							
-GE:q2_mobility	q2_mobility																							
-GE:q2_readmitted	q2_readmitted																							
-GE:q2_received_date	q2_received_date																							
-GE:q2_satisfaction	q2_satisfaction																							
-GE:q2_scan_date	q2_scan_date																							
-GE:q2_self_care	q2_self_care																							
-GE:q2_success	q2_success																							
-GE:q2_surgery_date	q2_surgery_date																							
-GE:q2_urine	q2_urine																							
-GE:q2_wound	q2_wound																							
-GE:score_change	score_change																							
-GE:status	status																							
-GE:status_date	status_date																							
-GE:stroke	stroke																							
-GE:vv_q1_clothing	Q1-VV4																							
-GE:vv_q1_concern	Q1-VV3																							
-GE:vv_q1_left_back_count	Q1-VV7																							
-GE:vv_q1_left_discolour	Q1-VV11																							
-GE:vv_q1_left_front_count	Q1-VV7																							
-GE:vv_q1_left_itch	Q1-VV10																							
-GE:vv_q1_left_pain_days	Q1-VV8																							
-GE:vv_q1_left_rash	Q1-VV12																							
-GE:vv_q1_left_support	Q1-VV9																							
-GE:vv_q1_left_ulcer	Q1-VV13																							
-GE:vv_q1_leisure	Q1-VV6																							
-GE:vv_q1_max_score	vv_q1_max_score																							
-GE:vv_q1_painkiller_days	Q1-VV1																							
-GE:vv_q1_right_back_count	Q1-VV7																							
-GE:vv_q1_right_discolour	Q1-VV11																							
-GE:vv_q1_right_front_count	Q1-VV7																							
-GE:vv_q1_right_itch	Q1-VV10																							
-GE:vv_q1_right_pain_days	Q1-VV9																							
-GE:vv_q1_right_rash	Q1-VV12																							
-GE:vv_q1_right_support	Q1-VV																							
-GE:vv_q1_right_ulcer	Q1-VV13																							
-GE:vv_q1_score	vv_q1_score																							
-GE:vv_q1_score_complete	vv_q1_score_complete																							
-GE:vv_q1_swelling	Q1-VV2																							
-GE:vv_q1_total_score	vv_q1_total_score																							
-GE:vv_q1_work	Q1-VV5																							
-GE:vv_q2_clothing	Q2-VV4																							
-GE:vv_q2_concern	Q2-VV3																							
-GE:vv_q2_left_back_count	Q2-VV7																							
-GE:vv_q2_left_discolour	Q2-VV11																							
-GE:vv_q2_left_front_count	Q2-VV7																							
-GE:vv_q2_left_itch	Q2-VV10																							
-GE:vv_q2_left_pain_days	Q2-VV8																							
-GE:vv_q2_left_rash	Q2-VV12																							
-GE:vv_q2_left_support	Q2-VV9																							
-GE:vv_q2_left_ulcer	Q2-VV13																							
-GE:vv_q2_left_visible	Q2-VV2																							
-GE:vv_q2_leisure	Q2-VV6																							
-GE:vv_q2_max_score	vv_q2_max_score																							
-GE:vv_q2_painkiller_days	Q2-VV1																							
-GE:vv_q2_right_back_count	Q2-VV7																							
-GE:vv_q2_right_discolour	Q2-VV11																							
-GE:vv_q2_right_front_count	Q2-VV7																							
-GE:vv_q2_right_itch	Q2-VV10																							
-GE:vv_q2_right_pain_days	Q2-VV9																							
-GE:vv_q2_right_rash	Q2-VV12																							
-GE:vv_q2_right_support	Q2-VV																							
-GE:vv_q2_right_ulcer	Q2-VV13																							
-GE:vv_q2_right_visible	Q2-VV2																							
-GE:vv_q2_score	vv_q2_score																							
-GE:vv_q2_score_complete	vv_q2_score_complete																							
-GE:vv_q2_swelling	Q1-VV2																							
-GE:vv_q2_total_score	vv_q2_total_score																							
-GE:vv_q2_work	Q1-VV5																							
-GE:vv_score_expected_final_model3	VV Score Final Predicted (Model 3)																							
-GE:mhd_mhmds_person_id	mhd_mhmds_person_id																							
-GE:mhd_mhmds_spell_id	mhd_mhmds_spell_id																							
-GE:ic_annual_id	ic_annual_id																							
-GE:ic_inactive_timestamp	ic_inactive_timestamp																							
-GE:ic_interim_ccg_code	ic_interim_ccg_code																							
-GE:ic_rec_ccg	ic_rec_ccg																							
-GE:ic_rec_endrp_aot_flag	ic_rec_endrp_aot_flag																							
-GE:ic_rec_endrp_cluster_flag	ic_rec_endrp_cluster_flag																							
-GE:ic_rec_endrp_cluster_type	ic_rec_endrp_cluster_type																							
-GE:ic_rec_endrp_cpa_epi_12_months	ic_rec_endrp_cpa_epi_12_months																							
-GE:ic_rec_endrp_cpa_flag	ic_rec_endrp_cpa_flag																							
-GE:ic_rec_endrp_cpa_review_within_12mnths	ic_rec_endrp_cpa_review_within_12mnths																							
-GE:ic_rec_endrp_eit_flag	ic_rec_endrp_eit_flag																							
-GE:ic_rec_endrp_employment_status	ic_rec_endrp_employment_status																							
-GE:ic_rec_endrp_honos_assessment_within_12mnths	ic_rec_endrp_honos_assessment_within_12mnths																							
-GE:ic_rec_endrp_hospital_spell_flag	ic_rec_endrp_hospital_spell_flag																							
-GE:ic_rec_endrp_mha_flag	ic_rec_endrp_mha_flag																							
-GE:ic_rec_endrp_pdiag_flag	ic_rec_endrp_pdiag_flag																							
-GE:ic_rec_endrp_recall_flag	ic_rec_endrp_recall_flag																							
-GE:ic_rec_endrp_sct_flag	ic_rec_endrp_sct_flag																							
-GE:ic_rec_endrp_settled_accommodation_indicator	ic_rec_endrp_settled_accommodation_indicator																							
-GE:ic_rec_ethnicity	ic_rec_ethnicity																							
-GE:ic_rec_rp_admission	ic_rec_rp_admission																							
-GE:ic_rec_rp_admission_formal	ic_rec_rp_admission_formal																							
-GE:ic_rec_rp_awol	ic_rec_rp_awol																							
-GE:ic_rec_rp_commissioners	ic_rec_rp_commissioners																							
-GE:ic_rec_rp_contacts	ic_rec_rp_contacts																							
-GE:ic_rec_rp_contacts_att	ic_rec_rp_contacts_att																							
-GE:ic_rec_rp_dayatt_contacts	ic_rec_rp_dayatt_contacts																							
-GE:ic_rec_rp_dayatt_contacts_att	ic_rec_rp_dayatt_contacts_att																							
-GE:ic_rec_rp_ddisc_days	ic_rec_rp_ddisc_days																							
-GE:ic_rec_rp_disch_net_followup	ic_rec_rp_disch_net_followup																							
-GE:ic_rec_rp_discharges_gross	ic_rec_rp_discharges_gross																							
-GE:ic_rec_rp_discharges_net	ic_rec_rp_discharges_net																							
-GE:ic_rec_rp_readmissions	ic_rec_rp_readmissions																							
-GE:ic_rec_rp_wrdst_days_cleansed	ic_rec_rp_wrdst_days_cleansed																							
-GE:ic_rec_rp_wrdst_days_gross	ic_rec_rp_wrdst_days_gross																							
-GE:ic_rec_rp_wrdst_days_net	ic_rec_rp_wrdst_days_net																							
-GE:ic_source_period_id	ic_source_period_id																							
-GE:ic_spell_rp_days	ic_spell_rp_days																							
-GE:mhd_age	mhd_age																							
-GE:mhd_ccg_of_gp_practice	mhd_ccg_of_gp_practice																							
-GE:mhd_ccg_of_residence	mhd_ccg_of_residence																							
-GE:mhd_code_of_commissioner	mhd_code_of_commissioner																							
-GE:mhd_code_of_gp_practice	mhd_code_of_gp_practice																							
-GE:mhd_county	mhd_county																							
-GE:mhd_crisisplancreat_date	mhd_crisisplancreat_date																							
-GE:mhd_crisisplanupdate_date	mhd_crisisplanupdate_date																							
-GE:mhd_electoral_ward_of_usual_address	mhd_electoral_ward_of_usual_address																							
-GE:mhd_emerpsych_date	mhd_emerpsych_date																							
-GE:mhd_end_date_mhcs	mhd_end_date_mhcs																							
-GE:mhd_ethnicity	mhd_ethnicity																							
-GE:mhd_gender	mhd_gender																							
-GE:mhd_health_care_spell_end_reason	mhd_health_care_spell_end_reason																							
-GE:mhd_lad_ua	mhd_lad_ua																							
-GE:mhd_manpsych_date	mhd_manpsych_date																							
-GE:mhd_marital_status	mhd_marital_status																							
-GE:mhd_pct_of_gp_practice	mhd_pct_of_gp_practice																							
-GE:mhd_pct_of_residence	mhd_pct_of_residence																							
-GE:mhd_postcode_district	mhd_postcode_district																							
-GE:mhd_propsych_date	mhd_propsych_date																							
-GE:mhd_provider_org_code	mhd_provider_org_code																							
-GE:mhd_psychpresc_date	mhd_psychpresc_date																							
-GE:mhd_psychtreat_start_date	mhd_psychtreat_start_date																							
-GE:mhd_start_date_mhcs	mhd_start_date_mhcs																							
-GE:mhd_valid_nhs_number_flag	mhd_valid_nhs_number_flag																							
-GE:mhd_valid_postcode_flag	mhd_valid_postcode_flag																							
-GE:mhd_year_of_first_known_psychiatric_care	mhd_year_of_first_known_psychiatric_care																							
-GE:reportingperiod_enddate	reportingperiod_enddate																							
-GE:reportingperiod_startdate	reportingperiod_startdate																							
-GE:ic_eve_primarydiagnosis	ic_eve_primarydiagnosis																							
-GE:ic_eve_secondarydiagnosis	ic_eve_secondarydiagnosis																							
-GE:mhd_abusequestion_indicator	mhd_abusequestion_indicator																							
-GE:mhd_accomodation_status	mhd_accomodation_status																							
-GE:mhd_assessment	mhd_assessment																							
-GE:mhd_attended_indicator	mhd_attended_indicator																							
-GE:mhd_carecluster_superclass_code	mhd_carecluster_superclass_code																							
-GE:mhd_carecoordinator_flag	mhd_carecoordinator_flag																							
-GE:mhd_clusteringtool_assessment_reason	mhd_clusteringtool_assessment_reason																							
-GE:mhd_consultmedium	mhd_consultmedium																							
-GE:mhd_contact_location_code	mhd_contact_location_code																							
-GE:mhd_contact_subject	mhd_contact_subject																							
-GE:mhd_duration	mhd_duration																							
-GE:mhd_employment_status	mhd_employment_status																							
-GE:mhd_event_id	mhd_event_id																							
-GE:mhd_eventdate	mhd_eventdate																							
-GE:mhd_eventtype	mhd_eventtype																							
-GE:mhd_honos_flag	mhd_honos_flag																							
-GE:mhd_honos_honosrating1_score	mhd_honos_honosrating1_score																							
-GE:mhd_honos_honosrating10_score	mhd_honos_honosrating10_score																							
-GE:mhd_honos_honosrating11_score	mhd_honos_honosrating11_score																							
-GE:mhd_honos_honosrating12_score	mhd_honos_honosrating12_score																							
-GE:mhd_honos_honosrating2_score	mhd_honos_honosrating2_score																							
-GE:mhd_honos_honosrating3_score	mhd_honos_honosrating3_score																							
-GE:mhd_honos_honosrating4_score	mhd_honos_honosrating4_score																							
-GE:mhd_honos_honosrating5_score	mhd_honos_honosrating5_score																							
-GE:mhd_honos_honosrating6_score	mhd_honos_honosrating6_score																							
-GE:mhd_honos_honosrating7_score	mhd_honos_honosrating7_score																							
-GE:mhd_honos_honosrating8_score	mhd_honos_honosrating8_score																							
-GE:mhd_honos_honosrating8_type	mhd_honos_honosrating8_type																							
-GE:mhd_honos_honosrating9_score	mhd_honos_honosrating9_score																							
-GE:mhd_honos_secure_flag	mhd_honos_secure_flag																							
-GE:mhd_honos65_flag	mhd_honos65_flag																							
-GE:mhd_honos65_rating1_score	mhd_honos65_rating1_score																							
-GE:mhd_honos65_rating10_score	mhd_honos65_rating10_score																							
-GE:mhd_honos65_rating11_score	mhd_honos65_rating11_score																							
-GE:mhd_honos65_rating12_score	mhd_honos65_rating12_score																							
-GE:mhd_honos65_rating2_score	mhd_honos65_rating2_score																							
-GE:mhd_honos65_rating3_score	mhd_honos65_rating3_score																							
-GE:mhd_honos65_rating4_score	mhd_honos65_rating4_score																							
-GE:mhd_honos65_rating5_score	mhd_honos65_rating5_score																							
-GE:mhd_honos65_rating6_score	mhd_honos65_rating6_score																							
-GE:mhd_honos65_rating7_score	mhd_honos65_rating7_score																							
-GE:mhd_honos65_rating8_score	mhd_honos65_rating8_score																							
-GE:mhd_honos65_rating8_type	mhd_honos65_rating8_type																							
-GE:mhd_honos65_rating9_score	mhd_honos65_rating9_score																							
-GE:mhd_honosca_flag	mhd_honosca_flag																							
-GE:mhd_honoscarating1_score	mhd_honoscarating1_score																							
-GE:mhd_honoscarating10_score	mhd_honoscarating10_score																							
-GE:mhd_honoscarating11_score	mhd_honoscarating11_score																							
-GE:mhd_honoscarating12_score	mhd_honoscarating12_score																							
-GE:mhd_honoscarating13_score	mhd_honoscarating13_score																							
-GE:mhd_honoscarating14_score	mhd_honoscarating14_score																							
-GE:mhd_honoscarating15_score	mhd_honoscarating15_score																							
-GE:mhd_honoscarating2_score	mhd_honoscarating2_score																							
-GE:mhd_honoscarating3_score	mhd_honoscarating3_score																							
-GE:mhd_honoscarating4_score	mhd_honoscarating4_score																							
-GE:mhd_honoscarating5_score	mhd_honoscarating5_score																							
-GE:mhd_honoscarating6_score	mhd_honoscarating6_score																							
-GE:mhd_honoscarating7_score	mhd_honoscarating7_score																							
-GE:mhd_honoscarating8_score	mhd_honoscarating8_score																							
-GE:mhd_honoscarating9_score	mhd_honoscarating9_score																							
-GE:mhd_honossecureratinga_score	mhd_honossecureratinga_score																							
-GE:mhd_honossecureratingb_score	mhd_honossecureratingb_score																							
-GE:mhd_honossecureratingc_score	mhd_honossecureratingc_score																							
-GE:mhd_honossecureratingd_score	mhd_honossecureratingd_score																							
-GE:mhd_honossecureratinge_score	mhd_honossecureratinge_score																							
-GE:mhd_honossecureratingf_score	mhd_honossecureratingf_score																							
-GE:mhd_honossecureratingg_score	mhd_honossecureratingg_score																							
-GE:mhd_jobrole	mhd_jobrole																							
-GE:mhd_mainspecialty	mhd_mainspecialty																							
-GE:mhd_mhc_team_type	mhd_mhc_team_type																							
-GE:mhd_mhct_flag	mhd_mhct_flag																							
-GE:mhd_mhct_honosrating1_score	mhd_mhct_honosrating1_score																							
-GE:mhd_mhct_honosrating10_score	mhd_mhct_honosrating10_score																							
-GE:mhd_mhct_honosrating11_score	mhd_mhct_honosrating11_score																							
-GE:mhd_mhct_honosrating12_score	mhd_mhct_honosrating12_score																							
-GE:mhd_mhct_honosrating2_score	mhd_mhct_honosrating2_score																							
-GE:mhd_mhct_honosrating3_score	mhd_mhct_honosrating3_score																							
-GE:mhd_mhct_honosrating4_score	mhd_mhct_honosrating4_score																							
-GE:mhd_mhct_honosrating5_score	mhd_mhct_honosrating5_score																							
-GE:mhd_mhct_honosrating6_score	mhd_mhct_honosrating6_score																							
-GE:mhd_mhct_honosrating7_score	mhd_mhct_honosrating7_score																							
-GE:mhd_mhct_honosrating8_score	mhd_mhct_honosrating8_score																							
-GE:mhd_mhct_honosrating8_type	mhd_mhct_honosrating8_type																							
-GE:mhd_mhct_honosrating9_score	mhd_mhct_honosrating9_score																							
-GE:mhd_nhs_occupcode	mhd_nhs_occupcode																							
-GE:mhd_pbr_cluster	mhd_pbr_cluster																							
-GE:mhd_phq9_q1_score	mhd_phq9_q1_score																							
-GE:mhd_phq9_q2_score	mhd_phq9_q2_score																							
-GE:mhd_phq9_q3_score	mhd_phq9_q3_score																							
-GE:mhd_phq9_q4_score	mhd_phq9_q4_score																							
-GE:mhd_phq9_q5_score	mhd_phq9_q5_score																							
-GE:mhd_phq9_q6_score	mhd_phq9_q6_score																							
-GE:mhd_phq9_q7_score	mhd_phq9_q7_score																							
-GE:mhd_phq9_q8_score	mhd_phq9_q8_score																							
-GE:mhd_phq9_q9_score	mhd_phq9_q9_score																							
-GE:mhd_phq9_total_score	mhd_phq9_total_score																							
-GE:mhd_primarydiagnosis	mhd_primarydiagnosis																							
-GE:mhd_sacrating13_score	mhd_sacrating13_score																							
-GE:mhd_sacratinga_score	mhd_sacratinga_score																							
-GE:mhd_sacratingb_score	mhd_sacratingb_score																							
-GE:mhd_sacratingc_score	mhd_sacratingc_score																							
-GE:mhd_sacratingd_score	mhd_sacratingd_score																							
-GE:mhd_sacratinge_score	mhd_sacratinge_score																							
-GE:mhd_secondarydiagnosis	mhd_secondarydiagnosis																							
-GE:mhd_settled_accommodation_indicator	mhd_settled_accommodation_indicator																							
-GE:mhd_treat	mhd_treat																							
-GE:mhd_weekly_hours_worked	mhd_weekly_hours_worked																							
-GE:ic_epi_rp_days	ic_epi_rp_days																							
-GE:ic_episode_epi_days	ic_episode_epi_days																							
-GE:mhd_admimet	mhd_admimet																							
-GE:mhd_commissioner_code	mhd_commissioner_code																							
-GE:mhd_delayed_dischend_date	mhd_delayed_dischend_date																							
-GE:mhd_delayed_dischreason	mhd_delayed_dischreason																							
-GE:mhd_delayed_dischstart_date	mhd_delayed_dischstart_date																							
-GE:mhd_dischdate	mhd_dischdate																							
-GE:mhd_dischmet	mhd_dischmet																							
-GE:mhd_dischreason	mhd_dischreason																							
-GE:mhd_endreason	mhd_endreason																							
-GE:mhd_endtime	mhd_endtime																							
-GE:mhd_epiend_date	mhd_epiend_date																							
-GE:mhd_episode_id	mhd_episode_id																							
-GE:mhd_epistart_date	mhd_epistart_date																							
-GE:mhd_epitype	mhd_epitype																							
-GE:mhd_expirydate	mhd_expirydate																							
-GE:mhd_expirytime	mhd_expirytime																							
-GE:mhd_int_clincare_intensity_code	mhd_int_clincare_intensity_code																							
-GE:mhd_intended_agegroup	mhd_intended_agegroup																							
-GE:mhd_mencat07	mhd_mencat07																							
-GE:mhd_referral_request_status_date	mhd_referral_request_status_date																							
-GE:mhd_refrec_date	mhd_refrec_date																							
-GE:mhd_sex_code	mhd_sex_code																							
-GE:mhd_source_of_referral	mhd_source_of_referral																							
-GE:mhd_starttime	mhd_starttime																							
-GE:mhd_status_of_service_request	mhd_status_of_service_request																							
-GE:mhd_teamtype	mhd_teamtype																							
-GE:mhd_wardsec_level	mhd_wardsec_level																							
-GE:event_type	event_type																							
-GE:event_date	event_date																							
-GE:supplied_gender	supplied_gender																							
-GE:supplied_date_of_birth	supplied_date_of_birth																							
-GE:latest_gender	latest_gender																							
-GE:latest_date_of_birth	latest_date_of_birth																							
-GE:date_of_death	date_of_death																							
-GE:gender_of_deceased	gender_of_deceased																							
-GE:date_of_birth	date_of_birth																							
-GE:date_of_registration	date_of_registration																							
-GE:icd9_underlying_cause	icd9_underlying_cause																							
-GE:icd9_multiple_cause_code_1	icd9_multiple_cause_code_1																							
-GE:icd9_multiple_cause_code_2	icd9_multiple_cause_code_2																							
-GE:icd9_multiple_cause_code_3	icd9_multiple_cause_code_3																							
-GE:icd9_multiple_cause_code_4	icd9_multiple_cause_code_4																							
-GE:icd9_multiple_cause_code_5	icd9_multiple_cause_code_5																							
-GE:icd9_multiple_cause_code_6	icd9_multiple_cause_code_6																							
-GE:icd9_multiple_cause_code_7	icd9_multiple_cause_code_7																							
-GE:icd9_multiple_cause_code_8	icd9_multiple_cause_code_8																							
-GE:icd9_multiple_cause_code_9	icd9_multiple_cause_code_9																							
-GE:icd9_multiple_cause_code_10	icd9_multiple_cause_code_10																							
-GE:icd9_multiple_cause_code_11	icd9_multiple_cause_code_11																							
-GE:icd9_multiple_cause_code_12	icd9_multiple_cause_code_12																							
-GE:icd9_multiple_cause_code_13	icd9_multiple_cause_code_13																							
-GE:icd9_multiple_cause_code_14	icd9_multiple_cause_code_14																							
-GE:icd9_multiple_cause_code_15	icd9_multiple_cause_code_15																							
-GE:icd10_underlying_cause	icd10_underlying_cause																							
-GE:icd10_multiple_cause_code_1	icd10_multiple_cause_code_1																							
-GE:icd10_multiple_cause_code_2	icd10_multiple_cause_code_2																							
-GE:icd10_multiple_cause_code_3	icd10_multiple_cause_code_3																							
-GE:icd10_multiple_cause_code_4	icd10_multiple_cause_code_4																							
-GE:icd10_multiple_cause_code_5	icd10_multiple_cause_code_5																							
-GE:icd10_multiple_cause_code_6	icd10_multiple_cause_code_6																							
-GE:icd10_multiple_cause_code_7	icd10_multiple_cause_code_7																							
-GE:icd10_multiple_cause_code_8	icd10_multiple_cause_code_8																							
-GE:icd10_multiple_cause_code_9	icd10_multiple_cause_code_9																							
-GE:icd10_multiple_cause_code_10	icd10_multiple_cause_code_10																							
-GE:icd10_multiple_cause_code_11	icd10_multiple_cause_code_11																							
-GE:icd10_multiple_cause_code_12	icd10_multiple_cause_code_12																							
-GE:icd10_multiple_cause_code_13	icd10_multiple_cause_code_13																							
-GE:icd10_multiple_cause_code_14	icd10_multiple_cause_code_14																							
-GE:icd10_multiple_cause_code_15	icd10_multiple_cause_code_15																							
-GE:patient_pseudo_id	patient_pseudo_id																							
-GE:tumour_pseudo_id	tumour_pseudo_id																							
-GE:nhs_number_status	nhs_number_status																							
-GE:gender_current_clean	gender_current_clean																							
-GE:consultant_speciality_code	consultant_speciality_code																							
-GE:primary_diagnosis	primary_diagnosis																							
-GE:morphology_clean	morphology_clean																							
-GE:stage_at_start	stage_at_start																							
-GE:regimen_number	regimen_number																							
-GE:programme_number	programme_number																							
-GE:intent_of_treatment	intent_of_treatment																							
-GE:analysis_group	analysis_group																							
-GE:benchmark_group	benchmark_group																							
-GE:height_at_start_of_regimen	height_at_start_of_regimen		height																					
-GE:weight_at_start_of_regimen	weight_at_start_of_regimen		weight																					
-GE:perf_stat_start_of_reg_clean	perf_stat_start_of_reg_clean																							
-GE:comorbidity_adjustment	comorbidity_adjustment																							
-GE:date_decision_to_treat	date_decision_to_treat																							
-GE:start_date_of_regimen	start_date_of_regimen																							
-GE:clinical_trial	clinical_trial																							
-GE:chemo_radiation	chemo_radiation																							
-GE:number_of_cycles_planned	number_of_cycles_planned																							
-GE:cycle_number	cycle_number																							
-GE:start_date_of_cycle	start_date_of_cycle																							
-GE:weight_at_start_of_cycle	weight_at_start_of_cycle		weight																					
-GE:perf_stat_start_of_cycle_clean	perf_stat_start_of_cycle_clean																							
-GE:opcs_procurement_code	opcs_procurement_code																							
-GE:drug_group	drug_group																							
-GE:actual_dose_per_administration	actual_dose_per_administration																							
-GE:administration_route	administration_route																							
-GE:administration_date	administration_date																							
-GE:opcs_delivery_code	opcs_delivery_code																							
-GE:date_of_final_treatment	date_of_final_treatment																							
-GE:regimen_mod_dose_reduction	regimen_mod_dose_reduction																							
-GE:regimen_mod_time_delay	regimen_mod_time_delay																							
-GE:regimen_mod_stopped_early	regimen_mod_stopped_early																							
-GE:regimen_outcome_summary	regimen_outcome_summary																							
+Label	Class Type	GECKO Label	GE Parents	Comment																				
+LABEL	CLASS_TYPE	C % SPLIT=|																						
+System Data		Genomics England																						
+Augmented/critical care period		history of augmented care|timeline																						
+Diagnosis		Genomics England																						
+Patient Data		Genomics England																						
+Admissions; Period of Care		Genomics England		 ?																				
+Psychiatric		Genomics England																						
+Maternity		Genomics England																						
+Geographical		Genomics England																						
+Episodes and spells; Period of care		Genomics England																						
+Clinical		Genomics England																						
+Clinical; Period of Care		Genomics England																						
+Practitioner		Genomics England																						
+Organisation		Genomics England																						
+Discharges; Period of Care		Genomics England																						
+Healthcare resource groups (HRG) data		Genomics England																						
+Patient Pathway		Genomics England																						
+Socio-economic		Genomics England																						
+Procedure		Genomics England																						
+Organisation data		Genomics England																						
+System data		Genomics England																						
+EPISODE MATCH RANK			Administrative																					
+episode_matched			Administrative																					
+Gender			Administrative																					
+HESID Matched			Administrative																					
+Hesid Rank			Administrative																					
+modified_date			Administrative																					
+patient_death			Administrative																					
+Procedure Revision Flag			Administrative																					
+Proms Procedure Code			Administrative																					
+proms_proc_group			Administrative																					
+proms_serial_no			Administrative																					
+Date of admission		life stage/time point	Admissions; Period of Care																					
+Method of admission			Admissions; Period of Care	waiting list or not waiting list																				
+Admission source			Admissions; Period of Care	where patient was prior to admission (hotel, home, court, psychiatrict, etc.)																				
+Date of decision to admit		life stage/time point	Admissions; Period of Care	date and time-related or timeline?																				
+Duration of elective wait (submitted)		life stage/time point	Admissions; Period of Care	date decided to admit -> actual admission date for elective admission - date and time-related or timeline?																				
+Calculation of Elecdur		life stage/time point	Admissions; Period of Care	above for waiting list or booked admissions 																				
+First regular day or night admission			Admissions; Period of Care																					
+Financial Year			Admissions; Period of Care|Appointments|Administrative																					
+Age Band 10 years		age/birthdate	Age Bands																					
+ic_age17_60		age/birthdate	Age Bands																					
+ic_age17_64		age/birthdate	Age Bands																					
+Age Band 5 years		age/birthdate	Age Bands																					
+ic_age50_74		age/birthdate	Age Bands																					
+ic_agechild		age/birthdate	Age Bands																					
+Appointment date			Appointments																					
+Attendance type			Appointments																					
+Attended or did not attend			Appointments																					
+Location Class			Appointments																					
+Location Tyoe			Appointments																					
+Outcome of attendance			Appointments																					
+Priority type			Appointments																					
+Service type requested			Appointments																					
+Medical staff type seeing patient			Appointments																					
+Code of patient‚Äö√Ñ√¥s registered or referring general medical practitioner			Appointments|Practitioner data																					
+Arrival mode			Attendances																					
+Attendances excluding planned			Attendances																					
+Attendance category			Attendances																					
+Attendance disposal			Attendances																					
+Department type			Attendances																					
+Incident location type			Attendances																					
+Patient group			Attendances																					
+Source of referral for A&E			Attendances																					
+Arrival date			Attendances																					
+Arrival time			Attendances																					
+Duration to conclusion			Attendances																					
+Conclusion time			Attendances																					
+Duration to departure			Attendances																					
+Departure time			Attendances																					
+Duration to assessment			Attendances																					
+Initial assessment time			Attendances																					
+Duration to treatment			Attendances																					
+Time seen for treatment			Attendances																					
+ACPDISP_N		history of augmented care	Augmented/critical care period	destination of discharged patient (e.g. ICU, home, death, etc.)																				
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDISP_N		history of augmented care	Augmented/critical care period																					
+ACPDQIND_N			Augmented/critical care period	quality of data																				
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period	end date of augmented care																				
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPEND_N		history of augmented care|life stage/time point	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period	location of augmented care																				
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPLOC_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period	order of an episode during augmented care																				
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPN_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period	death and organ donation																				
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPOUT_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period	was augmented care planned before admission?																				
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPPLAN_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period	location of patient before augmented care (e.g. ICU, recovery, ER, etc.)																				
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+ACPSOUR_N		history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period	speciality of consultant managing the augmented care																				
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period specialty function code		physician/practitioner info|history of augmented care	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+Augmented care period start date		history of augmented care|life stage/time point	Augmented/critical care period																					
+High-dependency care level			Augmented/critical care period	number of days of high-dependency care during augmented care (is this life support?)																				
+depdays_2			Augmented/critical care period																					
+depdays_3			Augmented/critical care period																					
+depdays_4			Augmented/critical care period																					
+depdays_5			Augmented/critical care period																					
+depdays_6			Augmented/critical care period																					
+depdays_7			Augmented/critical care period																					
+depdays_8			Augmented/critical care period																					
+depdays_9			Augmented/critical care period																					
+Intensive care level days		history of intensive care	Augmented/critical care period																					
+intdays_2		history of intensive care	Augmented/critical care period																					
+intdays_3		history of intensive care	Augmented/critical care period																					
+intdays_4		history of intensive care	Augmented/critical care period																					
+intdays_5		history of intensive care	Augmented/critical care period																					
+intdays_6		history of intensive care	Augmented/critical care period																					
+intdays_7		history of intensive care	Augmented/critical care period																					
+intdays_8		history of intensive care	Augmented/critical care period																					
+intdays_9		history of intensive care	Augmented/critical care period																					
+Number of augmented care periods within episode		history of augmented care	Augmented/critical care period																					
+Number of organ systems supported		history of organ support	Augmented/critical care period																					
+orgsup_2		history of organ support	Augmented/critical care period																					
+orgsup_3		history of organ support	Augmented/critical care period																					
+orgsup_4		history of organ support	Augmented/critical care period																					
+orgsup_5		history of organ support	Augmented/critical care period																					
+orgsup_6		history of organ support	Augmented/critical care period																					
+orgsup_7		history of organ support	Augmented/critical care period																					
+orgsup_8		history of organ support	Augmented/critical care period																					
+orgsup_9		history of organ support	Augmented/critical care period																					
+Early cancer diagnosis		oncological	Cancer diagnosis																					
+CCG Code			CCG	clinical commission group																				
+CCG Name			CCG	clinical commission group																				
+Cause Code			Clinical	cause of injury or poisoning																				
+diag_13			Clinical	should be under Clinical diagnoses - this can be disease or trauma																				
+diag_14			Clinical																					
+diag_15			Clinical																					
+diag_16			Clinical																					
+diag_17			Clinical																					
+diag_18			Clinical																					
+diag_19			Clinical																					
+diag_20			Clinical																					
+Date of procedure		surgical interventions	Clinical																					
+opdate_02		surgical interventions	Clinical																					
+opdate_03		surgical interventions	Clinical																					
+opdate_04		surgical interventions	Clinical																					
+opdate_05		surgical interventions	Clinical																					
+opdate_06		surgical interventions	Clinical																					
+opdate_07		surgical interventions	Clinical																					
+opdate_08		surgical interventions	Clinical																					
+opdate_09		surgical interventions	Clinical																					
+opdate_10		surgical interventions	Clinical																					
+opdate_11		surgical interventions	Clinical																					
+opdate_12		surgical interventions	Clinical																					
+opdate_13		surgical interventions	Clinical																					
+opdate_14		surgical interventions	Clinical																					
+opdate_15		surgical interventions	Clinical																					
+opdate_16		surgical interventions	Clinical																					
+opdate_17		surgical interventions	Clinical																					
+opdate_18		surgical interventions	Clinical																					
+opdate_19		surgical interventions	Clinical																					
+opdate_20		surgical interventions	Clinical																					
+opdate_21		surgical interventions	Clinical																					
+opdate_22		surgical interventions	Clinical																					
+opdate_23		surgical interventions	Clinical																					
+opdate_24		surgical interventions	Clinical																					
+Operation status code		surgical interventions	Clinical																					
+Operative procedure		surgical interventions	Clinical																					
+opertn_02		surgical interventions	Clinical																					
+opertn_03		surgical interventions	Clinical																					
+opertn_04		surgical interventions	Clinical																					
+opertn_05		surgical interventions	Clinical																					
+opertn_06		surgical interventions	Clinical																					
+opertn_07		surgical interventions	Clinical																					
+opertn_08		surgical interventions	Clinical																					
+opertn_09		surgical interventions	Clinical																					
+opertn_10		surgical interventions	Clinical																					
+opertn_11		surgical interventions	Clinical																					
+opertn_12		surgical interventions	Clinical																					
+opertn_13		surgical interventions	Clinical																					
+opertn_14		surgical interventions	Clinical																					
+opertn_15		surgical interventions	Clinical																					
+opertn_16		surgical interventions	Clinical																					
+opertn_17		surgical interventions	Clinical																					
+opertn_18		surgical interventions	Clinical																					
+opertn_19		surgical interventions	Clinical																					
+opertn_20		surgical interventions	Clinical																					
+opertn_21		surgical interventions	Clinical																					
+opertn_22		surgical interventions	Clinical																					
+opertn_23		surgical interventions	Clinical																					
+opertn_24		surgical interventions	Clinical																					
+Count of procedures		surgical interventions	Clinical																					
+Post-operative duration		surgical interventions	Clinical																					
+Pre-operative duration		surgical interventions	Clinical																					
+Waiting calculation indicator			Clinical	if and how 'Days Waiting' was calculated - timeline?																				
+A&E diagnosis: 2 character			Clinical diagnoses	disease or trauma																				
+diag2_02			Clinical diagnoses																					
+diag2_03			Clinical diagnoses																					
+diag2_04			Clinical diagnoses																					
+diag2_05			Clinical diagnoses																					
+diag2_06			Clinical diagnoses																					
+diag2_07			Clinical diagnoses																					
+diag2_08			Clinical diagnoses																					
+diag2_09			Clinical diagnoses																					
+diag2_10			Clinical diagnoses																					
+diag2_11			Clinical diagnoses																					
+diag2_12			Clinical diagnoses																					
+A&E diagnosis - anatomical area			Clinical Diagnoses	disease or trauma																				
+diaga_02			Clinical Diagnoses																					
+diaga_03			Clinical Diagnoses																					
+diaga_04			Clinical Diagnoses																					
+diaga_05			Clinical Diagnoses																					
+diaga_06			Clinical Diagnoses																					
+diaga_07			Clinical Diagnoses																					
+diaga_08			Clinical Diagnoses																					
+diaga_09			Clinical Diagnoses																					
+diaga_10			Clinical Diagnoses																					
+diaga_11			Clinical Diagnoses																					
+diaga_12			Clinical Diagnoses																					
+A&E diagnosis - anatomical side			Clinical Diagnoses	disease or trauma																				
+diags_02			Clinical Diagnoses																					
+diags_03			Clinical Diagnoses																					
+diags_04			Clinical Diagnoses																					
+diags_05			Clinical Diagnoses																					
+diags_06			Clinical Diagnoses																					
+diags_07			Clinical Diagnoses																					
+diags_08			Clinical Diagnoses																					
+diags_09			Clinical Diagnoses																					
+diags_10			Clinical Diagnoses																					
+diags_11			Clinical Diagnoses																					
+diags_12			Clinical Diagnoses																					
+Diagnosis Scheme in Use			Clinical diagnoses	e.g. ICD-10																				
+Number of Procedures		surgical interventions	Clinical Diagnosis																					
+Number of Diagnoses			Clinical Diagnosis|Clinical diagnoses	disease or trauma																				
+A&E investigation		laboratory measures|physiological measurements	Clinical Investigations	should I use OR or just two parents?																				
+invest_02		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_03		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_04		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_05		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_06		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_07		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_08		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_09		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_10		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_11		laboratory measures|physiological measurements	Clinical Investigations																					
+invest_12		laboratory measures|physiological measurements	Clinical Investigations																					
+A&E Investigation: 2 character		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_02		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_03		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_04		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_05		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_06		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_07		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_08		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_09		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_10		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_11		laboratory measures|physiological measurements	Clinical Investigations																					
+invest2_12		laboratory measures|physiological measurements	Clinical Investigations																					
+Number of Investigations		laboratory measures|physiological measurements	Clinical Investigations																					
+Number of Treatments		medication|non-pharmacological interventions	Clinical Treatments																					
+A&E treatment		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_02		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_03		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_04		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_05		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_06		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_07		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_08		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_09		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_10		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_11		medication|non-pharmacological interventions	Clinical Treatments																					
+treat_12		medication|non-pharmacological interventions	Clinical Treatments																					
+A&E Treatment: 2 character		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_02		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_03		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_04		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_05		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_06		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_07		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_08		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_09		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_10		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_11		medication|non-pharmacological interventions	Clinical Treatments																					
+treat2_12		medication|non-pharmacological interventions	Clinical Treatments																					
+Patient classification			Clinical; Period of Care	ordinary, day, night, delivery, etc.																				
+Intended management			Clinical; Period of Care	what was planned to happen in hospital																				
+Treatment specialty		physician/practitioner info	Clinical; Period of Care																					
+Main specialty		physician/practitioner info	Clinical; Period of Care|Clinical																					
+diag_02			Clinical|Clinical diagnoses	disease or trauma																				
+diag_03			Clinical|Clinical diagnoses																					
+diag_04			Clinical|Clinical diagnoses																					
+diag_05			Clinical|Clinical diagnoses																					
+diag_06			Clinical|Clinical diagnoses																					
+diag_07			Clinical|Clinical diagnoses																					
+diag_08			Clinical|Clinical diagnoses																					
+diag_09			Clinical|Clinical diagnoses																					
+diag_10			Clinical|Clinical diagnoses																					
+diag_11			Clinical|Clinical diagnoses																					
+diag_12			Clinical|Clinical diagnoses																					
+All Diagnosis codes			Clinical|Clinical Diagnosis|Clinical diagnoses	diagnosis codes for ER attendance (could be disease or trauma)																				
+Organisation code (patient pathway ID issuer)		unique identifiers	Clinical|Patient Pathway																					
+Commissioning Organisation Code			Commissioning Organisation																					
+Commissioning Organisation Name			Commissioning Organisation																					
+Last DNA or patient cancelled date			Count of diagnoses	this parent is not right? patient offered appt and missed date without advance notice																				
+ccsorcloc		history of intensive care	Critical care admission and discharge data	type of location patient in prior to start of critical care (recorvery, imaging, ER, etc.)																				
+acardsupdays		history of cardiovascular support	Critical care adult activity data																					
+aressupdays		history of respiratory support	Critical care adult activity data																					
+bcardsupdays		history of cardiovascular support	Critical care adult activity data																					
+bressupdays		history of respiratory support	Critical care adult activity data																					
+cclev2days		history of intensive care	Critical care adult activity data																					
+cclev3days		history of intensive care	Critical care adult activity data																					
+dermsupdays		history of dermatological support	Critical care adult activity data																					
+gisupdays		history of gastrointestinal support	Critical care adult activity data																					
+liversupdays		history of liver support	Critical care adult activity data																					
+neurosupdays		history of neurological support	Critical care adult activity data																					
+orgsupmax		history of organ support	Critical care adult activity data																					
+rensupdays		history of renal support	Critical care adult activity data																					
+ccadmisorc		history of intensive care	Critical care adult admission and discharge data	source of patient (same hospital, different hospital, etc.)																				
+ccadmitype		history of intensive care	Critical care adult admission and discharge data	was critical care result of non-emergency?																				
+ccdisdate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	dicharge date if alive or date of death																				
+ccdisdest		history of intensive care	Critical care adult admission and discharge data	destination of critical care discharge (same hospital, different hospital, etc.)																				
+ccdisloc		history of intensive care	Critical care adult admission and discharge data	location for further care at end of critical care																				
+ccdisrdydate		history of intensive care|life stage/time point	Critical care adult admission and discharge data	date declared ready for discharge or transfer																				
+ccdisrdytime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	time declared ready for discharge or transfer																				
+ccdisstat		history of intensive care	Critical care adult admission and discharge data	discharge status (e.g. early discharge, continuing care in another location, died, etc.)																				
+ccdistime		history of intensive care|life stage/time point	Critical care adult admission and discharge data	discharge time																				
+unitbedconfig			Critical care adult admission and discharge data	level 2 beds, level 3 beds, or flexible - in unit																				
+bestmatch			Critical care period of care	selects the best match for mulitple rows of critical care dates - this is just a Y/N flag																				
+ccapcrel			Critical care period of care	used to select bestmatch - derived from episode start date and discharge date																				
+ccstarttime		history of intensive care|life stage/time point	Critical care period of care	time critical care started																				
+ccunitfun			Critical care period of care	principal service provided in ward patient was admitted to for critical care (e.g. cardiac, thoracic, burns, etc.)																				
+ccstartdate		history of intensive care|life stage/time point	Critical care start date	critical care start date																				
+Ambulatory Care Sensitive Condition Flag			Diagnosis																					
+Principal alcohol related diagnosis		alcohol	Diagnosis																					
+Principal alcohol related diagnosis		alcohol	Diagnosis																					
+Principal alcohol related fraction		alcohol	Diagnosis																					
+Count of diagnoses			Diagnosis	disease or trauma																				
+Diagnostic Test Request Date			Diagnostic Test Dates	diagnostic tests could be physiological measurements or laboratory measures																				
+Diagnostic Test Request Received Date			Diagnostic Test Dates																					
+Diagnostic Test Date			Diagnostic Test Dates																					
+Month of Test			Diagnostic Test Dates																					
+Year of Test			Diagnostic Test Dates																					
+Service Report Issue Date			Diagnostic Test Dates																					
+Date of discharge		life stage/time point	Discharges; Period of Care																					
+Destination on discharge			Discharges; Period of Care																					
+Method of discharge			Discharges; Period of Care																					
+Discharge ready date		life stage/time point	Discharges; Period of Care																					
+Bed days within the year			Episodes and spells; Period of care																					
+Episode duration		life stage/time point	Episodes and spells; Period of care																					
+Date episode ended		life stage/time point	Episodes and spells; Period of care																					
+Episode order			Episodes and spells; Period of care	transfer to care of another consultant increases number of episode (1,2,3,4...)																				
+Date episode started		life stage/time point	Episodes and spells; Period of care																					
+Episode status			Episodes and spells; Period of care	was episode still occurring on Mar 31 (end of year)? date or timeline?																				
+Episode type			Episodes and spells; Period of care	general, delivery, birth, detained under mental health legisation or long-term psych patient, other deliver, other birth																				
+Finished Admission Episode			Episodes and spells; Period of care																					
+Finished Admission Episode, emergency classification			Episodes and spells; Period of care	admission from ER																				
+Finished Consultant Episode			Episodes and spells; Period of care	continuous period of care under one consultant																				
+Finished In-Year Discharge Episode			Episodes and spells; Period of care	(episodes and spells; period of care) patient was discharged at end of episode before end of year																				
+Beginning of spell indicator			Episodes and spells; Period of care																					
+Duration of spell			Episodes and spells; Period of care																					
+End of spell indicator			Episodes and spells; Period of care																					
+Ward type at start of episode			Episodes and spells; Period of care																					
+Year and month of HES dataset			Episodes and spells; Period of care|Appointments																					
+Ethnic Category Code		ethnicity/race	Ethnic Category																					
+Ethnic Category Group		ethnicity/race	Ethnic Category																					
+Ethnic Category Description		ethnicity/race	Ethnic Category																					
+Fetal ID		unique identifiers	Fetal																					
+Gender Code		gender	Gender																					
+Gender Description		gender	Gender																					
+Area Team of GP Practice			Geographical																					
+Area Team of Residence			Geographical																					
+Area Team of Treatment			Geographical																					
+Cancer network		residence	Geographical																					
+Cancer registry		residence	Geographical																					
+CCG of GP Practice		location|physician/practitioner info	Geographical																					
+CCG of Residence		residence	Geographical																					
+CCG of Residence		residence	Geographical																					
+Origin of CCG of Responsibility			Geographical	how CCG responsibility was assigned																				
+CCG of Treatment		location	Geographical	CCG where patient was treated																				
+Origin of CCG of Treatment			Geographical	how CCG treament was assigned																				
+Commissioning Region of GP Practice		location	Geographical																					
+Commissioning Region of Residence		residence	Geographical																					
+Commissioning Region of Treatment		location	Geographical																					
+Current electoral ward		residence	Geographical																					
+Current electoral ward (ONS)		residence	Geographical																					
+Government office region of treatment			Geographical																					
+Local authority district in 1998			Geographical																					
+Lower Super Output Area			Geographical																					
+Lower Super Output Area			Geographical																					
+Middle Super Output Area, 2011			Geographical																					
+Westminster parliamentary constituency			Geographical																					
+Westminster parliamentary constituency (ONS)			Geographical																					
+County of residence (ONS)		residence	Geographical																					
+Government Office region of residence		residence	Geographical																					
+Government office region of residence (ONS)		residence	Geographical																					
+Health Authority of residence		residence	Geographical																					
+Local authority district of residence		residence	Geographical																					
+Local authority district of residence (ONS)		residence	Geographical																					
+PCT of residence - mapped according to data year		residence	Geographical																					
+PCT of residence (2006)		residence	Geographical																					
+Regional Office of residence		residence	Geographical																					
+SHA of residence		residence	Geographical																					
+SHA of residence (2006)		residence	Geographical																					
+Regional Office of treatment			Geographical																					
+Rural/Urban Indicator			Geographical																					
+Electoral ward in 1991			Geographical																					
+Electoral ward in 1998			Geographical																					
+Census Output Area, 2011			Geographical																					
+Census Output Area, 2011			Geographical																					
+Census output area, 2001 (6 character ward identifier)			Geographical																					
+primerecp			Geographical																					
+PCT of residence (2002)		residence	Geographical																					
+SHA of residence (2002)		residence	Geographical																					
+PCT of residence - mapped according to data year		residence	Geographical																					
+County of residence		residence	Geographical|Appointments																					
+SHA area of treatment			Geographical|Appointments																					
+Ordnance Survey grid reference			Geographical|Organisation data																					
+Middle Super Output Area, 2001			Geographical|Patient Data																					
+Site code of treatment			Geographical|Patient Data																					
+Primary Care Trust area of main provider			Geographical|System Data																					
+Trust derived dominant procedure			Healthcare resource groups (HRG) data	procedure code submitted to SUS - is this a surgical procedure?																				
+Trust derived HRG value v3.5			Healthcare resource groups (HRG) data																					
+Version No. of Trust derived HRG			Healthcare resource groups (HRG) data																					
+SUS generated Core Spell HRG			Healthcare resource groups (HRG) data																					
+SUS generated HRG			Healthcare resource groups (HRG) data																					
+SUS generated HRG version number			Healthcare resource groups (HRG) data																					
+SUS generated HRG for information			Healthcare resource groups (HRG) data																					
+Trust derived HRG value			Healthcare resource groups (HRG) data|Patient Data																					
+hr_score_expected_final_model3			Hip Replacement																					
+Q1-HR6			Hip Replacement - Q1																					
+Q1-HR9			Hip Replacement - Q1																					
+Q1-HR3			Hip Replacement - Q1																					
+Q1-HR1			Hip Replacement - Q1																					
+hr_q1_score			Hip Replacement - Q1																					
+hr_q1_score_complete			Hip Replacement - Q1																					
+Q1-HR7			Hip Replacement - Q1																					
+Q1-HR10			Hip Replacement - Q1																					
+Q1-HR11			Hip Replacement - Q1																					
+Q1-HR2			Hip Replacement - Q1																					
+Q1-HR5			Hip Replacement - Q1																					
+Q1-HR8			Hip Replacement - Q1																					
+Q1-HR4			Hip Replacement - Q1																					
+Q1-HR12			Hip Replacement - Q1																					
+Q2-HR6			Hip Replacement - Q2																					
+Q2-HR9			Hip Replacement - Q2																					
+Q2-HR3			Hip Replacement - Q2																					
+Q2-HR1			Hip Replacement - Q2																					
+hr_q2_score			Hip Replacement - Q2																					
+hr_q2_score_complete			Hip Replacement - Q2																					
+Q2-HR7			Hip Replacement - Q2																					
+Q2-HR10			Hip Replacement - Q2																					
+Q2-HR11			Hip Replacement - Q2																					
+Q2-HR2			Hip Replacement - Q2																					
+Q2-HR5			Hip Replacement - Q2																					
+Q2-HR8			Hip Replacement - Q2																					
+Q2-HR4			Hip Replacement - Q2																					
+Q2-HR12			Hip Replacement - Q2																					
+Imaging Code (NICIP)			Imaging Codes																					
+Imaging Code (NICIP) Description			Imaging Codes																					
+Imaging Code (SNOMED)			Imaging Codes																					
+Arthritis Indicator		diagnosis of arthritis	Indicators																					
+Cancer Indicator		oncological	Indicators																					
+Circulation			Indicators	leg pain due to poor circulation																				
+Complete			Indicators	indicator if Q1 and Q2 are complete																				
+Depression		diagnosis of depression	Indicators																					
+Diabetes		diagnosis of diabetes	Indicators																					
+Heart Disease Indicator		diagnosis of heart disease	Indicators																					
+High Blood Pressiure Indicator		occurrence of high blood pressure	Indicators																					
+Kidney Disease		diagnosis of renal disease	Indicators																					
+Liver Disease		diagnosis of liver disease	Indicators																					
+Lung Disease		respiratory system	Indicators																					
+nervous_system		nervous system	Indicators																					
+stroke		occurrence of stroke	Indicators																					
+Q1 - KR10		signs and symptoms	Knee Replacement - Q1	may be too broad?																				
+Q1 - KR8		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR7		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR2		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR1		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR11		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR12		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR6		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR4		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR5		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR3		signs and symptoms	Knee Replacement - Q1																					
+Q1-KR9		signs and symptoms	Knee Replacement - Q1																					
+Q2-KR10		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR8		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR7		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR2		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR1		signs and symptoms	Knee Replacement - Q2																					
+kr_q2_score_complete		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR11		signs and symptoms	Knee Replacement - Q2																					
+kr_q2_stairs		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR6		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR4		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR5		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR3		signs and symptoms	Knee Replacement - Q2																					
+Q2-KR9		signs and symptoms	Knee Replacement - Q2																					
+Location - LSOA		residence	Location	derived from residence post code																				
+Location - MSOA		residence	Location	derived from residence post code																				
+Gestation period in weeks at first antenatal assessment		pregnancy history	Maternity																					
+First antenatal assessment date		pregnancy history	Maternity																					
+Antenatal days of stay		pregnancy history	Maternity																					
+Resuscitation Method			Maternity	resusciation for baby - may be drugs or non-pharm																				
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+BIRESUS_N			Maternity																					
+Birth Order		pregnancy history	Maternity	?																				
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+BIRORDR_N			Maternity																					
+Birth Status		pregnancy history	Maternity	baby stillborn or alive - maybe pregnancy history? not sure																				
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+BIRSTAT_N			Maternity																					
+Birth Weight		pregnancy history|weight	Maternity	not sure if it's right to call this both																				
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+BIRWEIT_N			Maternity																					
+Delivery place change reason			Maternity	why delivery place was changed																				
+Delivery place (intended)		pregnancy history|location	Maternity																					
+Alternative Delivery method (Derived)		pregnancy history	Maternity	method of birth (e.g. breech, forceps, etc.) may involve surgical intervention																				
+delmeth_2		pregnancy history	Maternity																					
+delmeth_3		pregnancy history	Maternity																					
+delmeth_4		pregnancy history	Maternity																					
+delmeth_5		pregnancy history	Maternity																					
+delmeth_6		pregnancy history	Maternity																					
+delmeth_7		pregnancy history	Maternity																					
+delmeth_8		pregnancy history	Maternity																					
+delmeth_9		pregnancy history	Maternity																					
+Labour/delivery onset method		pregnancy history	Maternity	may involve drugs or surgical																				
+Delivery place (actual)		pregnancy history|location	Maternity																					
+delplac_2			Maternity																					
+delplac_3			Maternity																					
+delplac_4			Maternity																					
+delplac_5			Maternity																					
+delplac_6			Maternity																					
+delplac_7			Maternity																					
+delplac_8			Maternity																					
+delplac_9			Maternity																					
+Anaesthetic given post-labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
+Anaesthetic given during labour or delivery		pregnancy history|use of anaesthetics	Maternity																					
+Status of person conducting delivery		physician/practitioner info	Maternity	is this also part of pregnancy history?																				
+delstat_2		physician/practitioner info	Maternity																					
+delstat_3		physician/practitioner info	Maternity																					
+delstat_4		physician/practitioner info	Maternity																					
+delstat_5		physician/practitioner info	Maternity																					
+delstat_6		physician/practitioner info	Maternity																					
+delstat_7		physician/practitioner info	Maternity																					
+delstat_8		physician/practitioner info	Maternity																					
+delstat_9		physician/practitioner info	Maternity																					
+Length of gestation			Maternity																					
+gestat_2			Maternity																					
+gestat_3			Maternity																					
+gestat_4			Maternity																					
+gestat_5			Maternity																					
+gestat_6			Maternity																					
+gestat_7			Maternity																					
+gestat_8			Maternity																					
+gestat_9			Maternity																					
+Healthly Neonate Indicator			Maternity																					
+Mother‚Äö√Ñ√¥s age at delivery			Maternity																					
+Episode Type - Maternity			Maternity																					
+Neonatal level of care			Maternity																					
+Age of baby in days			Maternity																					
+Number of babies		pregnancy history	Maternity																					
+Number of previous pregnancies		pregnancy history	Maternity																					
+Number of baby tails			Maternity																					
+Postnatal stay			Maternity																					
+Sex of baby		pregnancy history|biological sex	Maternity																					
+sexbaby_2		pregnancy history|biological sex	Maternity																					
+sexbaby_3		pregnancy history|biological sex	Maternity																					
+sexbaby_4		pregnancy history|biological sex	Maternity																					
+sexbaby_5		pregnancy history|biological sex	Maternity																					
+sexbaby_6		pregnancy history|biological sex	Maternity																					
+sexbaby_7		pregnancy history|biological sex	Maternity																					
+sexbaby_8		pregnancy history|biological sex	Maternity																					
+sexbaby_9		pregnancy history|biological sex	Maternity																					
+Well baby flag		pregnancy history	Maternity																					
+Modality ID			Modality	IDs that group procedures and methods																				
+Morphology ID			Morphology	categorizes imaging conducted on abnormalities																				
+Commissioning serial number			Organisation	identifies an NHS service agreement																				
+Health Authority area where patient‚Äö√Ñ√¥s GP is registered			Organisation	where GP is registered																				
+Regional Office area where patient‚Äö√Ñ√¥s GP was registered			Organisation	where GP is registered																				
+Primary care group			Organisation	PCG responsible for patient																				
+Provider code (5 character)			Organisation	code of organization acting as health care provider																				
+Commissioner code			Organisation	code of organization comissioning patient's care																				
+Commissioner‚Äö√Ñ√¥s Regional Office			Organisation	location of commissioner																				
+Commissioner‚Äö√Ñ√¥s Strategic Health Authority			Organisation	location of commissioner (SHA)																				
+Commissioner code status			Organisation	if commissioner's code is recognized by NHS																				
+Pseudonymised code of GP practice			Organisation	registered GP																				
+Organisation Code			Organisation	organization that submitted imaging record																				
+Organisation Code			Organisation	organization that submitted imaging record																				
+Organisation Name			Organisation	organization that submitted imaging record																				
+PCT of responsibility (2002)			Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
+Provider Code			Organisation data|Appointments	code of organization acting as health care provider																				
+Primary Care Trust area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (PCT)																				
+Strategic Health Authority area where patient‚Äö√Ñ√¥s GP was registered			Organisation|Organisation data	location of GP (SHA)																				
+Provider code (3 character)			Organisation|Organisation data																					
+Provider code of treatment			Organisation|Organisation data	combo of 3 and 5 character codes																				
+Provider type			Organisation|Organisation data	provdier type of organization																				
+PCT of responsibility (2006)			Organisation|System Data|Organisation data	primary care trust responsible for patient (location where GP is registered, not where patient lives)																				
+Age at activity date		age/birthdate	Patient Data																					
+Age on admission		age/birthdate	Patient Data																					
+ADMINCAT			Patient Data	what kind of patient (NHS, private, amenity, category II)																				
+Admin category at start of episode			Patient Data																					
+Administrative & legal status of patient			Patient Data	patient formally detained? e.g. psychiatric																				
+Age at end of episode		age/birthdate	Patient Data																					
+Ethnic category		ethnicity/race	Patient Data																					
+NHS Number valid flag			Patient Data																					
+Postcode Found			Patient Data																					
+Postcode district			Patient Data																					
+Age at start of episode			Patient Data																					
+Age at start of episode - babies decimalised			Patient Data																					
+Age on day of appointment			Patient Data																					
+Age on arrival - babies decimalised			Patient Data																					
+Ethnic category (audit version)			Patient Data																					
+Age on arrival			Patient Data																					
+Age on arrival - babies decimalised			Patient Data																					
+Date of birth - patient		age/birthdate	Patient Data|Appointments																					
+Sex of patient		biological sex	Patient Data|Appointments																					
+Earliest reasonable date offered			Patient Pathway	earliest date for appointment or admission - date and time-related or timeline?																				
+RTT period end date			Patient Pathway																					
+REFERRAL TO TREATMENT- RTT period start date			Patient Pathway																					
+RTT period status			Patient Pathway																					
+Method of Admission - Waiting List			Patient Pathway																					
+Days waiting			Patient Pathway																					
+Duration of wait (referral to treatment period)			Patient Pathway|Appointments																					
+Patient Source Setting Description			Patient Source Setting																					
+PostOp3			Post-Operative (Q2)																					
+q2_allergy			Post-Operative (Q2)																					
+PostOp5			Post-Operative (Q2)																					
+q2_assisted			Post-Operative (Q2)																					
+q2_assisted_by			Post-Operative (Q2)																					
+q2_bleeding			Post-Operative (Q2)																					
+q2_complete			Post-Operative (Q2)																					
+q2_completed_date			Post-Operative (Q2)																					
+q2_disability			Post-Operative (Q2)																					
+PostOp4			Post-Operative (Q2)																					
+q2_eq5d_health_scale			Post-Operative (Q2)																					
+q2_eq5d_index			Post-Operative (Q2)																					
+q2_eq5d_profile			Post-Operative (Q2)																					
+q2_eq5d_profile_complete			Post-Operative (Q2)																					
+q2_eq5d_scale_complete			Post-Operative (Q2)																					
+q2_form_version			Post-Operative (Q2)																					
+q2_further_surgery		pregnancy history	Post-Operative (Q2)																					
+q2_general_health			Post-Operative (Q2)																					
+q2_language			Post-Operative (Q2)																					
+q2_living_arrangements			Post-Operative (Q2)																					
+q2_mobility			Post-Operative (Q2)																					
+q2_readmitted			Post-Operative (Q2)																					
+q2_received_date			Post-Operative (Q2)																					
+q2_satisfaction			Post-Operative (Q2)																					
+q2_scan_date			Post-Operative (Q2)																					
+q2_self_care			Post-Operative (Q2)																					
+q2_success			Post-Operative (Q2)																					
+q2_surgery_date			Post-Operative (Q2)																					
+q2_urine			Post-Operative (Q2)																					
+q2_wound			Post-Operative (Q2)																					
+Consultant code		physician/practitioner info	Practitioner																					
+Referring organisation code			Practitioner																					
+Referrer code			Practitioner																					
+Referral request received date			Practitioner																					
+Code of GP practice			Practitioner|Geographical|Practitioner data																					
+PreOp3			Pre-Operative (Q1)	does pre-op fall under surgical?																				
+PreOp5			Pre-Operative (Q1)																					
+q1_assisted			Pre-Operative (Q1)																					
+q1_assisted_by			Pre-Operative (Q1)																					
+q1_complete			Pre-Operative (Q1)																					
+q1_completed_date			Pre-Operative (Q1)																					
+q1_disability			Pre-Operative (Q1)																					
+PO4			Pre-Operative (Q1)																					
+q1_eq5d_health_scale			Pre-Operative (Q1)																					
+q1_eq5d_index			Pre-Operative (Q1)																					
+q1_eq5d_profile			Pre-Operative (Q1)																					
+q1_eq5d_profile_complete			Pre-Operative (Q1)																					
+q1_eq5d_scale_complete			Pre-Operative (Q1)																					
+q1_form_version			Pre-Operative (Q1)																					
+q1_general_health			Pre-Operative (Q1)																					
+q1_language			Pre-Operative (Q1)																					
+q1_living_arrangements			Pre-Operative (Q1)																					
+q1_mobility			Pre-Operative (Q1)																					
+q1_previous_surgery			Pre-Operative (Q1)																					
+q1_procode			Pre-Operative (Q1)																					
+q1_received_date			Pre-Operative (Q1)																					
+q1_scan_date			Pre-Operative (Q1)																					
+q1_self_care			Pre-Operative (Q1)																					
+q1_symptom_period			Pre-Operative (Q1)																					
+opcs43			Procedure|Geographical																					
+Provider Name			Provider																					
+Provider SHA Code			Provider SHA																					
+Provider SHA Name			Provider SHA																					
+Provider Site Code			Provider Site																					
+Provider Site Name			Provider Site																					
+Psychiatric history on admission		mental and behaviour disorders	Psychiatric																					
+Duration of care to psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	period of time from admission date to psychiatric census																				
+Age at psychiatric census date		mental and behaviour disorders|life stage/time point	Psychiatric	age at psychiatric census																				
+Status of patient included in psychiatric census			Psychiatric	detained or not detained, long term																				
+Ward type at psychiatric census date			Psychiatric	characteristics of the ward																				
+Duration of detention		mental and behaviour disorders|life stage/time point	Psychiatric	days between detention and psychiatric cesus																				
+Date detention commenced		mental and behaviour disorders|life stage/time point	Psychiatric	when detention started (psychiatric)																				
+V code indicator			Psychiatric																					
+Marital status (psychiatric)		marital status value	Psychiatric|Clinical																					
+Care Support Indicator			Psychiatric|Patient Data	is care available to patient at home?																				
+Referrer Organisation code			Referrer Organisation																					
+Region ID			Region																					
+EQ5D HEALTH SCALE EXPECTED (MODEL1)			Scoring																					
+eq5d_index_change			Scoring																					
+EQ5D HEALTH SCALE EXPECTED (FINAL MODEL1)			Scoring																					
+EQ5D INDEX CHANGE			Scoring																					
+kr_q1_score_complete			Scoring																					
+kr_q2_score			Scoring																					
+kr_score_expected_final_model3			Scoring																					
+score_change			Scoring																					
+status			Scoring																					
+status_date			Scoring																					
+vv_q1_score			Scoring																					
+vv_q1_score_complete			Scoring																					
+vv_q1_total_score			Scoring																					
+vv_q2_score			Scoring																					
+vv_q2_score_complete			Scoring																					
+vv_q2_total_score			Scoring																					
+VV Score Final Predicted (Model 3)			Scoring																					
+IMD Index of Multiple Deprivation			Socio-economic|Geographical																					
+IMD Decile Group			Socio-economic|Geographical																					
+IMD Crime Domain			Socio-economic|Geographical																					
+IMD Education Training and Skills Domain			Socio-economic|Geographical																					
+IMD Employment Deprivation Domain			Socio-economic|Geographical																					
+IMD Health and Disability Domain			Socio-economic|Geographical																					
+IMD Barriers to Housing and Service Domain			Socio-economic|Geographical																					
+IMD Income Domain			Socio-economic|Geographical																					
+IMD Income affecting Adults Domain			Socio-economic|Geographical																					
+IMD Income affecting Children Domain			Socio-economic|Geographical																					
+IMD Living Environment Domain			Socio-economic|Geographical																					
+IMD Overall Rank			Socio-economic|Geographical																					
+Sub Modality ID			Sub Modality																					
+Sub Region ID			Sub Region																					
+Sub System ID			Sub System																					
+Sub-System Component ID			Sub-System Component																					
+System ID			System																					
+Patient identifier		unique identifiers	System Data																					
+NHS Patient identifier		unique identifiers	System Data																					
+match_rank			System Data																					
+Record identifier		unique identifiers	System Data																					
+CDS extract date			System Data	system data for updates																				
+CDS protocol identifier		unique identifiers	System Data	system data SUS																				
+CDS version number			System Data	system data SUS																				
+Ethnic character (audit version)		ethnicity/race	System Data																					
+NHS number status indicator			System Data																					
+Origin of primary care group			System Data																					
+Origin of primary care trust of responsibility			System Data																					
+Origin of PCT of responsibility (2006)			System Data																					
+CDS sender identity			System Data																					
+SUS generated spell identifier			System Data																					
+Record identifier			System Data																					
+Attendence Key Flag			System Data																					
+First attendance			System Data																					
+Origin of primary care trust of responsibility dependent on the data year			System Data																					
+AEKEY flag			System Data																					
+Net applicable date			System Data																					
+PCT of responsibility dependent on the data year			System Data																					
+Origin of PCT of responsibility (2002)			System Data																					
+Reporting period end date			System Data																					
+SUS generated HRG version number			System Data																					
+Record Identifier			System Data																					
+NHS Number Status			System Data																					
+NHS Number Status Description			System Data																					
+Record identifier		unique identifiers	System Data|Administrative																					
+PCT of responsibility dependent on the data year			System Data|Geographical																					
+Submission date			System Data|Geographical																					
+SUS loaded staging date			System Data|Healthcare resource groups (HRG) data																					
+Primary care trust			System Data|Organisation Data																					
+SUS record ID		unique identifiers	System Data|System data																					
+Q1-VV4		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV3		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV8		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV6		occurrence of varicose veins	Varicose Vein - Q1																					
+vv_q1_max_score		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV1		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV11		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV7		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV10		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV9		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV12		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV13		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV2		occurrence of varicose veins	Varicose Vein - Q1																					
+Q1-VV5		occurrence of varicose veins	Varicose Vein - Q1																					
+Q2-VV4		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV3		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV8		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV6		occurrence of varicose veins	Varicose Vein - Q2																					
+vv_q2_max_score		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV1		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV11		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV7		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV10		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV9		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV12		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV13		occurrence of varicose veins	Varicose Vein - Q2																					
+Q2-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+Q1-VV2		occurrence of varicose veins	Varicose Vein - Q2																					
+Q1-VV5		occurrence of varicose veins	Varicose Vein - Q2																					
+Critical care adult activity data		history of intensive care		critical care == life support ?																				
+Critical care period of care		history of intensive care																						
+Critical care adult admission and discharge data		history of intensive care																						
+Critical care admission and discharge data		history of intensive care																						
+Critical care start date		history of intensive care																						
+Appointments				outpatient appointments (broad)																				
+Clinical Diagnosis				might this also include non-disease diagnoses, e.g. trauma																				
+Organisation Data				details about the provider, health authority, etc. (Broad)																				
+Attendances				attendances to the ER (broad)																				
+Clinical diagnoses				diagnoses made at the ER (broad), could be disease or trauma?																				
+Practitioner data		physician/practitioner info																						
+Clinical Investigations				investigations made at the ER (broad)																				
+Clinical Treatments				treatments made at the ER (broad) - either pharmaceutical or non-pharmaceutical																				
+Diagnostic Test Dates				could be 'laboratory measures' but this isn't the actual test, just dates so 'timeline' might be better?																				
+Ethnic Category		ethnicity/race																						
+Imaging Codes		laboratory measures		standardized codes for imaging procedures																				
+Referrer Organisation		physician/practitioner info																						
+Age Bands				broader than 'age/birthdate' - this is a grouping category																				
+Cancer diagnosis		oncological																						
+CCG				clincial commision groups - this is broader than physcian?																				
+Location		location																						
+Commissioning Organisation																								
+Provider SHA		physician/practitioner info																						
+Provider		physician/practitioner info																						
+Provider Site		physician/practitioner info																						
+Indicators		diseases		indicators for diseases																				
+Administrative				not sure this maps to anything																				
+Scoring				not sure this maps to anything																				
+Hip Replacement - Q1				are these questions to determine if hip replacement is NEEDED (symptoms) or after hip replacement?																				
+Hip Replacement - Q2																								
+Hip Replacement																								
+Knee Replacement - Q1				are these questions to determine if knee replacement is NEEDED (symptoms) or after knee replacement?																				
+Knee Replacement - Q2																								
+Pre-Operative (Q1)				questions about QOL before surgery, does this fall under 'surgical'?																				
+Post-Operative (Q2)				questions about QOL after surgery, does this fall under 'surgical'?																				
+Varicose Vein - Q1		occurrence of varicose veins																						
+Varicose Vein - Q2		occurrence of varicose veins																						
+acpdqind_2																								
+acpdqind_3																								
+acpdqind_4																								
+acpdqind_5																								
+acpdqind_6																								
+acpdqind_7																								
+acpdqind_8																								
+acpdqind_9																								
+delmeth_d		pregnancy history																						
+primercp																								
+resstha_his																								
+Patient Source Setting																								
+did_snomedct_code																								
+Test Request to Test Request Received																								
+Test Request to Test																								
+Test Request to Service (Test) Report Issue																								
+Test Request Received to Test																								
+Test Request Received to Service (test) Report Issue																								
+Test to Service (Test) Report Issue																								
+Fetal																								
+Modality																								
+Morphology																								
+Referrer																								
+Referrer type																								
+Region																								
+Sub Early cancer diagnosis																								
+Sub Modality																								
+Sub Region																								
+Sub System																								
+Sub-System Component																								
+System																								
+hes_dids_version																								
+mhd_mhmds_person_id																								
+mhd_mhmds_spell_id																								
+ic_annual_id																								
+ic_inactive_timestamp																								
+ic_interim_ccg_code																								
+ic_rec_ccg																								
+ic_rec_endrp_aot_flag																								
+ic_rec_endrp_cluster_flag																								
+ic_rec_endrp_cluster_type																								
+ic_rec_endrp_cpa_epi_12_months																								
+ic_rec_endrp_cpa_flag																								
+ic_rec_endrp_cpa_review_within_12mnths																								
+ic_rec_endrp_eit_flag																								
+ic_rec_endrp_employment_status																								
+ic_rec_endrp_honos_assessment_within_12mnths																								
+ic_rec_endrp_hospital_spell_flag																								
+ic_rec_endrp_mha_flag																								
+ic_rec_endrp_pdiag_flag																								
+ic_rec_endrp_recall_flag																								
+ic_rec_endrp_sct_flag																								
+ic_rec_endrp_settled_accommodation_indicator																								
+ic_rec_ethnicity		ethnicity/race																						
+ic_rec_rp_admission																								
+ic_rec_rp_admission_formal																								
+ic_rec_rp_awol																								
+ic_rec_rp_commissioners																								
+ic_rec_rp_contacts																								
+ic_rec_rp_contacts_att																								
+ic_rec_rp_dayatt_contacts																								
+ic_rec_rp_dayatt_contacts_att																								
+ic_rec_rp_ddisc_days																								
+ic_rec_rp_disch_net_followup																								
+ic_rec_rp_discharges_gross																								
+ic_rec_rp_discharges_net																								
+ic_rec_rp_readmissions																								
+ic_rec_rp_wrdst_days_cleansed																								
+ic_rec_rp_wrdst_days_gross																								
+ic_rec_rp_wrdst_days_net																								
+ic_source_period_id																								
+ic_spell_rp_days																								
+mhd_age		age/birthdate																						
+mhd_ccg_of_gp_practice		physician/practitioner info																						
+mhd_ccg_of_residence																								
+mhd_code_of_commissioner																								
+mhd_code_of_gp_practice		physician/practitioner info																						
+mhd_county		residence																						
+mhd_crisisplancreat_date																								
+mhd_crisisplanupdate_date																								
+mhd_electoral_ward_of_usual_address																								
+mhd_emerpsych_date																								
+mhd_end_date_mhcs																								
+mhd_ethnicity		ethnicity/race																						
+mhd_gender		gender																						
+mhd_health_care_spell_end_reason																								
+mhd_lad_ua																								
+mhd_manpsych_date																								
+mhd_marital_status																								
+mhd_pct_of_gp_practice																								
+mhd_pct_of_residence																								
+mhd_postcode_district																								
+mhd_propsych_date																								
+mhd_provider_org_code																								
+mhd_psychpresc_date																								
+mhd_psychtreat_start_date																								
+mhd_start_date_mhcs																								
+mhd_valid_nhs_number_flag																								
+mhd_valid_postcode_flag																								
+mhd_year_of_first_known_psychiatric_care																								
+reportingperiod_enddate																								
+reportingperiod_startdate																								
+ic_eve_primarydiagnosis																								
+ic_eve_secondarydiagnosis																								
+mhd_abusequestion_indicator																								
+mhd_accomodation_status																								
+mhd_assessment																								
+mhd_attended_indicator																								
+mhd_carecluster_superclass_code																								
+mhd_carecoordinator_flag																								
+mhd_clusteringtool_assessment_reason																								
+mhd_consultmedium																								
+mhd_contact_location_code																								
+mhd_contact_subject																								
+mhd_duration																								
+mhd_employment_status																								
+mhd_event_id																								
+mhd_eventdate																								
+mhd_eventtype																								
+mhd_honos_flag																								
+mhd_honos_honosrating1_score																								
+mhd_honos_honosrating10_score																								
+mhd_honos_honosrating11_score																								
+mhd_honos_honosrating12_score																								
+mhd_honos_honosrating2_score																								
+mhd_honos_honosrating3_score																								
+mhd_honos_honosrating4_score																								
+mhd_honos_honosrating5_score																								
+mhd_honos_honosrating6_score																								
+mhd_honos_honosrating7_score																								
+mhd_honos_honosrating8_score																								
+mhd_honos_honosrating8_type																								
+mhd_honos_honosrating9_score																								
+mhd_honos_secure_flag																								
+mhd_honos65_flag																								
+mhd_honos65_rating1_score																								
+mhd_honos65_rating10_score																								
+mhd_honos65_rating11_score																								
+mhd_honos65_rating12_score																								
+mhd_honos65_rating2_score																								
+mhd_honos65_rating3_score																								
+mhd_honos65_rating4_score																								
+mhd_honos65_rating5_score																								
+mhd_honos65_rating6_score																								
+mhd_honos65_rating7_score																								
+mhd_honos65_rating8_score																								
+mhd_honos65_rating8_type																								
+mhd_honos65_rating9_score																								
+mhd_honosca_flag																								
+mhd_honoscarating1_score																								
+mhd_honoscarating10_score																								
+mhd_honoscarating11_score																								
+mhd_honoscarating12_score																								
+mhd_honoscarating13_score																								
+mhd_honoscarating14_score																								
+mhd_honoscarating15_score																								
+mhd_honoscarating2_score																								
+mhd_honoscarating3_score																								
+mhd_honoscarating4_score																								
+mhd_honoscarating5_score																								
+mhd_honoscarating6_score																								
+mhd_honoscarating7_score																								
+mhd_honoscarating8_score																								
+mhd_honoscarating9_score																								
+mhd_honossecureratinga_score																								
+mhd_honossecureratingb_score																								
+mhd_honossecureratingc_score																								
+mhd_honossecureratingd_score																								
+mhd_honossecureratinge_score																								
+mhd_honossecureratingf_score																								
+mhd_honossecureratingg_score																								
+mhd_jobrole																								
+mhd_mainspecialty																								
+mhd_mhc_team_type																								
+mhd_mhct_flag																								
+mhd_mhct_honosrating1_score																								
+mhd_mhct_honosrating10_score																								
+mhd_mhct_honosrating11_score																								
+mhd_mhct_honosrating12_score																								
+mhd_mhct_honosrating2_score																								
+mhd_mhct_honosrating3_score																								
+mhd_mhct_honosrating4_score																								
+mhd_mhct_honosrating5_score																								
+mhd_mhct_honosrating6_score																								
+mhd_mhct_honosrating7_score																								
+mhd_mhct_honosrating8_score																								
+mhd_mhct_honosrating8_type																								
+mhd_mhct_honosrating9_score																								
+mhd_nhs_occupcode																								
+mhd_pbr_cluster																								
+mhd_phq9_q1_score																								
+mhd_phq9_q2_score																								
+mhd_phq9_q3_score																								
+mhd_phq9_q4_score																								
+mhd_phq9_q5_score																								
+mhd_phq9_q6_score																								
+mhd_phq9_q7_score																								
+mhd_phq9_q8_score																								
+mhd_phq9_q9_score																								
+mhd_phq9_total_score																								
+mhd_primarydiagnosis																								
+mhd_sacrating13_score																								
+mhd_sacratinga_score																								
+mhd_sacratingb_score																								
+mhd_sacratingc_score																								
+mhd_sacratingd_score																								
+mhd_sacratinge_score																								
+mhd_secondarydiagnosis																								
+mhd_settled_accommodation_indicator																								
+mhd_treat																								
+mhd_weekly_hours_worked																								
+ic_epi_rp_days																								
+ic_episode_epi_days																								
+mhd_admimet																								
+mhd_commissioner_code																								
+mhd_delayed_dischend_date																								
+mhd_delayed_dischreason																								
+mhd_delayed_dischstart_date																								
+mhd_dischdate																								
+mhd_dischmet																								
+mhd_dischreason																								
+mhd_endreason																								
+mhd_endtime																								
+mhd_epiend_date																								
+mhd_episode_id																								
+mhd_epistart_date																								
+mhd_epitype																								
+mhd_expirydate																								
+mhd_expirytime																								
+mhd_int_clincare_intensity_code																								
+mhd_intended_agegroup																								
+mhd_mencat07																								
+mhd_referral_request_status_date																								
+mhd_refrec_date																								
+mhd_sex_code		biological sex																						
+mhd_source_of_referral																								
+mhd_starttime																								
+mhd_status_of_service_request																								
+mhd_teamtype																								
+mhd_wardsec_level																								
+event_type																								
+event_date																								
+supplied_gender		gender																						
+supplied_date_of_birth		age/birthdate																						
+latest_gender		gender																						
+latest_date_of_birth		age/birthdate																						
+date_of_death		life stage/time point																						
+gender_of_deceased		gender																						
+date_of_birth		age/birthdate																						
+date_of_registration				maybe time point?																				
+icd9_underlying_cause				is this disease only, or disease and trauma?																				
+icd9_multiple_cause_code_1																								
+icd9_multiple_cause_code_2																								
+icd9_multiple_cause_code_3																								
+icd9_multiple_cause_code_4																								
+icd9_multiple_cause_code_5																								
+icd9_multiple_cause_code_6																								
+icd9_multiple_cause_code_7																								
+icd9_multiple_cause_code_8																								
+icd9_multiple_cause_code_9																								
+icd9_multiple_cause_code_10																								
+icd9_multiple_cause_code_11																								
+icd9_multiple_cause_code_12																								
+icd9_multiple_cause_code_13																								
+icd9_multiple_cause_code_14																								
+icd9_multiple_cause_code_15																								
+icd10_underlying_cause																								
+icd10_multiple_cause_code_1																								
+icd10_multiple_cause_code_2																								
+icd10_multiple_cause_code_3																								
+icd10_multiple_cause_code_4																								
+icd10_multiple_cause_code_5																								
+icd10_multiple_cause_code_6																								
+icd10_multiple_cause_code_7																								
+icd10_multiple_cause_code_8																								
+icd10_multiple_cause_code_9																								
+icd10_multiple_cause_code_10																								
+icd10_multiple_cause_code_11																								
+icd10_multiple_cause_code_12																								
+icd10_multiple_cause_code_13																								
+icd10_multiple_cause_code_14																								
+icd10_multiple_cause_code_15																								
+patient_pseudo_id																								
+tumour_pseudo_id																								
+nhs_number_status																								
+gender_current_clean		gender																						
+consultant_speciality_code		physician/practitioner info		provider specialty code for cancer treatment																				
+primary_diagnosis		oncological																						
+morphology_clean		oncological		morphology for cell type before cancer treatment - maybe physiological?																				
+stage_at_start		oncological		tumor/metastasis stage before treatment																				
+regimen_number				Chronological order of SACT drug regimen since commencement of patient's disease management																				
+programme_number				Chronological order of SACT drug programme since commencement of patient's disease management																				
+intent_of_treatment																								
+analysis_group																								
+benchmark_group																								
+height_at_start_of_regimen		height																						
+weight_at_start_of_regimen		weight																						
+perf_stat_start_of_reg_clean				activity/disability status																				
+comorbidity_adjustment		prescription		if patient's physical state was significant in deciding type of anti-cacer drugs																				
+date_decision_to_treat		life stage/time point																						
+start_date_of_regimen		life stage/time point																						
+clinical_trial				is patient part of clinical trial																				
+chemo_radiation		use of anti-cancer drugs|history of radiation treatment																						
+number_of_cycles_planned		use of anti-cancer drugs																						
+cycle_number		use of anti-cancer drugs																						
+start_date_of_cycle		life stage/time point																						
+weight_at_start_of_cycle		weight																						
+perf_stat_start_of_cycle_clean				activity/disability status																				
+opcs_procurement_code				OPCS code to identify procurement																				
+drug_group		use of anti-cancer drugs																						
+actual_dose_per_administration		posology																						
+administration_route		administration method																						
+administration_date		administration method																						
+opcs_delivery_code				OPCS code to identify delivery (of baby?)																				
+date_of_final_treatment		use of anti-cancer drugs																						
+regimen_mod_dose_reduction		posology																						
+regimen_mod_time_delay		use of anti-cancer drugs		extending time between administration - is this prescription or admin method?																				
+regimen_mod_stopped_early		use of anti-cancer drugs																						
+regimen_outcome_summary		use of anti-cancer drugs		anti cancer drug program completed or not																				
+																								

--- a/mappings/index.tsv
+++ b/mappings/index.tsv
@@ -516,3 +516,4 @@ GCS:0000000		GCS
 GE:0000000		Genomics England																										
 SAPRIN:0000000		SAPRIN																										
 VZ:0000000		Vukuzazi																										
+MAELSTROM:0000000		Maelstrom																										

--- a/mappings/index.tsv
+++ b/mappings/index.tsv
@@ -1,453 +1,518 @@
-ID	Ontology Label	Preferred Label	Value	Class Type	Parent	Target	Output Of	Measurement Of	Information About	Comment																	
-ID	A alternative term	LABEL		CLASS_TYPE	C % SPLIT=|	C 'has target' some %	C 'output of' some %	C 'measurement of' some %	C 'is about' some %	A comment																	
-GECKO:9999998		CINECA																									
-																											
-GECKO:0000093	medication	medication history			CINECA|clinical history																						
-GECKO:0000092		surgical interventions			CINECA																						
-GECKO:0000091		non-pharmacological interventions			CINECA|clinical history																						
-GECKO:0000090		heart rate			CINECA																						
-GECKO:0000089		blood pressure			CINECA																						
-GECKO:0000088		circulation and respiration			CINECA																						
-GECKO:0000087		height			CINECA																						
-GECKO:0000086		weight			CINECA																						
-GECKO:0000085		anthropometry			CINECA																						
-GECKO:0000084		physiological measurements			CINECA																						
-GECKO:0000083		signs and symptoms			CINECA																						
-GECKO:0000082		oncological			CINECA																						
-GECKO:0000081		circulatory system			CINECA																						
-GECKO:0000080		respiratory system			CINECA																						
-GECKO:0000079		digestive system			CINECA																						
-GECKO:0000078		nervous system			CINECA																						
-GECKO:0000077		mental and behaviour disorders			CINECA																						
-GECKO:0000076		endocrine/nutritional/metabolic disorders			CINECA																						
-GECKO:0000075		blood-related disorders			CINECA																						
-GECKO:0000074		diseases			CINECA|clinical history																						
-GECKO:0000073		physician/practitioner info			CINECA																						
-GECKO:0000072		nutrition			CINECA																						
-GECKO:0000071		sleep		equivalent	clinical history				GO sleep																		
-GECKO:0000070		physical activity			CINECA																						
-GECKO:0000069		alcohol			CINECA																						
-GECKO:0000068		tobacco			CINECA																						
-GECKO:0000068					lifestyle and behaviours				Smoking																		
-GECKO:0000067		lifestyle and behaviours			CINECA																						
-GECKO:0000066		family and household structure			CINECA																						
-GECKO:0000065		education			CINECA																						
-GECKO:0000065				equivalent	socio-demographic and economic characteristics				NCIT Education																		
-GECKO:0000064		residence			CINECA																						
-GECKO:0000063		birthplace			CINECA																						
-GECKO:0000062		genealogy			CINECA																						
-GECKO:0000061		ethnicity/race			CINECA																						
-GECKO:0000060		gender			CINECA																						
-GECKO:0000059		biological sex			CINECA																						
-GECKO:0000058		age/birthdate			CINECA																						
-GECKO:0000057		socio-demographic and economic characteristics			CINECA																						
-GECKO:0000056		questionnaire/survey data			CINECA																						
-GECKO:0000055		unique identifiers			CINECA																						
-GECKO:0000054		consent/accessibility			CINECA																						
-GECKO:0000053		date and time-related information			CINECA																						
-GECKO:0000052		survey administration			CINECA																						
-GECKO:0000051		associated medication			CINECA																						
-GECKO:0000050		associated disease			CINECA																						
-GECKO:0000049		associated phenotype			CINECA																						
-GECKO:0000048		associated cell type/tissue type/biosample			CINECA																						
-GECKO:0000047		processing method			CINECA																						
-GECKO:0000046		availability			CINECA																						
-GECKO:0000045		available data format(s)			CINECA																						
-GECKO:0000044		sample size			CINECA																						
-GECKO:0000043		other			CINECA																						
-GECKO:0000042		eQTL			CINECA																						
-GECKO:0000041		RNAseq/gene expression			CINECA																						
-GECKO:0000040		Microbiome markers			CINECA																						
-GECKO:0000039		Metagenomics			CINECA																						
-GECKO:0000038		Epigenetics			CINECA																						
-GECKO:0000037		Sequence variants			CINECA																						
-GECKO:0000036		WES			CINECA																						
-GECKO:0000035		WGS			CINECA																						
-GECKO:0000034		DNA/Genotyping			CINECA																						
-GECKO:0000033		data type			CINECA																						
-GECKO:0000032		genomics			CINECA																						
-GECKO:0000030		biosample source/anatomical location			CINECA																						
-GECKO:0000029		microbial data			CINECA																						
-GECKO:0000028		microbiology			CINECA																						
-GECKO:0000027		laboratory measures			CINECA																						
-GECKO:0000026		storage method			CINECA																						
-GECKO:0000021		saliva			CINECA																						
-GECKO:0000020		stool			CINECA																						
-GECKO:0000019		fasting or non-fasting			CINECA																						
-GECKO:0000018		venous or arterial			CINECA																						
-GECKO:0000017		blood			CINECA																						
-GECKO:0000016		urine			CINECA																						
-GECKO:0000015		sample type			CINECA																						
-GECKO:0000014		biosample			CINECA																						
-GECKO:0000013		data collection events			CINECA																						
-GECKO:0000012		age range			CINECA																						
-GECKO:0000011		gender(s) studied in cohort			CINECA																						
-GECKO:0000010		sex(es) studied in cohort			CINECA																						
-GECKO:0000009		demographic data			CINECA																						
-GECKO:0000008		num. participants			CINECA																						
-GECKO:0000007		criteria for enrollment and recruitment procedures			CINECA																						
-GECKO:0000006		location			CINECA																						
-GECKO:0000005		population data			CINECA																						
-GECKO:0000004		study design			CINECA																						
-GECKO:0000003		timeline			CINECA																						
-GECKO:0000002		aims and objectives			CINECA																						
-GECKO:0000001		basic cohort attributes			CINECA																						
-EFO:0008354	cognitive function measurement	cognitive function measurement result			physiological measurements					mental health																	
-EFO:0007869	wellbeing measurement	wellbeing measurement result			physiological measurements					mental health																	
-EFO:0007117	carotid artery intima media thickness	carotid artery intima media thickness value			physiological measurements																						
-EFO:0006941	grip strength measurement	grip strength measurement value			physiological measurements																						
-EFO:0005666	thyroid peroxidase antibody measurement	thyroid peroxidase antibody measurement value			blood measurement value																						
-EFO:0003926	neuropsychological test	neuropsychological test result		subclass	physiological measurements					mental health																	
-DOID:8725		vascular dementia			disease																						
-DOID:848		arthritis			disease																						
-DOID:77		gastrointestinal system disease			disease																						
-DOID:535		sleep disorder			disease																						
-DOID:5223		infertility			disease																						
-DOID:4		disease			entity																						
-DOID:2825		nose disease			disease																						
-DOID:1579		respiratory system disease		equivalent	respiratory system																						
-DOID:1307		dementia			disease																						
-DOID:10652		Alzheimer's disease			disease																						
-DOID:0050155		auditory system disease			disease																						
-CMO:0002821	blood osteocalcin level	blood osteocalcin level value		equivalent	blood measurement value	osteocalcin																					
-CMO:0002818	blood type I collagen C-terminal telopeptide level	blood type I collagen C-terminal telopeptide level value			blood measurement value					May be difficult to find a term for this because it's looking at the C-terminal teolpeptide of type I collagen																	
-CMO:0002786	blood hemoglobin A1c level	blood hemoglobin A1c level value		subclass	blood measurement value	hemoglobin				No A1c																	
-CMO:0002698	urine ketone body level	urine ketone body level value		equivalent	urine measurement value	ketone																					
-CMO:0002685	blood lipoprotein triglyceride level	blood lipoprotein triglyceride level value		equivalent	blood measurement value	triglyceride-rich lipoprotein particle																					
-CMO:0002656	bacteria count	bacteria count value		subclass	microbial data																						
-CMO:0002502	heart blood flow measurement	heart blood flow measurement value		subclass	circulation and respiration																						
-CMO:0002239	blood gamma-glutamyltransferase activity level	blood gamma-glutamyltransferase activity level value		equivalent	blood measurement value			gamma-glutamyltransferase activity																			
-CMO:0001561	bone measurement	bone measurement value			sample type					could possibly be physiological measurements instead>																	
-CMO:0001349	plateletcrit	plateletcrit value			blood measurement value																						
-CMO:0001348	mean platelet volume	mean platelet volume value			blood measurement value																						
-CMO:0001294	blood glucagon level	blood glucagon level value		equivalent	blood measurement value	glucagon																					
-CMO:0001291	blood triiodothyronine level	blood triiodothyronine level value		equivalent	blood measurement value	triiodothyronine																					
-CMO:0001288	blood thyroxine level	blood thyroxine level value		equivalent	blood measurement value	thyroxine																					
-CMO:0001284	blood troponin T level	blood troponin T level value		equivalent	blood measurement value	troponin T, cardiac muscle																					
-CMO:0001247	blood thyroid stimulating hormone level	blood thyroid stimulating hormone level value		equivalent	blood measurement value	thyroid stimulating hormone																					
-CMO:0001226	bone mineral density	bone mineral density value			bone measurement value																						
-CMO:0000761	urine potassium level	urine potassium level value		equivalent	urine measurement value	potassium																					
-CMO:0000757	urine albumin excretion rate	urine albumin excretion rate value		equivalent	urine measurement value	albumin				this is looking at excretion rate so perhaps we need an excretion process																	
-CMO:0000625	urine total protein level	urine total protein level value		subclass	urine measurement value	protein																					
-CMO:0000580	blood aspartate aminotransferase activity level	blood aspartate aminotransferase activity level value		equivalent	blood measurement value			aspartate aminotransferase activity		when using a process - is it a target or measurement of? Is there a difference?																	
-CMO:0000576	blood alkaline phosphate activity level	blood alkaline phosphate activity level value		equivalent	blood measurement value			alkaline phosphate activity		when using a process - is it a target or measurement of? Is there a difference?																	
-CMO:0000574	blood alanine aminotransferase activity level	blood alanine aminotransferase activity level value		equivalent	blood measurement value			alanine aminotransferase activity		when using a process - is it a target or measurement of? Is there a difference?																	
-CMO:0000538	blood creatinine level	blood creatinine level value		equivalent	blood measurement value	creatinine																					
-CMO:0000522	blood apoliprotein B level	blood apolipoprotein B level value		equivalent	blood measurement value	apolipoprotein B-100																					
-CMO:0000519	blood apolipoprotein A level	blood apolipoprotein A level value		equivalent	blood measurement value	apolipoprotein A																					
-CMO:0000513	blood estradiol level	blood estradiol level value		equivalent	blood measurement value	estradiol																					
-CMO:0000512	blood testosterone level	blood testosterone level value		equivalent	blood measurement value	testosterone																					
-CMO:0000504	blood phosphate level	blood phosphate level value		equivalent	blood measurement value	phosphate																					
-CMO:0000502	blood calcium level	blood calcium level value		equivalent	blood measurement value	calcium																					
-CMO:0000501	blood uric acid level	blood uric acid level value		equivalent	blood measurement value	uric acid																					
-CMO:0000499	blood sodium level	blood sodium level value		equivalent	blood measurement value	sodium																					
-CMO:0000497	blood chloride level	blood chloride level value		equivalent	blood measurement value	chloride																					
-CMO:0000496	blood potassium level	blood potassium level value		equivalent	blood measurement value	potassium																					
-CMO:0000485	blood adiponectin level	blood adiponectin level value		equivalent	blood measurement value	adiponectin																					
-CMO:0000386	urine color	urine color value			urine measurement value																						
-CMO:0000383	urine glucose level	urine glucose level value		equivalent	urine measurement value	glucose																					
-CMO:0000364	complete blood cell count	complete blood cell count value			blood measurement value																						
-CMO:0000349	blood insulin level	blood insulin level value		equivalent	blood measurement value	insulin																					
-CMO:0000294	pulse	pulse value		equivalent	heart rate																						
-CMO:0000281	urine calcium level	urine calcium level value		equivalent	urine measurement value	calcium																					
-CMO:0000279	urine bilirubin level	urine bilirubin level value		equivalent	urine measurement value	bilirubin																					
-CMO:0000258	urine pH	urine pH value			urine measurement value																						
-CMO:0000257	urine specific gravity	urine specific gravity value			urine measurement value																						
-CMO:0000256	urine measurement	urine measurement value		equivalent	urine																						
-CMO:0000242	waist circumference	waist circumference value		subclass	anthropometry																						
-CMO:0000209	blood fibrinogen level	blood fibrinogen level value		equivalent	blood measurement value	fibrinogen complex																					
-CMO:0000129	urine sodium level	urine sodium level value			urine measurement value	sodium																					
-CMO:0000125	urine creatinine level	urine creatinine level value		equivalent	urine measurement value	creatinine																					
-CMO:0000123	blood bilirubin level	blood bilirubin level value			blood measurement value	bilirubin																					
-CMO:0000115	blood renin activity level	blood renin activity level value		equivalent	blood measurement value	renin																					
-CMO:0000053	blood low density lipoprotein cholesterol level	blood low density lipoprotein cholesterol level value		equivalent	blood measurement value	low-density lipoprotein cholesterol																					
-CMO:0000052	blood high density lipoprotein cholesterol level	blood high density lipoprotein cholesterol level value		equivalent	blood measurement value	high-density lipoprotein cholesterol																					
-CMO:0000051	blood total cholesterol level	blood total cholesterol level value		equivalent	blood measurement value	cholesterol																					
-CMO:0000049	blood urea nitrogen level	blood urea nitrogen level value		equivalent	blood measurement value	urea																					
-CMO:0000046	blood glucose level	blood glucose level value		equivalent	blood measurement value	glucose																					
-CMO:0000041	red blood cell distribution width	red blood cell distribution width value			blood measurement value																						
-CMO:0000035	blood measurement	blood measurement value		equivalent	blood																						
-CMO:0000034	blood basophil count	blood basophil count value		equivalent	blood measurement value	basophil																					
-CMO:0000033	blood eosinophil count	blood eosinophil count value		equivalent	blood measurement value	eosinophil																					
-CMO:0000032	blood monocyte count	blood monocyte count value		equivalent	blood measurement value	monocyte																					
-CMO:0000031	blood lymphocyte count	blood lymphocyte count value		equivalent	blood measurement value	lymphocyte																					
-CMO:0000030	blood neutrophil count	blood neutrophil count value		equivalent	blood measurement value	neutrophil																					
-CMO:0000028	blood protein measurement	blood protein measurement value		equivalent	blood measurement value	protein																					
-CMO:0000014	hip circumference	hip circumference value			anthropometry																						
-CMO:0000003	blood pressure measurement	blood pressure measurement value		equivalent	blood pressure																						
-CL:0000775		neutrophil			cell																						
-CL:0000771		eosinophil			cell																						
-CL:0000767		basophil			cell																						
-CL:0000738	leukocyte	white blood cell			cell																						
-CL:0000576		monocyte			cell																						
-CL:0000542		lymphocyte			cell																						
-CL:0000232	erythrocyte	red blood cell			cell																						
-CL:0000066	epithelial cell	epithelial cell			cell																						
-CL:0000000		cell			material entity																						
-CHEBI:82594		Ferritin			chemical entity																						
-CHEBI:81569		Follicle stimulating hormone			chemical entity																						
-CHEBI:81568		Luteinizing hormone			chemical entity																						
-CHEBI:80332		C-peptide			chemical entity																						
-CHEBI:75769		B vitamin			chemical entity																						
-CHEBI:5391		glucagon			chemical entity																						
-CHEBI:47775		high-density lipoprotein cholesterol			chemical entity																						
-CHEBI:47774		low-density lipoprotein cholesterol			chemical entity																						
-CHEBI:40304		8-hydroxy-2'-deoxyguanosine			chemical entity																						
-CHEBI:37445		folate			chemical entity																						
-CHEBI:35143		hemoglobin			chemical entity																						
-CHEBI:30660		thyroxine			chemical entity																						
-CHEBI:29026		urobilinogen			chemical entity																						
-CHEBI:28984		aluminum atom			chemical entity																						
-CHEBI:27363		zinc			chemical entity																						
-CHEBI:27300		vitamin D			chemical entity																						
-CHEBI:27226		uric acid			chemical entity																						
-CHEBI:26708	sodium atom	sodium			chemical entity																						
-CHEBI:26216	potassium atom	potassium			chemical entity																						
-CHEBI:26020		phosphate			chemical entity																						
-CHEBI:25016		lead atom			chemical entity																						
-CHEBI:24431		chemical entity			material entity																						
-CHEBI:23965		estradiol			chemical entity																						
-CHEBI:22984		calcium			chemical entity																						
-CHEBI:22977		cadmium			chemical entity																						
-CHEBI:21241		vitamin C			chemical entity																						
-CHEBI:18258	3,3',5-triiodo-L-thyronine	triiodothyronine			chemical entity																						
-CHEBI:17996		chloride			chemical entity																						
-CHEBI:17933		calcidiol			chemical entity																						
-CHEBI:17347		testosterone			chemical entity																						
-CHEBI:17234		glucose			chemical entity																						
-CHEBI:17230		homocysteine			chemical entity																						
-CHEBI:17087		ketone			chemical entity																						
-CHEBI:16990	bilirubin IXalpha	bilirubin			chemical entity																						
-CHEBI:16814		dehydroepiandrosterone sulfate			chemical entity																						
-CHEBI:16737		creatinine			chemical entity																						
-CHEBI:16301		nitrite			chemical entity																						
-CHEBI:16199		urea			chemical entity																						
-CHEBI:16113		cholesterol			chemical entity																						
-BFO:0000040		material entity			entity																						
-BFO:0000015		process			entity																						
-BFO:0000001		entity																									
-GECKO:0000094	associated disease(s)	disease(s) treated with medication			CINECA																						
-GECKO:0000095		prescription			CINECA																						
-GECKO:0000096		drug response(s)			CINECA																						
-GECKO:0000097		posology			CINECA																						
-GECKO:0000098	administration method	administration method of medication			CINECA																						
-GECKO:0000099		life stage/time point			CINECA																						
-GECKO:0000100		general research data documents			CINECA																						
-GECKO:0000101		statistics			CINECA																						
-GECKO:0000102		summary statistics for additional data from federated sources			CINECA																						
-GECKO:1000000		echocardiography result			physiological measurements		Echocardiography																				
-GECKO:1000001		urine vitamin C level value		equivalent	urine measurement value	vitamin C																					
-GECKO:1000002		urine uric acid level value		equivalent	urine measurement value	uric acid																					
-GECKO:1000003		urine bacteria count value		equivalent	urine measurement value|bacteria count value																						
-GECKO:1000004		urine cast level value		equivalent	urine measurement value	Urine Casts																					
-GECKO:1000005		urine epithelial cell level value		equivalent	urine measurement value	epithelial cell																					
-GECKO:1000006		urine leukocyte level value		equivalent	urine measurement value	white blood cell																					
-GECKO:1000007		urine erythrocyte level value		equivalent	urine measurement value	red blood cell																					
-GECKO:1000008		blood presence in urine value		equivalent	urine measurement value	UBERON blood																					
-GECKO:1000009		urine nitrite level value		equivalent	urine measurement value	nitrite																					
-GECKO:1000010		urine urobilinogen level value		equivalent	urine measurement value	urobilinogen																					
-GECKO:1000011		blood apolipoprotein E level value		equivalent	blood measurement value	apolipoprotein E																					
-GECKO:1000012		blood telomere length value		equivalent	blood measurement value	teleomere length																					
-GECKO:1000013		blood prostate-specific antigen level value		equivalent	blood measurement value	prostate-specific antigen																					
-GECKO:1000014		blood follicle stimulating hormone level value		equivalent	blood measurement value	Follicle stimulating hormone																					
-GECKO:1000015		blood lutenizing hormone level value		equivalent	blood measurement value	Luteinizing hormone																					
-GECKO:1000016		blood insulin-like growth factor I level value		equivalent	blood measurement value	insulin-like growth factor I																					
-GECKO:1000017		blood dehydroepiandrosterone sulfate level value		equivalent	blood measurement value	dehydroepiandrosterone sulfate																					
-GECKO:1000018		cancer antigen 125 measurement value		equivalent	blood measurement value		CA-125 Measurement																				
-GECKO:1000019		carcinoembryonic antigen measurement value		equivalent	blood measurement value		Carcinoembryonic Antigen Measurement																				
-GECKO:1000020		Helicobacter pylori antibody measurement value			blood measurement value	Helicobacter pylori				Need to look at antibodies, not the bacteria																	
-GECKO:1000021		Hepatits A antibody measurement value		equivalent	blood measurement value		Hepatitis A Antibody Measurement																				
-GECKO:1000022		Hepatits B antibody measurement value		equivalent	blood measurement value		Hepatitis B Virus Antibody Measurement																				
-GECKO:1000023		Hepatits C antibody measurement value		equivalent	blood measurement value		Hepatitis C Antibody Measurement																				
-GECKO:1000024		blood type determination value		equivalent	blood measurement value		Blood Type Determination																				
-GECKO:1000025		blood cadmium level value		equivalent	blood measurement value	cadmium																					
-GECKO:1000026		blood lead level value		equivalent	blood measurement value	lead atom																					
-GECKO:1000027		blood aluminum level value		equivalent	blood measurement value	aluminum atom																					
-GECKO:1000028		blood zinc level value		equivalent	blood measurement value	zinc																					
-GECKO:1000029		blood vitamin D level value		equivalent	blood measurement value	vitamin D																					
-GECKO:1000030		rheumatoid factor measurement value		equivalent	blood measurement value		Rheumatoid Factor Measurement																				
-GECKO:1000031		blood 8-OHdG level value		equivalent	blood measurement value	8-hydroxy-2'-deoxyguanosine																					
-GECKO:1000032		blood vitamin B12 level value		equivalent	blood measurement value	B vitamin																					
-GECKO:1000033		blood calcidiol level value		equivalent	blood measurement value	calcidiol																					
-GECKO:1000034		blood thyroglobulin level value		equivalent	blood measurement value	thyroglobulin																					
-GECKO:1000035		blood ferritin level value		equivalent	blood measurement value	Ferritin																					
-GECKO:1000036		blood C-peptide level value		equivalent	blood measurement value	C-peptide																					
-GECKO:1000037		blood folate level value		equivalent	blood measurement value	folate																					
-GECKO:1000038		blood C-reactive protein level value		equivalent	blood measurement value	C-reactive protein																					
-GECKO:1000039		blood homocysteine level value		equivalent	blood measurement value	homocysteine																					
-GECKO:1000040		X-ray imaging result			physiological measurements		X-Ray Imaging																				
-GECKO:1000041		brain MRI result			physiological measurements	brain																					
-GECKO:1000042		physical performance testing result			physiological measurements		Physical Performance Testing																				
-GECKO:1000043		diagnosis of dementia			mental and behaviour disorders				dementia																		
-GECKO:1000044		diagnosis of depression			mental and behaviour disorders				Depressivity	mental health																	
-GECKO:1000045		diagnosis of vascular dementia			diagnosis of dementia				vascular dementia																		
-GECKO:1000046		diagnosis of Alzheimer's disease			diagnosis of dementia				DOID:10652																		
-GECKO:1000047		diagnosis of arthritis	yes/no		diseases				arthritis																		
-GECKO:1000048		diagnosis of nose disease	yes/no		diseases				nose disease																		
-GECKO:1000049		diagnosis of auditory system disease	yes/no		diseases				auditory system disease																		
-GECKO:1000051		diagnosis of gastrointestinal system disease	yes/no		digestive system				gastrointestinal system disease																		
-GECKO:1000052		diagnosis of sleep disorder	yes/no		mental and behaviour disorders				sleep disorder																		
-GECKO:1000053		information about diet			nutrition				Diet																		
-GECKO:1000054		blood fasting glucose level value		subclass	blood glucose level value|fasting or non-fasting																						
-GECKO:1000055		Food Frequency Questionnaire result		equivalent	information about diet		Food Frequency Questionnaire																				
-GECKO:1000056		diagnosis of infertility	yes/no		diseases				infertility																		
-GECKO:1000057		breastfeeding value	yes/no		lifestyle and behaviours				Breast Feeding	women's health																	
-GECKO:1000058		menstrual cycle history		equivalent	clinical history				menstrual cycle																		
-GECKO:1000059		physical activity history		equivalent	clinical history				NCIT Physical Activity																		
-GECKO:1000060		snoring value	yes/no	equivalent	sleep				Snoring																		
-GECKO:1000062		alcohol consumption history		equivalent	lifestyle and behaviours				Alcohol Consumption																		
-GECKO:1000062				equivalent	alcohol																						
-GECKO:1000063		family clinical history		subclass	clinical history																						
-GECKO:1000069		household income value	text		socio-demographic and economic characteristics				Household Income																		
-GECKO:1000070		marital status value	text		socio-demographic and economic characteristics				Marital Status																		
-GECKO:1000072		lactate dehydrogenase measurement value		equivalent	blood measurement value		Lactate Dehydrogenase Measurement																				
-GECKO:1000073		presence of crystals in urine value	yes/no	subclass	urine measurement value																						
-GECKO:1000074		quality of life survey result			lifestyle and behaviours	Quality of Life				mental health																	
-GECKO:1000075		activity of daily living survey result			lifestyle and behaviours	Activity of Daily Living				mental health																	
-GECKO:1000076		spirometry result			circulation and respiration		spirometry																				
-GECKO:1000077		unsaturated iron binding capacity measurement value			blood measurement value																						
-GO:0008150	biological_process	biological process			process																						
-GO:0003674	molecular_function	molecular function			process																						
-GO:0005575	cellular_component	cellular component			material entity																						
-GO:0003840		gamma-glutamyltransferase activity			molecular function																						
-GO:0004021	L-alanine:2-oxoglutarate aminotransferase activity	alanine aminotransferase activity			molecular function																						
-GO:0004035		alkaline phosphate activity			molecular function																						
-GO:0004069	L-aspartate:2-oxoglutarate aminotransferase activity	aspartate aminotransferase activity			molecular function																						
-GO:0005577		fibrinogen complex			cellular component																						
-GO:0007565		female pregnancy		subclass	biological process																						
-GO:0030431	sleep	GO sleep		subclass	biological process																						
-GO:0034385		triglyceride-rich lipoprotein particle			cellular component																						
-GO:0042697		menopause		subclass	biological process																						
-GO:0044850		menstrual cycle		subclass	biological process																						
-HP:0000716		Depressivity			trait																						
-HP:0025267		Snoring			trait																						
-MMO:0000094		spirometry		subclass	assay																						
-NCBITaxon:10566		Human papillomavirus		subclass	organism																						
-NCBITaxon:210		Helicobacter pylori		subclass	organism																						
-GECKO:9999999		trait			entity																						
-NCIT:C107400		Overall Well-Being			trait																						
-NCIT:C125944		Hepatitis B Virus Antibody Measurement			assay																						
-NCIT:C129765		teleomere length			trait																						
-NCIT:C139210		Grip Strength			trait																						
-NCIT:C150523		Physical Performance Testing			assay																						
-NCIT:C15222		Diet			trait																						
-NCIT:C154329		Smoking			process																						
-NCIT:C16273		Alcohol Consumption			process																						
-NCIT:C16525		Echocardiography			assay																						
-NCIT:C16529	Education	NCIT Education			trait																						
-NCIT:C16809		Magnetic Resonance Imaging			assay																						
-NCIT:C17047		Quality of Life			trait																						
-NCIT:C17173		Surgery			process																						
-NCIT:C17708	Physical Activity	NCIT Physical Activity			trait																						
-NCIT:C25173		Family			trait																						
-NCIT:C25188		Marital Status			trait																						
-NCIT:C25193		Occupation			trait																						
-NCIT:C25596		Breast Feeding			process																						
-NCIT:C38095		Urine Casts			material entity																						
-NCIT:C38101		X-Ray Imaging			assay																						
-NCIT:C53291		Activity of Daily Living			process																						
-NCIT:C64855		Lactate Dehydrogenase Measurement			assay																						
-NCIT:C70811		Household Income			trait																						
-NCIT:C74717		Rheumatoid Factor Measurement			assay																						
-NCIT:C79089		CA-125 Measurement			assay																						
-NCIT:C81983		Carcinoembryonic Antigen Measurement			assay																						
-NCIT:C92534		Hepatitis A Antibody Measurement			assay																						
-NCIT:C92535		Hepatitis C Antibody Measurement			assay																						
-NCIT:C94817		Food Frequency Questionnaire			assay																						
-NCIT:C98843		Blood Type Determination			assay																						
-OBI:0000070		assay			process																						
-OBI:0002390		exposure to second hand smoke			clinical history																						
-OBI:0002393		pregnancy history			clinical history				female pregnancy																		
-OBI:0002410		menopausal status			questionnaire/survey data				menopause	women's health																	
-OBI:0100026		organism			material entity																						
-OGMS:0000015		clinical history			questionnaire/survey data					where does this fall under? Not physiological, and it's more than just diseases																	
-PR:000000001		protein			material entity																						
-PR:000003015		prostate-specific antigen			protein																						
-PR:000003777		adiponectin			protein																						
-PR:000003918		albumin			protein																						
-PR:000005897		C-reactive protein			protein																						
-PR:000009054		insulin		subclass	protein																						
-PR:000009182		insulin-like growth factor I			protein																						
-PR:000013883		renin			protein																						
-PR:000016283		thyroglobulin			protein																						
-PR:000016509		troponin T, cardiac muscle			protein																						
-PR:000028269		thyroid stimulating hormone			protein																						
-PR:000030444		osteocalcin			protein																						
-PR:P02649	apolipoprotein E (human)	apolipoprotein E			protein																						
-PR:P04114	apolipoprotein B-100	apolipoprotein B-100			protein																						
-PR:P08519	apolipoprotein(a) (human)	apolipoprotein A			protein																						
-UBERON:0001062		anatomical entity			material entity																						
-UBERON:0000178	blood	UBERON blood			anatomical entity																						
-UBERON:0000955		brain			anatomical entity																						
-OBI:0002368		clinical history of cancer			oncological 																						
-CMO:0000008	calculated blood pressure	calculated blood pressure value			blood pressure measurement value																						
-CMO:0000105	body mass index (BMI)	body mass index value			anthropometry																						
-CMO:0000004	systolic blood pressure	systolic blood pressure value			blood pressure measurement value																						
-CMO:0000005	diastolic blood pressure	diastolic blood pressure value			blood pressure measurement value																						
-GECKO:1000078		type of medication taken			medication history																						
-GECKO:1000079		use of antibiotics			type of medication taken																						
-GECKO:1000080		use of therapeutic hormones			type of medication taken					maybe not the best name																	
-GECKO:1000081		use of steroid hormones			use of therapeutic hormones																						
-GECKO:1000082		use of corticosteroids			use of steroid hormones																						
-GECKO:1000083		use of diuretics			type of medication taken																						
-GECKO:1000084		use of beta blockers			use of adrenergic agents																						
-GECKO:1000085		use of antihypertensive agents			type of medication taken																						
-GECKO:1000086		use of angiotensin convertin enzyme inhibitors			use of antihypertensive agents																						
-GECKO:1000087		use of angiotensin receptor blockers			use of antihypertensive agents																						
-GECKO:1000088		use of adrenergic agents			type of medication taken																						
-GECKO:1000089		use of alpha adrenergic blockers			use of adrenergic agents																						
-GECKO:1000090		use of calcium channel blockers			type of medication taken																						
-GECKO:1000091		use of antidiabetes agents			type of medication taken																						
-GECKO:1000092		use of cardiovascular drugs			type of medication taken																						
-GECKO:1000093		use of glibenclamide			use of antidiabetes agents																						
-GECKO:1000094		use of metformin			use of antidiabetes agents																						
-GECKO:1000095		use of insulin			use of antidiabetes agents																						
-GECKO:1000096		use of antiplatelets			type of medication taken																						
-GECKO:1000097		use of anticholesteremic agents			type of medication taken																						
-GECKO:1000098		use of statins			use of anticholesteremic agents																						
-GECKO:1000099		use of nitrates			use of cardiovascular drugs																						
-GECKO:1000100		use of gemfibroxil			use of anticholesteremic agents																						
-GECKO:1000101		use of analgesics			type of medication taken																						
-GECKO:1000102		use of acetaminophen			use of analgesics																						
-GECKO:1000103		use of ibuprofen			use of analgesics																						
-GECKO:1000104		use of diclophenac			use of analgesics																						
-GECKO:1000105		use of indomethacin			use of analgesics																						
-GECKO:1000106		use of thyroid hormones			use of therapeutic hormones																						
-GECKO:1000107		use of levthyroxine			use of thyroid hormones																						
-GECKO:1000108		use of antineoplastic agents			type of medication taken																						
-GECKO:1000109		use of immunosuppressants			type of medication taken																						
-GECKO:1000110		use of methotrexate			use of antineoplastic agents|use of immunosuppressants																						
-GECKO:1000111		use of gastrointestinal drugs			type of medication taken																						
-GECKO:1000112		use of central nervous system drugs			type of medication taken					e.g., psychotropics and anticonvulsants																	
-GECKO:1000113		diagnosis of hypertension			circulatory system																						
-GECKO:1000115		diagnosis of heart disease			circulatory system																						
-GECKO:1000116		diagnosis of diabetes			endocrine/nutritional/metabolic disorders																						
-GECKO:1000117		diagnosis of stroke			circulatory system																						
-GECKO:1000118		diagnosis of chronic obstructive pulmonary disease			respiratory system																						
-GECKO:1000120		diagnosis of renal failure			endocrine/nutritional/metabolic disorders																						
-GECKO:1000121		diagnosis of jaundice			endocrine/nutritional/metabolic disorders																						
-GECKO:1000122		diagnosis of liver failure			endocrine/nutritional/metabolic disorders																						
-GECKO:1000124		diagnosis of bacterial infection			diseases																						
-GECKO:1000125		diagnosis of tuberculosis			diagnosis of bacterial infection																						
-GECKO:1000126		occurrence of acid reflux			signs and symptoms																						
-GECKO:1000127		occurrence of heartburn			signs and symptoms																						
-GECKO:1000128		occurrence of difficulty swallowing			signs and symptoms																						
-GECKO:1000129		history of medication for hypertension			disease(s) treated with medication																						
-GECKO:1000130		history of medication for diabetes			disease(s) treated with medication																						
-GECKO:1000131		history of medication for cardiac disease			disease(s) treated with medication																						
-GECKO:1000132		history of medication for high cholesterol			disease(s) treated with medication																						
-GECKO:1000133		history of medication for mental disorder			disease(s) treated with medication																						
-GECKO:1000134		history of medication for gastrointestinal disease			disease(s) treated with medication																						
-GECKO:1000135		opiate use history			recreational drug use history																						
-GECKO:1000136		oral health history			clinical history																						
-GECKO:1000137		recreational drug use history			clinical history|lifestyle and behaviours																						
-GECKO:1000138		diagnosis of HIV			diagnosis of viral infection				human immunodeficiency virus infectious disease																		
-GECKO:1000139		diagnosis of viral infection			diseases																						
-GECKO:1000140		occurrence of high cholesterol			signs and symptoms					symptom or diagnosis?																	
-GECKO:1000141		occurrence of cough			signs and symptoms																						
-GECKO:1000142		occurrence of fever			signs and symptoms																						
-GECKO:1000143		occurrence of weight loss			signs and symptoms																						
-GECKO:1000144		occurrence of night sweats			signs and symptoms																						
-GECKO:1000145		history of medication for tuberculosis			disease(s) treated with medication																						
-GECKO:1000146		occupation			socio-demographic and economic characteristics				Occupation																		
-DOID:526	human immunodeficiency virus infectious disease	human immunodeficiency virus infectious disease			disease																						
+ID	Ontology Label	Preferred Label	Value	Class Type	Parent	Target	Output Of	Measurement Of	Information About	Occurrence Of	Comment																	
+ID	A alternative term	LABEL		CLASS_TYPE	C % SPLIT=|	C 'has target' some %	C 'output of' some %	C 'measurement of' some %	C 'is about' some %		A comment																	
+BFO:0000001		entity																										
+BFO:0000015		process			entity																							
+BFO:0000040		material entity			entity																							
+CHEBI:15365		acetylsalicylic acid			chemical entity																							
+CHEBI:16113		cholesterol			chemical entity																							
+CHEBI:16199		urea			chemical entity																							
+CHEBI:16301		nitrite			chemical entity																							
+CHEBI:16737		creatinine			chemical entity																							
+CHEBI:16814		dehydroepiandrosterone sulfate			chemical entity																							
+CHEBI:16990	bilirubin IXalpha	bilirubin			chemical entity																							
+CHEBI:17087		ketone			chemical entity																							
+CHEBI:17230		homocysteine			chemical entity																							
+CHEBI:17234		glucose			chemical entity																							
+CHEBI:17347		testosterone			chemical entity																							
+CHEBI:17933		calcidiol			chemical entity																							
+CHEBI:17996		chloride			chemical entity																							
+CHEBI:18258	3,3',5-triiodo-L-thyronine	triiodothyronine			chemical entity																							
+CHEBI:21241		vitamin C			chemical entity																							
+CHEBI:22977		cadmium			chemical entity																							
+CHEBI:22984		calcium			chemical entity																							
+CHEBI:23965		estradiol			chemical entity																							
+CHEBI:24431		chemical entity			material entity																							
+CHEBI:25016		lead atom			chemical entity																							
+CHEBI:26020		phosphate			chemical entity																							
+CHEBI:26216	potassium atom	potassium			chemical entity																							
+CHEBI:26708	sodium atom	sodium			chemical entity																							
+CHEBI:27226		uric acid			chemical entity																							
+CHEBI:27300		vitamin D			chemical entity																							
+CHEBI:27363		zinc			chemical entity																							
+CHEBI:28984		aluminum atom			chemical entity																							
+CHEBI:29026		urobilinogen			chemical entity																							
+CHEBI:30660		thyroxine			chemical entity																							
+CHEBI:35143		hemoglobin			chemical entity																							
+CHEBI:37445		folate			chemical entity																							
+CHEBI:40304		8-hydroxy-2'-deoxyguanosine			chemical entity																							
+CHEBI:47774		low-density lipoprotein cholesterol			chemical entity																							
+CHEBI:47775		high-density lipoprotein cholesterol			chemical entity																							
+CHEBI:5391		glucagon			chemical entity																							
+CHEBI:75769		B vitamin			chemical entity																							
+CHEBI:80332		C-peptide			chemical entity																							
+CHEBI:81568		Luteinizing hormone			chemical entity																							
+CHEBI:81569		Follicle stimulating hormone			chemical entity																							
+CHEBI:82594		Ferritin			chemical entity																							
+CL:0000000		cell			material entity																							
+CL:0000066	epithelial cell	epithelial cell			cell																							
+CL:0000232	erythrocyte	red blood cell			cell																							
+CL:0000542		lymphocyte			cell																							
+CL:0000576		monocyte			cell																							
+CL:0000738	leukocyte	white blood cell			cell																							
+CL:0000767		basophil			cell																							
+CL:0000771		eosinophil			cell																							
+CL:0000775		neutrophil			cell																							
+CMO:0000003	blood pressure measurement	blood pressure measurement value		equivalent	blood pressure																							
+CMO:0000004	systolic blood pressure	systolic blood pressure value			blood pressure measurement value																							
+CMO:0000005	diastolic blood pressure	diastolic blood pressure value			blood pressure measurement value																							
+CMO:0000008	calculated blood pressure	calculated blood pressure value			blood pressure measurement value																							
+CMO:0000014	hip circumference	hip circumference value			anthropometry																							
+CMO:0000028	blood protein measurement	blood protein measurement value		equivalent	blood measurement value	protein																						
+CMO:0000030	blood neutrophil count	blood neutrophil count value		equivalent	blood measurement value	neutrophil																						
+CMO:0000031	blood lymphocyte count	blood lymphocyte count value		equivalent	blood measurement value	lymphocyte																						
+CMO:0000032	blood monocyte count	blood monocyte count value		equivalent	blood measurement value	monocyte																						
+CMO:0000033	blood eosinophil count	blood eosinophil count value		equivalent	blood measurement value	eosinophil																						
+CMO:0000034	blood basophil count	blood basophil count value		equivalent	blood measurement value	basophil																						
+CMO:0000035	blood measurement	blood measurement value		equivalent	blood																							
+CMO:0000041	red blood cell distribution width	red blood cell distribution width value			blood measurement value																							
+CMO:0000046	blood glucose level	blood glucose level value		equivalent	blood measurement value	glucose																						
+CMO:0000049	blood urea nitrogen level	blood urea nitrogen level value		equivalent	blood measurement value	urea																						
+CMO:0000051	blood total cholesterol level	blood total cholesterol level value		equivalent	blood measurement value	cholesterol																						
+CMO:0000052	blood high density lipoprotein cholesterol level	blood high density lipoprotein cholesterol level value		equivalent	blood measurement value	high-density lipoprotein cholesterol																						
+CMO:0000053	blood low density lipoprotein cholesterol level	blood low density lipoprotein cholesterol level value		equivalent	blood measurement value	low-density lipoprotein cholesterol																						
+CMO:0000105	body mass index (BMI)	body mass index value			anthropometry																							
+CMO:0000115	blood renin activity level	blood renin activity level value		equivalent	blood measurement value	renin																						
+CMO:0000123	blood bilirubin level	blood bilirubin level value			blood measurement value	bilirubin																						
+CMO:0000125	urine creatinine level	urine creatinine level value		equivalent	urine measurement value	creatinine																						
+CMO:0000129	urine sodium level	urine sodium level value			urine measurement value	sodium																						
+CMO:0000187	distal forelimb circumference	arm circumference value			anthropometry																							
+CMO:0000209	blood fibrinogen level	blood fibrinogen level value		equivalent	blood measurement value	fibrinogen complex																						
+CMO:0000242	waist circumference	waist circumference value		subclass	anthropometry																							
+CMO:0000256	urine measurement	urine measurement value		equivalent	urine																							
+CMO:0000257	urine specific gravity	urine specific gravity value			urine measurement value																							
+CMO:0000258	urine pH	urine pH value			urine measurement value																							
+CMO:0000279	urine bilirubin level	urine bilirubin level value		equivalent	urine measurement value	bilirubin																						
+CMO:0000281	urine calcium level	urine calcium level value		equivalent	urine measurement value	calcium																						
+CMO:0000294	pulse	pulse value		equivalent	heart rate																							
+CMO:0000349	blood insulin level	blood insulin level value		equivalent	blood measurement value	insulin																						
+CMO:0000364	complete blood cell count	complete blood cell count value			blood measurement value																							
+CMO:0000383	urine glucose level	urine glucose level value		equivalent	urine measurement value	glucose																						
+CMO:0000386	urine color	urine color value			urine measurement value																							
+CMO:0000485	blood adiponectin level	blood adiponectin level value		equivalent	blood measurement value	adiponectin																						
+CMO:0000496	blood potassium level	blood potassium level value		equivalent	blood measurement value	potassium																						
+CMO:0000497	blood chloride level	blood chloride level value		equivalent	blood measurement value	chloride																						
+CMO:0000499	blood sodium level	blood sodium level value		equivalent	blood measurement value	sodium																						
+CMO:0000501	blood uric acid level	blood uric acid level value		equivalent	blood measurement value	uric acid																						
+CMO:0000502	blood calcium level	blood calcium level value		equivalent	blood measurement value	calcium																						
+CMO:0000504	blood phosphate level	blood phosphate level value		equivalent	blood measurement value	phosphate																						
+CMO:0000512	blood testosterone level	blood testosterone level value		equivalent	blood measurement value	testosterone																						
+CMO:0000513	blood estradiol level	blood estradiol level value		equivalent	blood measurement value	estradiol																						
+CMO:0000519	blood apolipoprotein A level	blood apolipoprotein A level value		equivalent	blood measurement value	apolipoprotein A																						
+CMO:0000522	blood apoliprotein B level	blood apolipoprotein B level value		equivalent	blood measurement value	apolipoprotein B-100																						
+CMO:0000538	blood creatinine level	blood creatinine level value		equivalent	blood measurement value	creatinine																						
+CMO:0000574	blood alanine aminotransferase activity level	blood alanine aminotransferase activity level value		equivalent	blood measurement value			alanine aminotransferase activity			when using a process - is it a target or measurement of? Is there a difference?																	
+CMO:0000576	blood alkaline phosphate activity level	blood alkaline phosphate activity level value		equivalent	blood measurement value			alkaline phosphate activity			when using a process - is it a target or measurement of? Is there a difference?																	
+CMO:0000580	blood aspartate aminotransferase activity level	blood aspartate aminotransferase activity level value		equivalent	blood measurement value			aspartate aminotransferase activity			when using a process - is it a target or measurement of? Is there a difference?																	
+CMO:0000625	urine total protein level	urine total protein level value		subclass	urine measurement value	protein																						
+CMO:0000757	urine albumin excretion rate	urine albumin excretion rate value		equivalent	urine measurement value	albumin					this is looking at excretion rate so perhaps we need an excretion process																	
+CMO:0000761	urine potassium level	urine potassium level value		equivalent	urine measurement value	potassium																						
+CMO:0001226	bone mineral density	bone mineral density value			bone measurement value																							
+CMO:0001247	blood thyroid stimulating hormone level	blood thyroid stimulating hormone level value		equivalent	blood measurement value	thyroid stimulating hormone																						
+CMO:0001284	blood troponin T level	blood troponin T level value		equivalent	blood measurement value	troponin T, cardiac muscle																						
+CMO:0001288	blood thyroxine level	blood thyroxine level value		equivalent	blood measurement value	thyroxine																						
+CMO:0001291	blood triiodothyronine level	blood triiodothyronine level value		equivalent	blood measurement value	triiodothyronine																						
+CMO:0001294	blood glucagon level	blood glucagon level value		equivalent	blood measurement value	glucagon																						
+CMO:0001348	mean platelet volume	mean platelet volume value			blood measurement value																							
+CMO:0001349	plateletcrit	plateletcrit value			blood measurement value																							
+CMO:0001561	bone measurement	bone measurement value			sample type						could possibly be physiological measurements instead>																	
+CMO:0002239	blood gamma-glutamyltransferase activity level	blood gamma-glutamyltransferase activity level value		equivalent	blood measurement value			gamma-glutamyltransferase activity																				
+CMO:0002502	heart blood flow measurement	heart blood flow measurement value		subclass	circulation and respiration																							
+CMO:0002656	bacteria count	bacteria count value		subclass	microbial data																							
+CMO:0002685	blood lipoprotein triglyceride level	blood lipoprotein triglyceride level value		equivalent	blood measurement value	triglyceride-rich lipoprotein particle																						
+CMO:0002698	urine ketone body level	urine ketone body level value		equivalent	urine measurement value	ketone																						
+CMO:0002786	blood hemoglobin A1c level	blood hemoglobin A1c level value		subclass	blood measurement value	hemoglobin					No A1c																	
+CMO:0002818	blood type I collagen C-terminal telopeptide level	blood type I collagen C-terminal telopeptide level value			blood measurement value						May be difficult to find a term for this because it's looking at the C-terminal teolpeptide of type I collagen																	
+CMO:0002821	blood osteocalcin level	blood osteocalcin level value		equivalent	blood measurement value	osteocalcin																						
+DOID:0050155		auditory system disease			disease																							
+DOID:10652		Alzheimer's disease			disease																							
+DOID:1307		dementia			disease																							
+DOID:14566	disease of cellular proliferation	neoplasm																										
+DOID:1579		respiratory system disease		equivalent	respiratory system																							
+DOID:2825		nose disease			disease																							
+DOID:2841		asthma			disease																							
+DOID:3083		chronic obstructive pulmonary disease			disease																							
+DOID:4		disease			entity																							
+DOID:5223		infertility			disease																							
+DOID:526	human immunodeficiency virus infectious disease	human immunodeficiency virus infectious disease			disease																							
+DOID:535		sleep disorder			disease																							
+DOID:77		gastrointestinal system disease			disease																							
+DOID:848		arthritis			disease																							
+DOID:8725		vascular dementia			disease																							
+EFO:0003926	neuropsychological test	neuropsychological test result		subclass	physiological measurements						mental health																	
+EFO:0005666	thyroid peroxidase antibody measurement	thyroid peroxidase antibody measurement value			blood measurement value																							
+EFO:0006941	grip strength measurement	grip strength measurement value			physiological measurements																							
+EFO:0007117	carotid artery intima media thickness	carotid artery intima media thickness value			physiological measurements																							
+EFO:0007869	wellbeing measurement	wellbeing measurement result			physiological measurements						mental health																	
+EFO:0008354	cognitive function measurement	cognitive function measurement result			physiological measurements						mental health																	
+GECKO:0000001		basic cohort attributes			CINECA																							
+GECKO:0000002		aims and objectives			CINECA																							
+GECKO:0000003		timeline			CINECA																							
+GECKO:0000004		study design			CINECA																							
+GECKO:0000005		population data			CINECA																							
+GECKO:0000006		location			CINECA																							
+GECKO:0000007		criteria for enrollment and recruitment procedures			CINECA																							
+GECKO:0000008		num. participants			CINECA																							
+GECKO:0000009		demographic data			CINECA																							
+GECKO:0000010		sex(es) studied in cohort			CINECA																							
+GECKO:0000011		gender(s) studied in cohort			CINECA																							
+GECKO:0000012		age range			CINECA																							
+GECKO:0000013		data collection events			CINECA																							
+GECKO:0000014		biosample			CINECA																							
+GECKO:0000015		sample type			CINECA																							
+GECKO:0000016		urine			CINECA																							
+GECKO:0000017		blood			CINECA																							
+GECKO:0000018		venous or arterial			CINECA																							
+GECKO:0000019		fasting or non-fasting			CINECA																							
+GECKO:0000020		stool			CINECA																							
+GECKO:0000021		saliva			CINECA																							
+GECKO:0000026		storage method			CINECA																							
+GECKO:0000027		laboratory measures			CINECA																							
+GECKO:0000028		microbiology			CINECA																							
+GECKO:0000029		microbial data			CINECA																							
+GECKO:0000030		biosample source/anatomical location			CINECA																							
+GECKO:0000032		genomics			CINECA																							
+GECKO:0000033		data type			CINECA																							
+GECKO:0000034		DNA/Genotyping			CINECA																							
+GECKO:0000035		WGS			CINECA																							
+GECKO:0000036		WES			CINECA																							
+GECKO:0000037		Sequence variants			CINECA																							
+GECKO:0000038		Epigenetics			CINECA																							
+GECKO:0000039		Metagenomics			CINECA																							
+GECKO:0000040		Microbiome markers			CINECA																							
+GECKO:0000041		RNAseq/gene expression			CINECA																							
+GECKO:0000042		eQTL			CINECA																							
+GECKO:0000043		other			CINECA																							
+GECKO:0000044		sample size			CINECA																							
+GECKO:0000045		available data format(s)			CINECA																							
+GECKO:0000046		availability			CINECA																							
+GECKO:0000047		processing method			CINECA																							
+GECKO:0000048		associated cell type/tissue type/biosample			CINECA																							
+GECKO:0000049		associated phenotype			CINECA																							
+GECKO:0000050		associated disease			CINECA																							
+GECKO:0000051		associated medication			CINECA																							
+GECKO:0000052		survey administration			CINECA																							
+GECKO:0000053		date and time-related information			CINECA																							
+GECKO:0000054		consent/accessibility			CINECA																							
+GECKO:0000055		unique identifiers			CINECA																							
+GECKO:0000056		questionnaire/survey data			CINECA																							
+GECKO:0000057		socio-demographic and economic characteristics			CINECA																							
+GECKO:0000058		age/birthdate			CINECA																							
+GECKO:0000059		biological sex			CINECA																							
+GECKO:0000060		gender			CINECA																							
+GECKO:0000061		ethnicity/race			CINECA																							
+GECKO:0000062		genealogy			CINECA																							
+GECKO:0000063		birthplace			CINECA																							
+GECKO:0000064		residence			CINECA																							
+GECKO:0000065		education			CINECA																							
+GECKO:0000065				equivalent	socio-demographic and economic characteristics				NCIT Education																			
+GECKO:0000066		family and household structure			CINECA																							
+GECKO:0000067		lifestyle and behaviours			CINECA																							
+GECKO:0000068		tobacco			CINECA																							
+GECKO:0000068					lifestyle and behaviours				Smoking																			
+GECKO:0000069		alcohol			CINECA																							
+GECKO:0000070		physical activity			CINECA																							
+GECKO:0000071		sleep		equivalent	clinical history				GO sleep																			
+GECKO:0000072		nutrition			CINECA																							
+GECKO:0000073		physician/practitioner info			CINECA																							
+GECKO:0000074		diseases			CINECA|clinical history																							
+GECKO:0000075		blood-related disorders			CINECA																							
+GECKO:0000076		endocrine/nutritional/metabolic disorders			CINECA																							
+GECKO:0000077		mental and behaviour disorders			CINECA																							
+GECKO:0000078		nervous system			CINECA																							
+GECKO:0000079		digestive system			CINECA																							
+GECKO:0000080		respiratory system			CINECA																							
+GECKO:0000081		circulatory system			CINECA																							
+GECKO:0000082		oncological			CINECA																							
+GECKO:0000083		signs and symptoms			CINECA																							
+GECKO:0000084		physiological measurements			CINECA																							
+GECKO:0000085		anthropometry			CINECA																							
+GECKO:0000086		weight			CINECA																							
+GECKO:0000087		height			CINECA																							
+GECKO:0000088		circulation and respiration			CINECA																							
+GECKO:0000089		blood pressure			CINECA																							
+GECKO:0000090		heart rate			CINECA																							
+GECKO:0000091		non-pharmacological interventions			CINECA|clinical history																							
+GECKO:0000092		surgical interventions			CINECA																							
+GECKO:0000093	medication	medication history			CINECA|clinical history																							
+GECKO:0000094	associated disease(s)	disease(s) treated with medication			CINECA																							
+GECKO:0000095		prescription			CINECA																							
+GECKO:0000096		drug response(s)			CINECA																							
+GECKO:0000097		posology			CINECA																							
+GECKO:0000098	administration method	administration method of medication			CINECA																							
+GECKO:0000099		life stage/time point			CINECA																							
+GECKO:0000100		general research data documents			CINECA																							
+GECKO:0000101		statistics			CINECA																							
+GECKO:0000102		summary statistics for additional data from federated sources			CINECA																							
+GECKO:1000000		echocardiography result			physiological measurements		Echocardiography																					
+GECKO:1000001		urine vitamin C level value		equivalent	urine measurement value	vitamin C																						
+GECKO:1000002		urine uric acid level value		equivalent	urine measurement value	uric acid																						
+GECKO:1000003		urine bacteria count value		equivalent	urine measurement value|bacteria count value																							
+GECKO:1000004		urine cast level value		equivalent	urine measurement value	Urine Casts																						
+GECKO:1000005		urine epithelial cell level value		equivalent	urine measurement value	epithelial cell																						
+GECKO:1000006		urine leukocyte level value		equivalent	urine measurement value	white blood cell																						
+GECKO:1000007		urine erythrocyte level value		equivalent	urine measurement value	red blood cell																						
+GECKO:1000008		blood presence in urine value		equivalent	urine measurement value	UBERON blood																						
+GECKO:1000009		urine nitrite level value		equivalent	urine measurement value	nitrite																						
+GECKO:1000010		urine urobilinogen level value		equivalent	urine measurement value	urobilinogen																						
+GECKO:1000011		blood apolipoprotein E level value		equivalent	blood measurement value	apolipoprotein E																						
+GECKO:1000012		blood telomere length value		equivalent	blood measurement value	teleomere length																						
+GECKO:1000013		blood prostate-specific antigen level value		equivalent	blood measurement value	prostate-specific antigen																						
+GECKO:1000014		blood follicle stimulating hormone level value		equivalent	blood measurement value	Follicle stimulating hormone																						
+GECKO:1000015		blood lutenizing hormone level value		equivalent	blood measurement value	Luteinizing hormone																						
+GECKO:1000016		blood insulin-like growth factor I level value		equivalent	blood measurement value	insulin-like growth factor I																						
+GECKO:1000017		blood dehydroepiandrosterone sulfate level value		equivalent	blood measurement value	dehydroepiandrosterone sulfate																						
+GECKO:1000018		cancer antigen 125 measurement value		equivalent	blood measurement value		CA-125 Measurement																					
+GECKO:1000019		carcinoembryonic antigen measurement value		equivalent	blood measurement value		Carcinoembryonic Antigen Measurement																					
+GECKO:1000020		Helicobacter pylori antibody measurement value			blood measurement value	Helicobacter pylori					Need to look at antibodies, not the bacteria																	
+GECKO:1000021		Hepatits A antibody measurement value		equivalent	blood measurement value		Hepatitis A Antibody Measurement																					
+GECKO:1000022		Hepatits B antibody measurement value		equivalent	blood measurement value		Hepatitis B Virus Antibody Measurement																					
+GECKO:1000023		Hepatits C antibody measurement value		equivalent	blood measurement value		Hepatitis C Antibody Measurement																					
+GECKO:1000024		blood type determination value		equivalent	blood measurement value		Blood Type Determination																					
+GECKO:1000025		blood cadmium level value		equivalent	blood measurement value	cadmium																						
+GECKO:1000026		blood lead level value		equivalent	blood measurement value	lead atom																						
+GECKO:1000027		blood aluminum level value		equivalent	blood measurement value	aluminum atom																						
+GECKO:1000028		blood zinc level value		equivalent	blood measurement value	zinc																						
+GECKO:1000029		blood vitamin D level value		equivalent	blood measurement value	vitamin D																						
+GECKO:1000030		rheumatoid factor measurement value		equivalent	blood measurement value		Rheumatoid Factor Measurement																					
+GECKO:1000031		blood 8-OHdG level value		equivalent	blood measurement value	8-hydroxy-2'-deoxyguanosine																						
+GECKO:1000032		blood vitamin B12 level value		equivalent	blood measurement value	B vitamin																						
+GECKO:1000033		blood calcidiol level value		equivalent	blood measurement value	calcidiol																						
+GECKO:1000034		blood thyroglobulin level value		equivalent	blood measurement value	thyroglobulin																						
+GECKO:1000035		blood ferritin level value		equivalent	blood measurement value	Ferritin																						
+GECKO:1000036		blood C-peptide level value		equivalent	blood measurement value	C-peptide																						
+GECKO:1000037		blood folate level value		equivalent	blood measurement value	folate																						
+GECKO:1000038		blood C-reactive protein level value		equivalent	blood measurement value	C-reactive protein																						
+GECKO:1000039		blood homocysteine level value		equivalent	blood measurement value	homocysteine																						
+GECKO:1000040		X-ray imaging result			physiological measurements		X-Ray Imaging																					
+GECKO:1000041		brain MRI result			physiological measurements	brain																						
+GECKO:1000042		physical performance testing result			physiological measurements		Physical Performance Testing																					
+GECKO:1000043		diagnosis of dementia			mental and behaviour disorders				dementia																			
+GECKO:1000044		diagnosis of depression			mental and behaviour disorders				Depressivity		mental health																	
+GECKO:1000045		diagnosis of vascular dementia			diagnosis of dementia				vascular dementia																			
+GECKO:1000046		diagnosis of Alzheimers disease			diagnosis of dementia				DOID:10652																			
+GECKO:1000047		diagnosis of arthritis	yes/no		diseases				arthritis																			
+GECKO:1000048		diagnosis of nose disease	yes/no		diseases				nose disease																			
+GECKO:1000049		diagnosis of auditory system disease	yes/no		diseases				auditory system disease																			
+GECKO:1000051		diagnosis of gastrointestinal system disease	yes/no		digestive system				gastrointestinal system disease																			
+GECKO:1000052		diagnosis of sleep disorder	yes/no		mental and behaviour disorders				sleep disorder																			
+GECKO:1000053		information about diet			nutrition				Diet																			
+GECKO:1000054		blood fasting glucose level value		subclass	blood glucose level value|fasting or non-fasting																							
+GECKO:1000055		Food Frequency Questionnaire result		equivalent	information about diet		Food Frequency Questionnaire																					
+GECKO:1000056		diagnosis of infertility	yes/no		diseases				infertility																			
+GECKO:1000057		breastfeeding value	yes/no		lifestyle and behaviours				Breast Feeding		women's health																	
+GECKO:1000058		menstrual cycle history		equivalent	clinical history				menstrual cycle																			
+GECKO:1000059		physical activity history		equivalent	clinical history				NCIT Physical Activity																			
+GECKO:1000060		snoring value	yes/no	equivalent	sleep				Snoring																			
+GECKO:1000062		alcohol consumption history		equivalent	lifestyle and behaviours				Alcohol Consumption																			
+GECKO:1000062				equivalent	alcohol																							
+GECKO:1000063		family clinical history		subclass	clinical history																							
+GECKO:1000069		household income value	text		socio-demographic and economic characteristics				Household Income																			
+GECKO:1000070		marital status value	text		socio-demographic and economic characteristics				Marital Status																			
+GECKO:1000072		lactate dehydrogenase measurement value		equivalent	blood measurement value		Lactate Dehydrogenase Measurement																					
+GECKO:1000073		presence of crystals in urine value	yes/no	subclass	urine measurement value																							
+GECKO:1000074		quality of life survey result			lifestyle and behaviours	Quality of Life					mental health																	
+GECKO:1000075		activity of daily living survey result			lifestyle and behaviours	Activity of Daily Living					mental health																	
+GECKO:1000076		spirometry result			circulation and respiration		spirometry																					
+GECKO:1000077		unsaturated iron binding capacity measurement value			blood measurement value																							
+GECKO:1000078		type of medication taken			medication history																							
+GECKO:1000079		use of antibiotics			type of medication taken																							
+GECKO:1000080		use of therapeutic hormones			type of medication taken						maybe not the best name																	
+GECKO:1000081		use of steroid hormones			use of therapeutic hormones																							
+GECKO:1000082		use of corticosteroids			use of steroid hormones																							
+GECKO:1000083		use of diuretics			type of medication taken																							
+GECKO:1000084		use of beta blockers			use of adrenergic agents																							
+GECKO:1000085		use of antihypertensive agents			type of medication taken																							
+GECKO:1000086		use of angiotensin convertin enzyme inhibitors			use of antihypertensive agents																							
+GECKO:1000087		use of angiotensin receptor blockers			use of antihypertensive agents																							
+GECKO:1000088		use of adrenergic agents			type of medication taken																							
+GECKO:1000089		use of alpha adrenergic blockers			use of adrenergic agents																							
+GECKO:1000090		use of calcium channel blockers			type of medication taken																							
+GECKO:1000091		use of antidiabetes agents			type of medication taken																							
+GECKO:1000092		use of cardiovascular drugs			type of medication taken																							
+GECKO:1000093		use of glibenclamide			use of antidiabetes agents																							
+GECKO:1000094		use of metformin			use of antidiabetes agents																							
+GECKO:1000095		use of insulin			use of antidiabetes agents																							
+GECKO:1000096		use of antiplatelets			type of medication taken																							
+GECKO:1000097		use of anticholesteremic agents			type of medication taken																							
+GECKO:1000098		use of statins			use of anticholesteremic agents																							
+GECKO:1000099		use of nitrates			use of cardiovascular drugs																							
+GECKO:1000100		use of gemfibroxil			use of anticholesteremic agents																							
+GECKO:1000101		use of analgesics			type of medication taken																							
+GECKO:1000102		use of acetaminophen			use of analgesics																							
+GECKO:1000103		use of ibuprofen			use of analgesics																							
+GECKO:1000104		use of diclophenac			use of analgesics																							
+GECKO:1000105		use of indomethacin			use of analgesics																							
+GECKO:1000106		use of thyroid hormones			use of therapeutic hormones																							
+GECKO:1000107		use of levthyroxine			use of thyroid hormones																							
+GECKO:1000108		use of antineoplastic agents			type of medication taken																							
+GECKO:1000109		use of immunosuppressants			type of medication taken																							
+GECKO:1000110		use of methotrexate			use of antineoplastic agents|use of immunosuppressants																							
+GECKO:1000111		use of gastrointestinal drugs			type of medication taken																							
+GECKO:1000112		use of central nervous system drugs			type of medication taken						e.g., psychotropics and anticonvulsants																	
+GECKO:1000113		diagnosis of hypertension			circulatory system																							
+GECKO:1000115		diagnosis of heart disease			circulatory system																							
+GECKO:1000116		diagnosis of diabetes			endocrine/nutritional/metabolic disorders																							
+GECKO:1000117		occurrence of stroke			signs and symptoms					Stroke																		
+GECKO:1000118		diagnosis of chronic obstructive pulmonary disease			respiratory system																							
+GECKO:1000120		diagnosis of renal failure			diagnosis of renal disease																							
+GECKO:1000121		diagnosis of jaundice			endocrine/nutritional/metabolic disorders																							
+GECKO:1000122		diagnosis of liver failure			diagnosis of liver disease																							
+GECKO:1000124		diagnosis of bacterial infection			diseases																							
+GECKO:1000125		diagnosis of tuberculosis			diagnosis of bacterial infection																							
+GECKO:1000126		occurrence of acid reflux			signs and symptoms																							
+GECKO:1000127		occurrence of heartburn			signs and symptoms																							
+GECKO:1000128		occurrence of difficulty swallowing			signs and symptoms																							
+GECKO:1000129		history of medication for hypertension			disease(s) treated with medication																							
+GECKO:1000130		history of medication for diabetes			disease(s) treated with medication																							
+GECKO:1000131		history of medication for cardiac disease			disease(s) treated with medication																							
+GECKO:1000132		history of medication for high cholesterol			disease(s) treated with medication																							
+GECKO:1000133		history of medication for mental disorder			disease(s) treated with medication																							
+GECKO:1000134		history of medication for gastrointestinal disease			disease(s) treated with medication																							
+GECKO:1000135		opiate use history			recreational drug use history																							
+GECKO:1000136		oral health history			clinical history																							
+GECKO:1000137		recreational drug use history			clinical history|lifestyle and behaviours																							
+GECKO:1000138		diagnosis of HIV			diagnosis of viral infection				human immunodeficiency virus infectious disease																			
+GECKO:1000139		diagnosis of viral infection			diseases																							
+GECKO:1000140		occurrence of high cholesterol			signs and symptoms						symptom or diagnosis?																	
+GECKO:1000141		occurrence of cough			signs and symptoms					Cough																		
+GECKO:1000142		occurrence of fever			signs and symptoms																							
+GECKO:1000143		occurrence of weight loss			signs and symptoms																							
+GECKO:1000144		occurrence of night sweats			signs and symptoms																							
+GECKO:1000145		history of medication for tuberculosis			disease(s) treated with medication																							
+GECKO:1000146		occupation			socio-demographic and economic characteristics				Occupation																			
+GECKO:9999998		CINECA																										
+GECKO:9999999		trait			entity																							
+GO:0003674	molecular_function	molecular function			process																							
+GO:0003840		gamma-glutamyltransferase activity			molecular function																							
+GO:0004021	L-alanine:2-oxoglutarate aminotransferase activity	alanine aminotransferase activity			molecular function																							
+GO:0004035		alkaline phosphate activity			molecular function																							
+GO:0004069	L-aspartate:2-oxoglutarate aminotransferase activity	aspartate aminotransferase activity			molecular function																							
+GO:0005575	cellular_component	cellular component			material entity																							
+GO:0005577		fibrinogen complex			cellular component																							
+GO:0007565		female pregnancy		subclass	biological process																							
+GO:0008150	biological_process	biological process			process																							
+GO:0030431	sleep	GO sleep		subclass	biological process																							
+GO:0034385		triglyceride-rich lipoprotein particle			cellular component																							
+GO:0042697		menopause		subclass	biological process																							
+GO:0044850		menstrual cycle		subclass	biological process																							
+HP:0000118		Phenotypic abnormality																										
+HP:0000716		Depressivity			trait																							
+HP:0001297		Stroke			Phenotypic abnormality																							
+HP:0001658		Myocardial infarction			Phenotypic abnormality																							
+HP:0002086		Abnormality of the respiratory system			Phenotypic abnormality																							
+HP:0002094		Dyspnea			Abnormality of the respiratory system																							
+HP:0002105		Hemoptysis			Phenotypic abnormality																							
+HP:0002619		Varicose veins																										
+HP:0002840		Lymphadenitis			Phenotypic abnormality																							
+HP:0002875		Exertional dyspnea			Dyspnea																							
+HP:0003074		Hyperglycemia			Phenotypic abnormality																							
+HP:0012378		Fatigue			Phenotypic abnormality																							
+HP:0012735		Cough			Abnormality of the respiratory system																							
+HP:0025267		Snoring			trait																							
+HP:0030828		Wheezing			Abnormality of the respiratory system																							
+HP:0032263		Increased blood pressure			Phenotypic abnormality																							
+HP:0100749		Chest pain			Phenotypic abnormality																							
+MMO:0000094		spirometry		subclass	assay																							
+NCBITaxon:10566		Human papillomavirus		subclass	organism																							
+NCBITaxon:210		Helicobacter pylori		subclass	organism																							
+NCIT:C107400		Overall Well-Being			trait																							
+NCIT:C125944		Hepatitis B Virus Antibody Measurement			assay																							
+NCIT:C129765		teleomere length			trait																							
+NCIT:C139210		Grip Strength			trait																							
+NCIT:C150523		Physical Performance Testing			assay																							
+NCIT:C15222		Diet			trait																							
+NCIT:C154329		Smoking			process																							
+NCIT:C16273		Alcohol Consumption			process																							
+NCIT:C16525		Echocardiography			assay																							
+NCIT:C16529	Education	NCIT Education			trait																							
+NCIT:C16809		Magnetic Resonance Imaging			assay																							
+NCIT:C17047		Quality of Life			trait																							
+NCIT:C17173		Surgery			process																							
+NCIT:C17708	Physical Activity	NCIT Physical Activity			trait																							
+NCIT:C25173		Family			trait																							
+NCIT:C25188		Marital Status			trait																							
+NCIT:C25193		Occupation			trait																							
+NCIT:C25596		Breast Feeding			process																							
+NCIT:C2849		Congenital Abnormality			disease																							
+NCIT:C38095		Urine Casts			material entity																							
+NCIT:C38101		X-Ray Imaging			assay																							
+NCIT:C53291		Activity of Daily Living			process																							
+NCIT:C64855		Lactate Dehydrogenase Measurement			assay																							
+NCIT:C70811		Household Income			trait																							
+NCIT:C74717		Rheumatoid Factor Measurement			assay																							
+NCIT:C79089		CA-125 Measurement			assay																							
+NCIT:C81983		Carcinoembryonic Antigen Measurement			assay																							
+NCIT:C92534		Hepatitis A Antibody Measurement			assay																							
+NCIT:C92535		Hepatitis C Antibody Measurement			assay																							
+NCIT:C93210		Inflammatory Disorder			disease																							
+NCIT:C94817		Food Frequency Questionnaire			assay																							
+NCIT:C98843		Blood Type Determination			assay																							
+OBI:0000070		assay			process																							
+OBI:0002368		clinical history of cancer			oncological 																							
+OBI:0002390		exposure to second hand smoke			clinical history																							
+OBI:0002393		pregnancy history			clinical history				female pregnancy																			
+OBI:0002410		menopausal status			questionnaire/survey data				menopause		women's health																	
+OBI:0100026		organism			material entity																							
+OGMS:0000015		clinical history			questionnaire/survey data						where does this fall under? Not physiological, and it's more than just diseases																	
+PR:000000001		protein			material entity																							
+PR:000003015		prostate-specific antigen			protein																							
+PR:000003777		adiponectin			protein																							
+PR:000003918		albumin			protein																							
+PR:000005897		C-reactive protein			protein																							
+PR:000009054		insulin		subclass	protein																							
+PR:000009182		insulin-like growth factor I			protein																							
+PR:000013883		renin			protein																							
+PR:000016283		thyroglobulin			protein																							
+PR:000016509		troponin T, cardiac muscle			protein																							
+PR:000028269		thyroid stimulating hormone			protein																							
+PR:000030444		osteocalcin			protein																							
+PR:P02649	apolipoprotein E (human)	apolipoprotein E			protein																							
+PR:P04114	apolipoprotein B-100	apolipoprotein B-100			protein																							
+PR:P08519	apolipoprotein(a) (human)	apolipoprotein A			protein																							
+UBERON:0000178	blood	UBERON blood			anatomical entity																							
+UBERON:0000955		brain			anatomical entity																							
+UBERON:0001062		anatomical entity			material entity																							
+GECKO:1000147		use of anti-cancer drugs			disease(s) treated with medication	oncological																						
+GECKO:1000148		use of anaesthetics			type of medication taken																							
+GECKO:1000149		diagnosis of renal disease			endocrine/nutritional/metabolic disorders																							
+GECKO:1000150		diagnosis of liver disease			endocrine/nutritional/metabolic disorders																							
+GECKO:1000151		occurrence of high blood pressure			signs and symptoms					Increased blood pressure																		
+GECKO:1000152		history of non-pharmacological treatment			non-pharmacological interventions						This is in reference to anything taken that is not considered a pharmaceutical																	
+GECKO:1000153		history of non-pharmacological treatment for high blood pressure			history of non-pharmacological treatment	Increased blood pressure																						
+GECKO:1000154		history of non-pharmacological treatment for high cholesterol			history of non-pharmacological treatment																							
+GECKO:1000155		history of radiation treatment			history of non-pharmacological treatment																							
+GECKO:1000156		occurrence of hyperglycemia			signs and symptoms					Hyperglycemia																		
+GECKO:1000157		history of medication for hyperglycemia			disease(s) treated with medication	Hyperglycemia																						
+GECKO:1000158		occurrence of heart attack			signs and symptoms					Myocardial infarction																		
+GECKO:1000159		use of asprin			use of non-steroidal anti-inflammatory drugs				acetylsalicylic acid																			
+GECKO:1000160		use of non-steroidal anti-inflammatory drugs			type of medication taken																							
+GECKO:1000161		occurrence of fatigue			signs and symptoms					Fatigue																		
+GECKO:1000162		occurrence of chest pain			signs and symptoms					Chest pain																		
+GECKO:1000163		occurrence of hemoptysis			signs and symptoms					Hemoptysis																		
+GECKO:1000164		occurrence of lymphadenitis			signs and symptoms					Lymphadenitis																		
+GECKO:1000165		diagnosis of asthma			respiratory system				asthma																			
+GECKO:1000166		history of medication for respiratory disease			disease(s) treated with medication	respiratory system																						
+GECKO:1000167		history of medication for asthma			history of medication for respiratory disease	asthma																						
+GECKO:1000168		history of medication for chronic obstructive pulmonary disease			history of medication for respiratory disease	chronic obstructive pulmonary disease																						
+GECKO:1000169		occurrence of exertional dyspnea			occurrence of dyspnea					Exertional dyspnea																		
+GECKO:1000170		occurrence of dyspnea			signs and symptoms					Dyspnea																		
+GECKO:1000171		occurrence of wheezing			signs and symptoms					Wheezing																		
+GECKO:1000172		history of medication for HIV			disease(s) treated with medication	human immunodeficiency virus infectious disease																						
+GECKO:1000173		sputum sample collected			other																							
+GECKO:1000174		diagnosis of inflammatory disorder			diseases				Inflammatory Disorder																			
+GECKO:1000175		history of intensive care			history of augmented care																							
+GECKO:1000176		history of organ support			history of augmented care																							
+GECKO:1000177		history of respiratory support			history of organ support																							
+GECKO:1000178		history of cardiovascular support			history of organ support																							
+GECKO:1000179		history of dermatological support			history of organ support																							
+GECKO:1000180		history of gastrointestinal support			history of organ support																							
+GECKO:1000181		history of liver support			history of organ support																							
+GECKO:1000182		history of neurological support			history of organ support																							
+GECKO:1000183		history of renal support			history of organ support																							
+GECKO:1000184		occurrence of varicose veins			signs and symptoms					Varicose veins																		
+GECKO:1000185		history of augmented care			non-pharmacological interventions						I bet we can find a better name for this, this is just taken from GE																	
+KOGES:0000000		KoGES																										
+GCS:0000000		GCS																										
+GE:0000000		Genomics England																										
+SAPRIN:0000000		SAPRIN																										
+VZ:0000000		Vukuzazi																										

--- a/mappings/koges-mapping.tsv
+++ b/mappings/koges-mapping.tsv
@@ -1,209 +1,208 @@
-Field ID	Field Label	Class Type	GECKO Label	GECKO Comment																			
-ID	LABEL	CLASS_TYPE	C % SPLIT=|	A comment																			
-KoGES:0000000	KoGES																						
-KoGES:0000001	Core Variables		KoGES																				
-KoGES:0000002	Core Questionnaires	equivalent	questionnaire/survey data																				
-KoGES:0000003	Socio-demographic data	equivalent	socio-demographic and economic characteristics																				
-KoGES:0000004	Education level	equivalent	education																				
-KoGES:0000005	Marital status	equivalent	marital status value																				
-KoGES:0000006	Household income	equivalent	household income value																				
-KoGES:0000007	Occupation	equivalent	occupation																				
-KoGES:0000008	Medical history	equivalent	clinical history																				
-KoGES:0000009	Disease history of hypertension, diabetes, hyperlipidemia, stroke, angina/myocardial infraction, cancer, etc.	equivalent	diseases																				
-KoGES:0000010	Previous diagnosis (Disease history)	subclass	diseases																				
-KoGES:0000011	Age at first diagnosis (Disease history)	subclass	diseases																				
-KoGES:0000012	Treatment progress (current treatment)	subclass	medication																				
-KoGES:0000013	Treatment method (hypertension, diabetes, hyperlipidemia only)	subclass	medication																				
-KoGES:0000014	Surgery (operation) history	subclass	surgical interventions																				
-KoGES:0000015	Previous surgery (operation)	subclass	surgical interventions																				
-KoGES:0000016	Age at first surgery	subclass	surgical interventions																				
-KoGES:0000017	Family disease history	subclass	family clinical history																				
-KoGES:0000018	Previous diagnosis (Family disease history)	subclass	family clinical history																				
-KoGES:0000019	Relationship	subclass	family clinical history																				
-KoGES:0000020	Age at first diagnosis (Family disease history)	subclass	family clinical history																				
-KoGES:0000021	Number of siblings and children	subclass	family and household structure																				
-KoGES:0000022	Lifestyle	equivalent	lifestyle and behaviours																				
-KoGES:0000023	Smoking habits	equivalent	tobacco																				
-KoGES:0000024	Amount of ciagrettes	subclass	tobacco																				
-KoGES:0000025	Total period of smoking	subclass	tobacco																				
-KoGES:0000026	Age at first smoking	subclass	tobacco																				
-KoGES:0000027	Secondhand smoking	equivalent	exposure to second hand smoke																				
-KoGES:0000028	Drinking habits	equivalent	alcohol consumption history																				
-KoGES:0000029	Amount of drinking	subclass	alcohol consumption history																				
-KoGES:0000030	Total period of drinking	subclass	alcohol consumption history																				
-KoGES:0000031	Drinking frequency	subclass	alcohol consumption history																				
-KoGES:0000032	Sleeping pattern	subclass	sleep																				
-KoGES:0000033	Hours of sleep	subclass	sleep																				
-KoGES:0000034	Time go to bed and wake up in the morning	subclass	sleep																				
-KoGES:0000035	Trouble of sleeping	subclass	sleep																				
-KoGES:0000036	Snoring	equivalent	snoring value																				
-KoGES:0000037	Physical activity	equivalent	physical activity history																				
-KoGES:0000038	Regular physical activity	subclass	physical activity history																				
-KoGES:0000039	Excercises	subclass	physical activity history																				
-KoGES:0000040	Household chores	subclass	physical activity history																				
-KoGES:0000041	Climbing stairs	subclass	physical activity history																				
-KoGES:0000042	Womens health		KoGES																				
-KoGES:0000043	Menstrual factors	subclass	menstrual cycle history																				
-KoGES:0000044	Age at menarche	subclass	menstrual cycle history																				
-KoGES:0000045	Length of menstrual cycle	subclass	menstrual cycle history																				
-KoGES:0000046	Menopause status	equivalent	menopausal status																				
-KoGES:0000047	Reproductive history	equivalent	pregnancy history																				
-KoGES:0000048	Number of pregnancies	subclass	pregnancy history																				
-KoGES:0000049	Age at each pregnancy	subclass	pregnancy history																				
-KoGES:0000050	Durations and outcome of pregnancies	subclass	pregnancy history																				
-KoGES:0000051	Breastfeeding	equivalent	breastfeeding value																				
-KoGES:0000052	Infertility	equivalent	diagnosis of infertility																				
-KoGES:0000053	Dietary survey	equivalent	information about diet																				
-KoGES:0000054	Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result																				
-KoGES:0000055	Dietary habits	subclass	information about diet																				
-KoGES:0000056	Anthropometric measurements	equivalent	anthropometry																				
-KoGES:0000057	Height & weight	equivalent	height|weight																				
-KoGES:0000058	Waist & hip circumference	equivalent	waist circumference value|hip circumference value																				
-KoGES:0000059	Body composition	subclass	anthropometry																				
-KoGES:0000060	Blood pressure & pulse rate	equivalent	blood pressure measurement value|pulse value																				
-KoGES:0000061	Core Clinical examination		KoGES																				
-KoGES:0000062	Core Blood test	equivalent	blood measurement value																				
-KoGES:0000063	Complete blood cell count	equivalent	complete blood cell count value																				
-KoGES:0000064	Glucose (fasting)	equivalent	blood fasting glucose level value	not fasting specified																			
-KoGES:0000065	Albumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
-KoGES:0000066	Blood urea nitrogen (BUN)	equivalent	blood urea nitrogen level value																				
-KoGES:0000067	Creatinine (Blood)	equivalent	blood creatinine level value																				
-KoGES:0000068	AST (SGOT)	equivalent	blood aspartate aminotransferase activity level value																				
-KoGES:0000069	ALT (SGPT)	equivalent	blood alanine aminotransferase activity level value																				
-KoGES:0000070	y-GTP	equivalent	blood gamma-glutamyltransferase activity level value																				
-KoGES:0000071	Total cholesterol	equivalent	blood total cholesterol level value																				
-KoGES:0000072	HDL-Cholesterol	equivalent	blood high density lipoprotein cholesterol level value																				
-KoGES:0000073	Triglyceride	equivalent	blood lipoprotein triglyceride level value																				
-KoGES:0000074	Core Urine test	equivalent	urine measurement value																				
-KoGES:0000075	pH	equivalent	urine pH value																				
-KoGES:0000076	Protein	equivalent	urine total protein level value																				
-KoGES:0000077	Glucose	equivalent	urine glucose level value																				
-KoGES:0000078	Blood	equivalent	blood presence in urine value																				
-KoGES:0000079	Substudy Variables		KoGES																				
-KoGES:0000080	Substudy Questionnaires	equivalent	questionnaire/survey data																				
-KoGES:0000081	Psychosocial well-being status (PWI)	subclass	wellbeing measurement result																				
-KoGES:0000082	Depression (CES-D, BDI)	subclass	diagnosis of depression	not the exact tests																			
-KoGES:0000083	24 hour recall dietary survey	subclass	information about diet																				
-KoGES:0000084	Sleep disorder	equivalent	diagnosis of sleep disorder																				
-KoGES:0000085	In-depth questionnaire (By disease)	equivalent	diseases																				
-KoGES:0000086	Respiratory disease	equivalent	respiratory system																				
-KoGES:0000087	Gastroenterologic disorder	equivalent	diagnosis of gastrointestinal system disease																				
-KoGES:0000088	Otorhinolaryngologic disorder (Ear, Nose)	equivalent	(diseases and ('diagnosis of nose disease' or 'diagnosis of auditory system disease'))																				
-KoGES:0000089	Arthritis	equivalent	diagnosis of arthritis																				
-KoGES:0000090	Aging study		KoGES																				
-KoGES:0000091	Aging study Questionnaires	subclass	questionnaire/survey data																				
-KoGES:0000092	Health-related quality of life (WHOQOL, EQ-SD, SF-12)	subclass	quality of life survey result																				
-KoGES:0000093	Activities of daily living (K-ADL, S-IADL)	subclass	activity of daily living survey result																				
-KoGES:0000094	Dementia screening (K-MMSE, K-MoCA)	subclass	diagnosis of dementia																				
-KoGES:0000095	Dementia screening by caregiver (CS-KGDS, KDSQ-C)	subclass	diagnosis of dementia	not by caregiver																			
-KoGES:0000096	Depression (GDS)	subclass	diagnosis of depression	not specific to aging studies																			
-KoGES:0000097	Vascular dementia / Alzheimers disease screening (Ischemia Scales)	equivalent	(diseases and ('diagnosis of vascular dementia' or GECKO:1000046))																				
-KoGES:0000098	Aging study Clincial examination		KoGES																				
-KoGES:0000099	Cognitive Function test	equivalent	cognitive function measurement result																				
-KoGES:0000100	Neuropsychological test (SNSB-II)	subclass	neuropsychological test result																				
-KoGES:0000101	Physical performance test (SPPB, SFT)	subclass	physical performance testing result																				
-KoGES:0000102	Grip strength	equivalent	grip strength measurement value																				
-KoGES:0000103	Brain MRI	equivalent	brain MRI result																				
-KoGES:0000104	Substudy Clinical Examination		KoGES																				
-KoGES:0000105	Spirometry	equivalent	spirometry result																				
-KoGES:0000106	Bone strength (sonometer)	subclass	bone measurement value	CMO has a few different terms that measure strength, e.g. ultimate force & stifness, but no exact match																			
-KoGES:0000107	Bone mineral density (DEXA test)	equivalent	bone mineral density value																				
-KoGES:0000108	X-ray (chest, hand, knee, C-spin)	subclass	X-ray imaging result																				
-KoGES:0000109	Ultrasound carotid Intima Media Thickness (IMT)	equivalent	carotid artery intima media thickness value																				
-KoGES:0000110	Pulse Wave Velocity (PWV)	subclass	heart blood flow measurement value	Has different pulse wave measurements, but this is the parent class to all																			
-KoGES:0000111	Ecocardiography	equivalent	echocardiography result																				
-KoGES:0000112	Substudy Blood test	equivalent	blood measurement value																				
-KoGES:0000113	Glucose (1hr on OGTT)	subclass	blood glucose level value																				
-KoGES:0000114	Glucose (2hr on OGTT)	subclass	blood glucose level value																				
-KoGES:0000115	HbA1C	equivalent	blood hemoglobin A1c level value																				
-KoGES:0000116	Insulin	equivalent	blood insulin level value																				
-KoGES:0000117	Insulin(1hr)	subclass	blood insulin level value																				
-KoGES:0000118	Insulin(2hr)	subclass	blood insulin level value																				
-KoGES:0000119	Total Protein	subclass	blood protein measurement value	CMO has plasma and serum total protein measurements																			
-KoGES:0000120	Total Bilirubin	equivalent	blood bilirubin level value																				
-KoGES:0000121	LDL-Cholesterol	equivalent	blood low density lipoprotein cholesterol level value																				
-KoGES:0000122	hs-CRP	equivalent	blood C-reactive protein level value																				
-KoGES:0000123	Homocystein	equivalent	blood homocysteine level value																				
-KoGES:0000203	Uric acid	equivalent	blood uric acid level value																				
-KoGES:0000125	Fibrinogen	equivalent	blood fibrinogen level value																				
-KoGES:0000126	Alkaline phosphate	equivalent	blood alkaline phosphate activity level value																				
-KoGES:0000127	Folate	equivalent	blood folate level value																				
-KoGES:0000128	Adiponectin	equivalent	blood adiponectin level value																				
-KoGES:0000129	Glucagon	equivalent	blood glucagon level value																				
-KoGES:0000130	C-peptide	equivalent	blood C-peptide level value																				
-KoGES:0000170	Renin	equivalent	blood renin activity level value																				
-KoGES:0000132	Phosphate	equivalent	blood phosphate level value																				
-KoGES:0000133	Tropinin T	equivalent	blood troponin T level value																				
-KoGES:0000134	Apolipoprotein A	equivalent	blood apolipoprotein A level value																				
-KoGES:0000135	Apolipoprotein B	equivalent	blood apolipoprotein B level value	Typo in CMO label?																			
-KoGES:0000136	Sodium(Na) (Blood)	equivalent	blood sodium level value																				
-KoGES:0000137	Potassium(K) (Blood)	equivalent	blood potassium level value																				
-KoGES:0000138	Chloride(Cl)	equivalent	blood chloride level value																				
-KoGES:0000139	Neutrophil	equivalent	blood neutrophil count value																				
-KoGES:0000140	Lymphocyte	equivalent	blood lymphocyte count value																				
-KoGES:0000141	Monocyte	equivalent	blood monocyte count value																				
-KoGES:0000142	Eosinophil	equivalent	blood eosinophil count value																				
-KoGES:0000143	Basophil	equivalent	blood basophil count value																				
-KoGES:0000144	Red cell distribution width (RDW)	equivalent	red blood cell distribution width value																				
-KoGES:0000145	Mean platelet volume (MPV)	equivalent	mean platelet volume value																				
-KoGES:0000146	Platlet crit (PCT)	equivalent	plateletcrit value																				
-KoGES:0000147	Vitamin B12	equivalent	blood vitamin B12 level value	ChEBI stops at B vitamin, but FOODON has vitamin B12 - would that be better?																			
-KoGES:0000148	25-OH-Vitamin D	equivalent	blood calcidiol level value	I *think* this is the right ChEBI term																			
-KoGES:0000149	Thyroglobulin	equivalent	blood thyroglobulin level value																				
-KoGES:0000152	Ferritin	equivalent	blood ferritin level value																				
-KoGES:0000151	UIBC	equivalent	unsaturated iron binding capacity measurement value																				
-KoGES:0000153	Oxidized LDL	subclass	blood low density lipoprotein cholesterol level value	not oxidized																			
-KoGES:0000154	8-OHdG	equivalent	blood 8-OHdG level value																				
-KoGES:0000155	Calcium(Ca) (Blood)	equivalent	blood calcium level value																				
-KoGES:0000156	Free T3	equivalent	blood triiodothyronine level value																				
-KoGES:0000157	Free T4	equivalent	blood thyroxine level value																				
-KoGES:0000158	TSH	equivalent	blood thyroid stimulating hormone level value																				
-KoGES:0000159	Anti-microsomal Ab	equivalent	thyroid peroxidase antibody measurement value																				
-KoGES:0000160	RF	equivalent	rheumatoid factor measurement value																				
-KoGES:0000161	Osteocalcin	equivalent	blood osteocalcin level value																				
-KoGES:0000162	C-telopeptide	equivalent	blood type I collagen C-terminal telopeptide level value																				
-KoGES:0000163	Vitamin D	equivalent	blood vitamin D level value																				
-KoGES:0000164	Estradiol	equivalent	blood estradiol level value																				
-KoGES:0000165	Cadmium(Cd)	equivalent	blood cadmium level value																				
-KoGES:0000166	Lead(Pb)	equivalent	blood lead level value	OK to use lead atom?																			
-KoGES:0000167	Aluminum(Al)	equivalent	blood aluminum level value	atom or ion?																			
-KoGES:0000168	Zinc(Zn)	equivalent	blood zinc level value	OK to use atom?																			
-KoGES:0000169	Blood type	equivalent	blood type determination value																				
-KoGES:0000171	Hepatitis B antibody	equivalent	Hepatits B antibody measurement value																				
-KoGES:0000172	Hepatitis C antibody	equivalent	Hepatits C antibody measurement value																				
-KoGES:0000173	Hepatitis A antibody (HAV)	equivalent	Hepatits A antibody measurement value																				
-KoGES:0000174	HPV(Human Papillomavirus)	subclass	blood measurement value	there's no such thing as an HPV blood test?																			
-KoGES:0000175	Helicobacter pylori	equivalent	Helicobacter pylori antibody measurement value																				
-KoGES:0000176	Carcinoembryonic antigen (CEA)	equivalent	carcinoembryonic antigen measurement value																				
-KoGES:0000177	Cancer antigen 125 (CA125)	equivalent	cancer antigen 125 measurement value																				
-KoGES:0000178	DHEA-S	equivalent	blood dehydroepiandrosterone sulfate level value																				
-KoGES:0000179	IGF-1	equivalent	blood insulin-like growth factor I level value																				
-KoGES:0000180	Testosterone	equivalent	blood testosterone level value																				
-KoGES:0000181	Luteinizing hormone (LH)	equivalent	blood lutenizing hormone level value																				
-KoGES:0000182	Follicle Stimulation Hormone (FSH)	equivalent	blood follicle stimulating hormone level value																				
-KoGES:0000183	Prostate Specific Antigen (PSA)	equivalent	blood prostate-specific antigen level value																				
-KoGES:0000184	Lactate Dehydrogenase (LDH)	equivalent	lactate dehydrogenase measurement value																				
-KoGES:0000185	Telomere length	equivalent	blood telomere length value																				
-KoGES:0000186	Apo E genotype	equivalent	blood apolipoprotein E level value	Not sure if this is quite right																			
-KoGES:0000187	Substudy Urine test	equivalent	urine measurement value																				
-KoGES:0000188	Ketone	equivalent	urine ketone body level value																				
-KoGES:0000189	Bilirubin	equivalent	urine bilirubin level value																				
-KoGES:0000190	Urobilinogen	equivalent	urine urobilinogen level value	NCIT does have a term for this - but have not used NCIT so far																			
-KoGES:0000191	Nitrite	equivalent	urine nitrite level value																				
-KoGES:0000192	Urinary specific gravity	equivalent	urine specific gravity value																				
-KoGES:0000193	Hematuria	equivalent	blood presence in urine value	No check for blood, though HP does have a term for 'blood in urine'. I think looking at the measurement is better here though																			
-KoGES:0000194	Color	equivalent	urine color value																				
-KoGES:0000195	R.B.C.	equivalent	urine erythrocyte level value	CMO only has RBC for blood samples																			
-KoGES:0000196	W.B.C.	equivalent	urine leukocyte level value	CMO only has WBC for blood samples																			
-KoGES:0000197	E.P. cells	equivalent	urine epithelial cell level value																				
-KoGES:0000198	Casts	equivalent	urine cast level value																				
-KoGES:0000199	Bacteria	equivalent	urine bacteria count value	No check for bacteria, though HP does have a term for 'bacteria in urine'. I think looking at the measurement is better here though																			
-KoGES:0000200	Crystals	equivalent	presence of crystals in urine value																				
-KoGES:0000201	Protein, total	equivalent	urine total protein level value																				
-KoGES:0000202	Creatinine (Urine)	equivalent	urine creatinine level value																				
-KoGES:0000203	Uric acid	equivalent	urine uric acid level value	CMO only has blood uric acid																			
-KoGES:0000204	Calcium (Urine)	equivalent	urine calcium level value																				
-KoGES:0000205	Sodium (Urine)	equivalent	urine sodium level value																				
-KoGES:0000206	Potassium (Urine)	equivalent	urine potassium level value																				
-KoGES:0000207	Vitamin C	equivalent	urine vitamin C level value	no CMO term for vit C levels in urine																			
-KoGES:0000208	Microalbumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
+Field Label	Class Type	GECKO Label	GECKO Comment																			
+LABEL	CLASS_TYPE	C % SPLIT=|	A comment																			
+Core Variables		KoGES																				
+Core Questionnaires	equivalent	questionnaire/survey data																				
+Socio-demographic data	equivalent	socio-demographic and economic characteristics																				
+Education level	equivalent	education																				
+Marital status	equivalent	marital status value																				
+Household income	equivalent	household income value																				
+Occupation	equivalent	occupation																				
+Medical history	equivalent	clinical history																				
+Disease history of hypertension, diabetes, hyperlipidemia, stroke, angina/myocardial infraction, cancer, etc.	equivalent	diseases																				
+Previous diagnosis (Disease history)	subclass	diseases																				
+Age at first diagnosis (Disease history)	subclass	diseases																				
+Treatment progress (current treatment)	subclass	medication																				
+Treatment method (hypertension, diabetes, hyperlipidemia only)	subclass	medication																				
+Surgery (operation) history	subclass	surgical interventions																				
+Previous surgery (operation)	subclass	surgical interventions																				
+Age at first surgery	subclass	surgical interventions																				
+Family disease history	subclass	family clinical history																				
+Previous diagnosis (Family disease history)	subclass	family clinical history																				
+Relationship	subclass	family clinical history																				
+Age at first diagnosis (Family disease history)	subclass	family clinical history																				
+Number of siblings and children	subclass	family and household structure																				
+Lifestyle	equivalent	lifestyle and behaviours																				
+Smoking habits	equivalent	tobacco																				
+Amount of ciagrettes	subclass	tobacco																				
+Total period of smoking	subclass	tobacco																				
+Age at first smoking	subclass	tobacco																				
+Secondhand smoking	equivalent	exposure to second hand smoke																				
+Drinking habits	equivalent	alcohol consumption history																				
+Amount of drinking	subclass	alcohol consumption history																				
+Total period of drinking	subclass	alcohol consumption history																				
+Drinking frequency	subclass	alcohol consumption history																				
+Sleeping pattern	subclass	sleep																				
+Hours of sleep	subclass	sleep																				
+Time go to bed and wake up in the morning	subclass	sleep																				
+Trouble of sleeping	subclass	sleep																				
+Snoring	equivalent	snoring value																				
+Physical activity	equivalent	physical activity history																				
+Regular physical activity	subclass	physical activity history																				
+Excercises	subclass	physical activity history																				
+Household chores	subclass	physical activity history																				
+Climbing stairs	subclass	physical activity history																				
+Womens health		KoGES																				
+Menstrual factors	subclass	menstrual cycle history																				
+Age at menarche	subclass	menstrual cycle history																				
+Length of menstrual cycle	subclass	menstrual cycle history																				
+Menopause status	equivalent	menopausal status																				
+Reproductive history	equivalent	pregnancy history																				
+Number of pregnancies	subclass	pregnancy history																				
+Age at each pregnancy	subclass	pregnancy history																				
+Durations and outcome of pregnancies	subclass	pregnancy history																				
+Breastfeeding	equivalent	breastfeeding value																				
+Infertility	equivalent	diagnosis of infertility																				
+Dietary survey	equivalent	information about diet																				
+Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result																				
+Dietary habits	subclass	information about diet																				
+Anthropometric measurements	equivalent	anthropometry																				
+Height & weight	equivalent	height|weight																				
+Waist & hip circumference	equivalent	waist circumference value|hip circumference value																				
+Body composition	subclass	anthropometry																				
+Blood pressure & pulse rate	equivalent	blood pressure measurement value|pulse value																				
+Core Clinical examination		KoGES																				
+Core Blood test	equivalent	blood measurement value																				
+Complete blood cell count	equivalent	complete blood cell count value																				
+Glucose (fasting)	equivalent	blood fasting glucose level value	not fasting specified																			
+Albumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
+Blood urea nitrogen (BUN)	equivalent	blood urea nitrogen level value																				
+Creatinine (Blood)	equivalent	blood creatinine level value																				
+AST (SGOT)	equivalent	blood aspartate aminotransferase activity level value																				
+ALT (SGPT)	equivalent	blood alanine aminotransferase activity level value																				
+y-GTP	equivalent	blood gamma-glutamyltransferase activity level value																				
+Total cholesterol	equivalent	blood total cholesterol level value																				
+HDL-Cholesterol	equivalent	blood high density lipoprotein cholesterol level value																				
+Triglyceride	equivalent	blood lipoprotein triglyceride level value																				
+Core Urine test	equivalent	urine measurement value																				
+pH	equivalent	urine pH value																				
+Protein	equivalent	urine total protein level value																				
+Glucose	equivalent	urine glucose level value																				
+Blood	equivalent	blood presence in urine value																				
+Substudy Variables		KoGES																				
+Substudy Questionnaires	equivalent	questionnaire/survey data																				
+Psychosocial well-being status (PWI)	subclass	wellbeing measurement result																				
+Depression (CES-D, BDI)	subclass	diagnosis of depression	not the exact tests																			
+24 hour recall dietary survey	subclass	information about diet																				
+Sleep disorder	equivalent	diagnosis of sleep disorder																				
+In-depth questionnaire (By disease)	equivalent	diseases																				
+Respiratory disease	equivalent	respiratory system																				
+Gastroenterologic disorder	equivalent	diagnosis of gastrointestinal system disease																				
+Otorhinolaryngologic disorder (Ear, Nose)	equivalent	diagnosis of nose disease|diagnosis of auditory system disease																				
+Arthritis	equivalent	diagnosis of arthritis																				
+Aging study		KoGES																				
+Aging study Questionnaires	subclass	questionnaire/survey data																				
+Health-related quality of life (WHOQOL, EQ-SD, SF-12)	subclass	quality of life survey result																				
+Activities of daily living (K-ADL, S-IADL)	subclass	activity of daily living survey result																				
+Dementia screening (K-MMSE, K-MoCA)	subclass	diagnosis of dementia																				
+Dementia screening by caregiver (CS-KGDS, KDSQ-C)	subclass	diagnosis of dementia	not by caregiver																			
+Depression (GDS)	subclass	diagnosis of depression	not specific to aging studies																			
+Vascular dementia / Alzheimers disease screening (Ischemia Scales)	equivalent	diagnosis of vascular dementia|diagnosis of Alzheimers disease																				
+Aging study Clincial examination		KoGES																				
+Cognitive Function test	equivalent	cognitive function measurement result																				
+Neuropsychological test (SNSB-II)	subclass	neuropsychological test result																				
+Physical performance test (SPPB, SFT)	subclass	physical performance testing result																				
+Grip strength	equivalent	grip strength measurement value																				
+Brain MRI	equivalent	brain MRI result																				
+Substudy Clinical Examination		KoGES																				
+Spirometry	equivalent	spirometry result																				
+Bone strength (sonometer)	subclass	bone measurement value	CMO has a few different terms that measure strength, e.g. ultimate force & stifness, but no exact match																			
+Bone mineral density (DEXA test)	equivalent	bone mineral density value																				
+X-ray (chest, hand, knee, C-spin)	subclass	X-ray imaging result																				
+Ultrasound carotid Intima Media Thickness (IMT)	equivalent	carotid artery intima media thickness value																				
+Pulse Wave Velocity (PWV)	subclass	heart blood flow measurement value	Has different pulse wave measurements, but this is the parent class to all																			
+Ecocardiography	equivalent	echocardiography result																				
+Substudy Blood test	equivalent	blood measurement value																				
+Glucose (1hr on OGTT)	subclass	blood glucose level value																				
+Glucose (2hr on OGTT)	subclass	blood glucose level value																				
+HbA1C	equivalent	blood hemoglobin A1c level value																				
+Insulin	equivalent	blood insulin level value																				
+Insulin(1hr)	subclass	blood insulin level value																				
+Insulin(2hr)	subclass	blood insulin level value																				
+Total Protein	subclass	blood protein measurement value	CMO has plasma and serum total protein measurements																			
+Total Bilirubin	equivalent	blood bilirubin level value																				
+LDL-Cholesterol	equivalent	blood low density lipoprotein cholesterol level value																				
+hs-CRP	equivalent	blood C-reactive protein level value																				
+Homocystein	equivalent	blood homocysteine level value																				
+Uric acid	equivalent	blood uric acid level value																				
+Fibrinogen	equivalent	blood fibrinogen level value																				
+Alkaline phosphate	equivalent	blood alkaline phosphate activity level value																				
+Folate	equivalent	blood folate level value																				
+Adiponectin	equivalent	blood adiponectin level value																				
+Glucagon	equivalent	blood glucagon level value																				
+C-peptide	equivalent	blood C-peptide level value																				
+Renin	equivalent	blood renin activity level value																				
+Phosphate	equivalent	blood phosphate level value																				
+Tropinin T	equivalent	blood troponin T level value																				
+Apolipoprotein A	equivalent	blood apolipoprotein A level value																				
+Apolipoprotein B	equivalent	blood apolipoprotein B level value	Typo in CMO label?																			
+Sodium(Na) (Blood)	equivalent	blood sodium level value																				
+Potassium(K) (Blood)	equivalent	blood potassium level value																				
+Chloride(Cl)	equivalent	blood chloride level value																				
+Neutrophil	equivalent	blood neutrophil count value																				
+Lymphocyte	equivalent	blood lymphocyte count value																				
+Monocyte	equivalent	blood monocyte count value																				
+Eosinophil	equivalent	blood eosinophil count value																				
+Basophil	equivalent	blood basophil count value																				
+Red cell distribution width (RDW)	equivalent	red blood cell distribution width value																				
+Mean platelet volume (MPV)	equivalent	mean platelet volume value																				
+Platlet crit (PCT)	equivalent	plateletcrit value																				
+Vitamin B12	equivalent	blood vitamin B12 level value	ChEBI stops at B vitamin, but FOODON has vitamin B12 - would that be better?																			
+25-OH-Vitamin D	equivalent	blood calcidiol level value	I *think* this is the right ChEBI term																			
+Thyroglobulin	equivalent	blood thyroglobulin level value																				
+Ferritin	equivalent	blood ferritin level value																				
+UIBC	equivalent	unsaturated iron binding capacity measurement value																				
+Oxidized LDL	subclass	blood low density lipoprotein cholesterol level value	not oxidized																			
+8-OHdG	equivalent	blood 8-OHdG level value																				
+Calcium(Ca) (Blood)	equivalent	blood calcium level value																				
+Free T3	equivalent	blood triiodothyronine level value																				
+Free T4	equivalent	blood thyroxine level value																				
+TSH	equivalent	blood thyroid stimulating hormone level value																				
+Anti-microsomal Ab	equivalent	thyroid peroxidase antibody measurement value																				
+RF	equivalent	rheumatoid factor measurement value																				
+Osteocalcin	equivalent	blood osteocalcin level value																				
+C-telopeptide	equivalent	blood type I collagen C-terminal telopeptide level value																				
+Vitamin D	equivalent	blood vitamin D level value																				
+Estradiol	equivalent	blood estradiol level value																				
+Cadmium(Cd)	equivalent	blood cadmium level value																				
+Lead(Pb)	equivalent	blood lead level value	OK to use lead atom?																			
+Aluminum(Al)	equivalent	blood aluminum level value	atom or ion?																			
+Zinc(Zn)	equivalent	blood zinc level value	OK to use atom?																			
+Blood type	equivalent	blood type determination value																				
+Hepatitis B antibody	equivalent	Hepatits B antibody measurement value																				
+Hepatitis C antibody	equivalent	Hepatits C antibody measurement value																				
+Hepatitis A antibody (HAV)	equivalent	Hepatits A antibody measurement value																				
+HPV(Human Papillomavirus)	subclass	blood measurement value	there's no such thing as an HPV blood test?																			
+Helicobacter pylori	equivalent	Helicobacter pylori antibody measurement value																				
+Carcinoembryonic antigen (CEA)	equivalent	carcinoembryonic antigen measurement value																				
+Cancer antigen 125 (CA125)	equivalent	cancer antigen 125 measurement value																				
+DHEA-S	equivalent	blood dehydroepiandrosterone sulfate level value																				
+IGF-1	equivalent	blood insulin-like growth factor I level value																				
+Testosterone	equivalent	blood testosterone level value																				
+Luteinizing hormone (LH)	equivalent	blood lutenizing hormone level value																				
+Follicle Stimulation Hormone (FSH)	equivalent	blood follicle stimulating hormone level value																				
+Prostate Specific Antigen (PSA)	equivalent	blood prostate-specific antigen level value																				
+Lactate Dehydrogenase (LDH)	equivalent	lactate dehydrogenase measurement value																				
+Telomere length	equivalent	blood telomere length value																				
+Apo E genotype	equivalent	blood apolipoprotein E level value	Not sure if this is quite right																			
+Substudy Urine test	equivalent	urine measurement value																				
+Ketone	equivalent	urine ketone body level value																				
+Bilirubin	equivalent	urine bilirubin level value																				
+Urobilinogen	equivalent	urine urobilinogen level value	NCIT does have a term for this - but have not used NCIT so far																			
+Nitrite	equivalent	urine nitrite level value																				
+Urinary specific gravity	equivalent	urine specific gravity value																				
+Hematuria	equivalent	blood presence in urine value	No check for blood, though HP does have a term for 'blood in urine'. I think looking at the measurement is better here though																			
+Color	equivalent	urine color value																				
+R.B.C.	equivalent	urine erythrocyte level value	CMO only has RBC for blood samples																			
+W.B.C.	equivalent	urine leukocyte level value	CMO only has WBC for blood samples																			
+E.P. cells	equivalent	urine epithelial cell level value																				
+Casts	equivalent	urine cast level value																				
+Bacteria	equivalent	urine bacteria count value	No check for bacteria, though HP does have a term for 'bacteria in urine'. I think looking at the measurement is better here though																			
+Crystals	equivalent	presence of crystals in urine value																				
+Protein, total	equivalent	urine total protein level value																				
+Creatinine (Urine)	equivalent	urine creatinine level value																				
+Uric acid	equivalent	urine uric acid level value	CMO only has blood uric acid																			
+Calcium (Urine)	equivalent	urine calcium level value																				
+Sodium (Urine)	equivalent	urine sodium level value																				
+Potassium (Urine)	equivalent	urine potassium level value																				
+Vitamin C	equivalent	urine vitamin C level value	no CMO term for vit C levels in urine																			
+Microalbumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			

--- a/mappings/koges-mapping.tsv
+++ b/mappings/koges-mapping.tsv
@@ -1,208 +1,207 @@
-Field Label	Class Type	GECKO Label	GECKO Comment																			
-LABEL	CLASS_TYPE	C % SPLIT=|	A comment																			
-Core Variables		KoGES																				
-Core Questionnaires	equivalent	questionnaire/survey data																				
-Socio-demographic data	equivalent	socio-demographic and economic characteristics																				
-Education level	equivalent	education																				
-Marital status	equivalent	marital status value																				
-Household income	equivalent	household income value																				
-Occupation	equivalent	occupation																				
-Medical history	equivalent	clinical history																				
-Disease history of hypertension, diabetes, hyperlipidemia, stroke, angina/myocardial infraction, cancer, etc.	equivalent	diseases																				
-Previous diagnosis (Disease history)	subclass	diseases																				
-Age at first diagnosis (Disease history)	subclass	diseases																				
-Treatment progress (current treatment)	subclass	medication																				
-Treatment method (hypertension, diabetes, hyperlipidemia only)	subclass	medication																				
-Surgery (operation) history	subclass	surgical interventions																				
-Previous surgery (operation)	subclass	surgical interventions																				
-Age at first surgery	subclass	surgical interventions																				
-Family disease history	subclass	family clinical history																				
-Previous diagnosis (Family disease history)	subclass	family clinical history																				
-Relationship	subclass	family clinical history																				
-Age at first diagnosis (Family disease history)	subclass	family clinical history																				
-Number of siblings and children	subclass	family and household structure																				
-Lifestyle	equivalent	lifestyle and behaviours																				
-Smoking habits	equivalent	tobacco																				
-Amount of ciagrettes	subclass	tobacco																				
-Total period of smoking	subclass	tobacco																				
-Age at first smoking	subclass	tobacco																				
-Secondhand smoking	equivalent	exposure to second hand smoke																				
-Drinking habits	equivalent	alcohol consumption history																				
-Amount of drinking	subclass	alcohol consumption history																				
-Total period of drinking	subclass	alcohol consumption history																				
-Drinking frequency	subclass	alcohol consumption history																				
-Sleeping pattern	subclass	sleep																				
-Hours of sleep	subclass	sleep																				
-Time go to bed and wake up in the morning	subclass	sleep																				
-Trouble of sleeping	subclass	sleep																				
-Snoring	equivalent	snoring value																				
-Physical activity	equivalent	physical activity history																				
-Regular physical activity	subclass	physical activity history																				
-Excercises	subclass	physical activity history																				
-Household chores	subclass	physical activity history																				
-Climbing stairs	subclass	physical activity history																				
-Womens health		KoGES																				
-Menstrual factors	subclass	menstrual cycle history																				
-Age at menarche	subclass	menstrual cycle history																				
-Length of menstrual cycle	subclass	menstrual cycle history																				
-Menopause status	equivalent	menopausal status																				
-Reproductive history	equivalent	pregnancy history																				
-Number of pregnancies	subclass	pregnancy history																				
-Age at each pregnancy	subclass	pregnancy history																				
-Durations and outcome of pregnancies	subclass	pregnancy history																				
-Breastfeeding	equivalent	breastfeeding value																				
-Infertility	equivalent	diagnosis of infertility																				
-Dietary survey	equivalent	information about diet																				
-Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result																				
-Dietary habits	subclass	information about diet																				
-Anthropometric measurements	equivalent	anthropometry																				
-Height & weight	equivalent	height|weight																				
-Waist & hip circumference	equivalent	waist circumference value|hip circumference value																				
-Body composition	subclass	anthropometry																				
-Blood pressure & pulse rate	equivalent	blood pressure measurement value|pulse value																				
-Core Clinical examination		KoGES																				
-Core Blood test	equivalent	blood measurement value																				
-Complete blood cell count	equivalent	complete blood cell count value																				
-Glucose (fasting)	equivalent	blood fasting glucose level value	not fasting specified																			
-Albumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
-Blood urea nitrogen (BUN)	equivalent	blood urea nitrogen level value																				
-Creatinine (Blood)	equivalent	blood creatinine level value																				
-AST (SGOT)	equivalent	blood aspartate aminotransferase activity level value																				
-ALT (SGPT)	equivalent	blood alanine aminotransferase activity level value																				
-y-GTP	equivalent	blood gamma-glutamyltransferase activity level value																				
-Total cholesterol	equivalent	blood total cholesterol level value																				
-HDL-Cholesterol	equivalent	blood high density lipoprotein cholesterol level value																				
-Triglyceride	equivalent	blood lipoprotein triglyceride level value																				
-Core Urine test	equivalent	urine measurement value																				
-pH	equivalent	urine pH value																				
-Protein	equivalent	urine total protein level value																				
-Glucose	equivalent	urine glucose level value																				
-Blood	equivalent	blood presence in urine value																				
-Substudy Variables		KoGES																				
-Substudy Questionnaires	equivalent	questionnaire/survey data																				
-Psychosocial well-being status (PWI)	subclass	wellbeing measurement result																				
-Depression (CES-D, BDI)	subclass	diagnosis of depression	not the exact tests																			
-24 hour recall dietary survey	subclass	information about diet																				
-Sleep disorder	equivalent	diagnosis of sleep disorder																				
-In-depth questionnaire (By disease)	equivalent	diseases																				
-Respiratory disease	equivalent	respiratory system																				
-Gastroenterologic disorder	equivalent	diagnosis of gastrointestinal system disease																				
-Otorhinolaryngologic disorder (Ear, Nose)	equivalent	diagnosis of nose disease|diagnosis of auditory system disease																				
-Arthritis	equivalent	diagnosis of arthritis																				
-Aging study		KoGES																				
-Aging study Questionnaires	subclass	questionnaire/survey data																				
-Health-related quality of life (WHOQOL, EQ-SD, SF-12)	subclass	quality of life survey result																				
-Activities of daily living (K-ADL, S-IADL)	subclass	activity of daily living survey result																				
-Dementia screening (K-MMSE, K-MoCA)	subclass	diagnosis of dementia																				
-Dementia screening by caregiver (CS-KGDS, KDSQ-C)	subclass	diagnosis of dementia	not by caregiver																			
-Depression (GDS)	subclass	diagnosis of depression	not specific to aging studies																			
-Vascular dementia / Alzheimers disease screening (Ischemia Scales)	equivalent	diagnosis of vascular dementia|diagnosis of Alzheimers disease																				
-Aging study Clincial examination		KoGES																				
-Cognitive Function test	equivalent	cognitive function measurement result																				
-Neuropsychological test (SNSB-II)	subclass	neuropsychological test result																				
-Physical performance test (SPPB, SFT)	subclass	physical performance testing result																				
-Grip strength	equivalent	grip strength measurement value																				
-Brain MRI	equivalent	brain MRI result																				
-Substudy Clinical Examination		KoGES																				
-Spirometry	equivalent	spirometry result																				
-Bone strength (sonometer)	subclass	bone measurement value	CMO has a few different terms that measure strength, e.g. ultimate force & stifness, but no exact match																			
-Bone mineral density (DEXA test)	equivalent	bone mineral density value																				
-X-ray (chest, hand, knee, C-spin)	subclass	X-ray imaging result																				
-Ultrasound carotid Intima Media Thickness (IMT)	equivalent	carotid artery intima media thickness value																				
-Pulse Wave Velocity (PWV)	subclass	heart blood flow measurement value	Has different pulse wave measurements, but this is the parent class to all																			
-Ecocardiography	equivalent	echocardiography result																				
-Substudy Blood test	equivalent	blood measurement value																				
-Glucose (1hr on OGTT)	subclass	blood glucose level value																				
-Glucose (2hr on OGTT)	subclass	blood glucose level value																				
-HbA1C	equivalent	blood hemoglobin A1c level value																				
-Insulin	equivalent	blood insulin level value																				
-Insulin(1hr)	subclass	blood insulin level value																				
-Insulin(2hr)	subclass	blood insulin level value																				
-Total Protein	subclass	blood protein measurement value	CMO has plasma and serum total protein measurements																			
-Total Bilirubin	equivalent	blood bilirubin level value																				
-LDL-Cholesterol	equivalent	blood low density lipoprotein cholesterol level value																				
-hs-CRP	equivalent	blood C-reactive protein level value																				
-Homocystein	equivalent	blood homocysteine level value																				
-Uric acid	equivalent	blood uric acid level value																				
-Fibrinogen	equivalent	blood fibrinogen level value																				
-Alkaline phosphate	equivalent	blood alkaline phosphate activity level value																				
-Folate	equivalent	blood folate level value																				
-Adiponectin	equivalent	blood adiponectin level value																				
-Glucagon	equivalent	blood glucagon level value																				
-C-peptide	equivalent	blood C-peptide level value																				
-Renin	equivalent	blood renin activity level value																				
-Phosphate	equivalent	blood phosphate level value																				
-Tropinin T	equivalent	blood troponin T level value																				
-Apolipoprotein A	equivalent	blood apolipoprotein A level value																				
-Apolipoprotein B	equivalent	blood apolipoprotein B level value	Typo in CMO label?																			
-Sodium(Na) (Blood)	equivalent	blood sodium level value																				
-Potassium(K) (Blood)	equivalent	blood potassium level value																				
-Chloride(Cl)	equivalent	blood chloride level value																				
-Neutrophil	equivalent	blood neutrophil count value																				
-Lymphocyte	equivalent	blood lymphocyte count value																				
-Monocyte	equivalent	blood monocyte count value																				
-Eosinophil	equivalent	blood eosinophil count value																				
-Basophil	equivalent	blood basophil count value																				
-Red cell distribution width (RDW)	equivalent	red blood cell distribution width value																				
-Mean platelet volume (MPV)	equivalent	mean platelet volume value																				
-Platlet crit (PCT)	equivalent	plateletcrit value																				
-Vitamin B12	equivalent	blood vitamin B12 level value	ChEBI stops at B vitamin, but FOODON has vitamin B12 - would that be better?																			
-25-OH-Vitamin D	equivalent	blood calcidiol level value	I *think* this is the right ChEBI term																			
-Thyroglobulin	equivalent	blood thyroglobulin level value																				
-Ferritin	equivalent	blood ferritin level value																				
-UIBC	equivalent	unsaturated iron binding capacity measurement value																				
-Oxidized LDL	subclass	blood low density lipoprotein cholesterol level value	not oxidized																			
-8-OHdG	equivalent	blood 8-OHdG level value																				
-Calcium(Ca) (Blood)	equivalent	blood calcium level value																				
-Free T3	equivalent	blood triiodothyronine level value																				
-Free T4	equivalent	blood thyroxine level value																				
-TSH	equivalent	blood thyroid stimulating hormone level value																				
-Anti-microsomal Ab	equivalent	thyroid peroxidase antibody measurement value																				
-RF	equivalent	rheumatoid factor measurement value																				
-Osteocalcin	equivalent	blood osteocalcin level value																				
-C-telopeptide	equivalent	blood type I collagen C-terminal telopeptide level value																				
-Vitamin D	equivalent	blood vitamin D level value																				
-Estradiol	equivalent	blood estradiol level value																				
-Cadmium(Cd)	equivalent	blood cadmium level value																				
-Lead(Pb)	equivalent	blood lead level value	OK to use lead atom?																			
-Aluminum(Al)	equivalent	blood aluminum level value	atom or ion?																			
-Zinc(Zn)	equivalent	blood zinc level value	OK to use atom?																			
-Blood type	equivalent	blood type determination value																				
-Hepatitis B antibody	equivalent	Hepatits B antibody measurement value																				
-Hepatitis C antibody	equivalent	Hepatits C antibody measurement value																				
-Hepatitis A antibody (HAV)	equivalent	Hepatits A antibody measurement value																				
-HPV(Human Papillomavirus)	subclass	blood measurement value	there's no such thing as an HPV blood test?																			
-Helicobacter pylori	equivalent	Helicobacter pylori antibody measurement value																				
-Carcinoembryonic antigen (CEA)	equivalent	carcinoembryonic antigen measurement value																				
-Cancer antigen 125 (CA125)	equivalent	cancer antigen 125 measurement value																				
-DHEA-S	equivalent	blood dehydroepiandrosterone sulfate level value																				
-IGF-1	equivalent	blood insulin-like growth factor I level value																				
-Testosterone	equivalent	blood testosterone level value																				
-Luteinizing hormone (LH)	equivalent	blood lutenizing hormone level value																				
-Follicle Stimulation Hormone (FSH)	equivalent	blood follicle stimulating hormone level value																				
-Prostate Specific Antigen (PSA)	equivalent	blood prostate-specific antigen level value																				
-Lactate Dehydrogenase (LDH)	equivalent	lactate dehydrogenase measurement value																				
-Telomere length	equivalent	blood telomere length value																				
-Apo E genotype	equivalent	blood apolipoprotein E level value	Not sure if this is quite right																			
-Substudy Urine test	equivalent	urine measurement value																				
-Ketone	equivalent	urine ketone body level value																				
-Bilirubin	equivalent	urine bilirubin level value																				
-Urobilinogen	equivalent	urine urobilinogen level value	NCIT does have a term for this - but have not used NCIT so far																			
-Nitrite	equivalent	urine nitrite level value																				
-Urinary specific gravity	equivalent	urine specific gravity value																				
-Hematuria	equivalent	blood presence in urine value	No check for blood, though HP does have a term for 'blood in urine'. I think looking at the measurement is better here though																			
-Color	equivalent	urine color value																				
-R.B.C.	equivalent	urine erythrocyte level value	CMO only has RBC for blood samples																			
-W.B.C.	equivalent	urine leukocyte level value	CMO only has WBC for blood samples																			
-E.P. cells	equivalent	urine epithelial cell level value																				
-Casts	equivalent	urine cast level value																				
-Bacteria	equivalent	urine bacteria count value	No check for bacteria, though HP does have a term for 'bacteria in urine'. I think looking at the measurement is better here though																			
-Crystals	equivalent	presence of crystals in urine value																				
-Protein, total	equivalent	urine total protein level value																				
-Creatinine (Urine)	equivalent	urine creatinine level value																				
-Uric acid	equivalent	urine uric acid level value	CMO only has blood uric acid																			
-Calcium (Urine)	equivalent	urine calcium level value																				
-Sodium (Urine)	equivalent	urine sodium level value																				
-Potassium (Urine)	equivalent	urine potassium level value																				
-Vitamin C	equivalent	urine vitamin C level value	no CMO term for vit C levels in urine																			
-Microalbumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
+	Field Label	Class Type	GECKO Label	GECKO Comment																			
+	LABEL	CLASS_TYPE	C % SPLIT=|	A comment																			
+KoGES:0000001	Core Variables		KoGES																				
+KoGES:0000002	Core Questionnaires	equivalent	questionnaire/survey data																				
+KoGES:0000003	Socio-demographic data	equivalent	socio-demographic and economic characteristics																				
+KoGES:0000004	Education level	equivalent	education																				
+KoGES:0000005	Marital status	equivalent	marital status value																				
+KoGES:0000006	Household income	equivalent	household income value																				
+KoGES:0000007	Occupation	equivalent	occupation																				
+KoGES:0000008	Medical history	equivalent	clinical history																				
+KoGES:0000009	Disease history of hypertension, diabetes, hyperlipidemia, stroke, angina/myocardial infraction, cancer, etc.	equivalent	diseases																				
+KoGES:0000010	Previous diagnosis (Disease history)	subclass	diseases																				
+KoGES:0000011	Age at first diagnosis (Disease history)	subclass	diseases																				
+KoGES:0000012	Treatment progress (current treatment)	subclass	medication history																				
+KoGES:0000013	Treatment method (hypertension, diabetes, hyperlipidemia only)	subclass	medication history																				
+KoGES:0000014	Surgery (operation) history	subclass	surgical interventions																				
+KoGES:0000015	Previous surgery (operation)	subclass	surgical interventions																				
+KoGES:0000016	Age at first surgery	subclass	surgical interventions																				
+KoGES:0000017	Family disease history	subclass	family clinical history																				
+KoGES:0000018	Previous diagnosis (Family disease history)	subclass	family clinical history																				
+KoGES:0000019	Relationship	subclass	family clinical history																				
+KoGES:0000020	Age at first diagnosis (Family disease history)	subclass	family clinical history																				
+KoGES:0000021	Number of siblings and children	subclass	family and household structure																				
+KoGES:0000022	Lifestyle	equivalent	lifestyle and behaviours																				
+KoGES:0000023	Smoking habits	equivalent	tobacco																				
+KoGES:0000024	Amount of ciagrettes	subclass	tobacco																				
+KoGES:0000025	Total period of smoking	subclass	tobacco																				
+KoGES:0000026	Age at first smoking	subclass	tobacco																				
+KoGES:0000027	Secondhand smoking	equivalent	exposure to second hand smoke																				
+KoGES:0000028	Drinking habits	equivalent	alcohol consumption history																				
+KoGES:0000029	Amount of drinking	subclass	alcohol consumption history																				
+KoGES:0000030	Total period of drinking	subclass	alcohol consumption history																				
+KoGES:0000031	Drinking frequency	subclass	alcohol consumption history																				
+KoGES:0000032	Sleeping pattern	subclass	sleep																				
+KoGES:0000033	Hours of sleep	subclass	sleep																				
+KoGES:0000034	Time go to bed and wake up in the morning	subclass	sleep																				
+KoGES:0000035	Trouble of sleeping	subclass	sleep																				
+KoGES:0000036	Snoring	equivalent	snoring value																				
+KoGES:0000037	Physical activity	equivalent	physical activity history																				
+KoGES:0000038	Regular physical activity	subclass	physical activity history																				
+KoGES:0000039	Excercises	subclass	physical activity history																				
+KoGES:0000040	Household chores	subclass	physical activity history																				
+KoGES:0000041	Climbing stairs	subclass	physical activity history																				
+KoGES:0000042	Womens health		KoGES																				
+KoGES:0000043	Menstrual factors	subclass	menstrual cycle history																				
+KoGES:0000044	Age at menarche	subclass	menstrual cycle history																				
+KoGES:0000045	Length of menstrual cycle	subclass	menstrual cycle history																				
+KoGES:0000046	Menopause status	equivalent	menopausal status																				
+KoGES:0000047	Reproductive history	equivalent	pregnancy history																				
+KoGES:0000048	Number of pregnancies	subclass	pregnancy history																				
+KoGES:0000049	Age at each pregnancy	subclass	pregnancy history																				
+KoGES:0000050	Durations and outcome of pregnancies	subclass	pregnancy history																				
+KoGES:0000051	Breastfeeding	equivalent	breastfeeding value																				
+KoGES:0000052	Infertility	equivalent	diagnosis of infertility																				
+KoGES:0000053	Dietary survey	equivalent	information about diet																				
+KoGES:0000054	Food Frequency Questionnaire	equivalent	Food Frequency Questionnaire result																				
+KoGES:0000055	Dietary habits	subclass	information about diet																				
+KoGES:0000056	Anthropometric measurements	equivalent	anthropometry																				
+KoGES:0000057	Height & weight	equivalent	height|weight																				
+KoGES:0000058	Waist & hip circumference	equivalent	waist circumference value|hip circumference value																				
+KoGES:0000059	Body composition	subclass	anthropometry																				
+KoGES:0000060	Blood pressure & pulse rate	equivalent	blood pressure measurement value|pulse value																				
+KoGES:0000061	Core Clinical examination		KoGES																				
+KoGES:0000062	Core Blood test	equivalent	blood measurement value																				
+KoGES:0000063	Complete blood cell count	equivalent	complete blood cell count value																				
+KoGES:0000064	Glucose (fasting)	equivalent	blood fasting glucose level value	not fasting specified																			
+KoGES:0000065	Albumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			
+KoGES:0000066	Blood urea nitrogen (BUN)	equivalent	blood urea nitrogen level value																				
+KoGES:0000067	Creatinine (Blood)	equivalent	blood creatinine level value																				
+KoGES:0000068	AST (SGOT)	equivalent	blood aspartate aminotransferase activity level value																				
+KoGES:0000069	ALT (SGPT)	equivalent	blood alanine aminotransferase activity level value																				
+KoGES:0000070	y-GTP	equivalent	blood gamma-glutamyltransferase activity level value																				
+KoGES:0000071	Total cholesterol	equivalent	blood total cholesterol level value																				
+KoGES:0000072	HDL-Cholesterol	equivalent	blood high density lipoprotein cholesterol level value																				
+KoGES:0000073	Triglyceride	equivalent	blood lipoprotein triglyceride level value																				
+KoGES:0000074	Core Urine test	equivalent	urine measurement value																				
+KoGES:0000075	pH	equivalent	urine pH value																				
+KoGES:0000076	Protein	equivalent	urine total protein level value																				
+KoGES:0000077	Glucose	equivalent	urine glucose level value																				
+KoGES:0000078	Blood	equivalent	blood presence in urine value																				
+KoGES:0000079	Substudy Variables		KoGES																				
+KoGES:0000080	Substudy Questionnaires	equivalent	questionnaire/survey data																				
+KoGES:0000081	Psychosocial well-being status (PWI)	subclass	wellbeing measurement result																				
+KoGES:0000082	Depression (CES-D, BDI)	subclass	diagnosis of depression	not the exact tests																			
+KoGES:0000083	24 hour recall dietary survey	subclass	information about diet																				
+KoGES:0000084	Sleep disorder	equivalent	diagnosis of sleep disorder																				
+KoGES:0000085	In-depth questionnaire (By disease)	equivalent	diseases																				
+KoGES:0000086	Respiratory disease	equivalent	respiratory system																				
+KoGES:0000087	Gastroenterologic disorder	equivalent	diagnosis of gastrointestinal system disease																				
+KoGES:0000088	Otorhinolaryngologic disorder (Ear, Nose)	equivalent	diagnosis of nose disease|diagnosis of auditory system disease																				
+KoGES:0000089	Arthritis	equivalent	diagnosis of arthritis																				
+KoGES:0000090	Aging study		KoGES																				
+KoGES:0000091	Aging study Questionnaires	subclass	questionnaire/survey data																				
+KoGES:0000092	Health-related quality of life (WHOQOL, EQ-SD, SF-12)	subclass	quality of life survey result																				
+KoGES:0000093	Activities of daily living (K-ADL, S-IADL)	subclass	activity of daily living survey result																				
+KoGES:0000094	Dementia screening (K-MMSE, K-MoCA)	subclass	diagnosis of dementia																				
+KoGES:0000095	Dementia screening by caregiver (CS-KGDS, KDSQ-C)	subclass	diagnosis of dementia	not by caregiver																			
+KoGES:0000096	Depression (GDS)	subclass	diagnosis of depression	not specific to aging studies																			
+KoGES:0000097	Vascular dementia / Alzheimers disease screening (Ischemia Scales)	equivalent	diagnosis of vascular dementia|diagnosis of Alzheimers disease																				
+KoGES:0000098	Aging study Clincial examination		KoGES																				
+KoGES:0000099	Cognitive Function test	equivalent	cognitive function measurement result																				
+KoGES:0000100	Neuropsychological test (SNSB-II)	subclass	neuropsychological test result																				
+KoGES:0000101	Physical performance test (SPPB, SFT)	subclass	physical performance testing result																				
+KoGES:0000102	Grip strength	equivalent	grip strength measurement value																				
+KoGES:0000103	Brain MRI	equivalent	brain MRI result																				
+KoGES:0000104	Substudy Clinical Examination		KoGES																				
+KoGES:0000105	Spirometry	equivalent	spirometry result																				
+KoGES:0000106	Bone strength (sonometer)	subclass	bone measurement value	CMO has a few different terms that measure strength, e.g. ultimate force & stifness, but no exact match																			
+KoGES:0000107	Bone mineral density (DEXA test)	equivalent	bone mineral density value																				
+KoGES:0000108	X-ray (chest, hand, knee, C-spin)	subclass	X-ray imaging result																				
+KoGES:0000109	Ultrasound carotid Intima Media Thickness (IMT)	equivalent	carotid artery intima media thickness value																				
+KoGES:0000110	Pulse Wave Velocity (PWV)	subclass	heart blood flow measurement value	Has different pulse wave measurements, but this is the parent class to all																			
+KoGES:0000111	Ecocardiography	equivalent	echocardiography result																				
+KoGES:0000112	Substudy Blood test	equivalent	blood measurement value																				
+KoGES:0000113	Glucose (1hr on OGTT)	subclass	blood glucose level value																				
+KoGES:0000114	Glucose (2hr on OGTT)	subclass	blood glucose level value																				
+KoGES:0000115	HbA1C	equivalent	blood hemoglobin A1c level value																				
+KoGES:0000116	Insulin	equivalent	blood insulin level value																				
+KoGES:0000117	Insulin(1hr)	subclass	blood insulin level value																				
+KoGES:0000118	Insulin(2hr)	subclass	blood insulin level value																				
+KoGES:0000119	Total Protein	subclass	blood protein measurement value	CMO has plasma and serum total protein measurements																			
+KoGES:0000120	Total Bilirubin	equivalent	blood bilirubin level value																				
+KoGES:0000121	LDL-Cholesterol	equivalent	blood low density lipoprotein cholesterol level value																				
+KoGES:0000122	hs-CRP	equivalent	blood C-reactive protein level value																				
+KoGES:0000123	Homocystein	equivalent	blood homocysteine level value																				
+KoGES:0000125	Fibrinogen	equivalent	blood fibrinogen level value																				
+KoGES:0000126	Alkaline phosphate	equivalent	blood alkaline phosphate activity level value																				
+KoGES:0000127	Folate	equivalent	blood folate level value																				
+KoGES:0000128	Adiponectin	equivalent	blood adiponectin level value																				
+KoGES:0000129	Glucagon	equivalent	blood glucagon level value																				
+KoGES:0000130	C-peptide	equivalent	blood C-peptide level value																				
+KoGES:0000170	Renin	equivalent	blood renin activity level value																				
+KoGES:0000132	Phosphate	equivalent	blood phosphate level value																				
+KoGES:0000133	Tropinin T	equivalent	blood troponin T level value																				
+KoGES:0000134	Apolipoprotein A	equivalent	blood apolipoprotein A level value																				
+KoGES:0000135	Apolipoprotein B	equivalent	blood apolipoprotein B level value	Typo in CMO label?																			
+KoGES:0000136	Sodium(Na) (Blood)	equivalent	blood sodium level value																				
+KoGES:0000137	Potassium(K) (Blood)	equivalent	blood potassium level value																				
+KoGES:0000138	Chloride(Cl)	equivalent	blood chloride level value																				
+KoGES:0000139	Neutrophil	equivalent	blood neutrophil count value																				
+KoGES:0000140	Lymphocyte	equivalent	blood lymphocyte count value																				
+KoGES:0000141	Monocyte	equivalent	blood monocyte count value																				
+KoGES:0000142	Eosinophil	equivalent	blood eosinophil count value																				
+KoGES:0000143	Basophil	equivalent	blood basophil count value																				
+KoGES:0000144	Red cell distribution width (RDW)	equivalent	red blood cell distribution width value																				
+KoGES:0000145	Mean platelet volume (MPV)	equivalent	mean platelet volume value																				
+KoGES:0000146	Platlet crit (PCT)	equivalent	plateletcrit value																				
+KoGES:0000147	Vitamin B12	equivalent	blood vitamin B12 level value	ChEBI stops at B vitamin, but FOODON has vitamin B12 - would that be better?																			
+KoGES:0000148	25-OH-Vitamin D	equivalent	blood calcidiol level value	I *think* this is the right ChEBI term																			
+KoGES:0000149	Thyroglobulin	equivalent	blood thyroglobulin level value																				
+KoGES:0000152	Ferritin	equivalent	blood ferritin level value																				
+KoGES:0000151	UIBC	equivalent	unsaturated iron binding capacity measurement value																				
+KoGES:0000153	Oxidized LDL	subclass	blood low density lipoprotein cholesterol level value	not oxidized																			
+KoGES:0000154	8-OHdG	equivalent	blood 8-OHdG level value																				
+KoGES:0000155	Calcium(Ca) (Blood)	equivalent	blood calcium level value																				
+KoGES:0000156	Free T3	equivalent	blood triiodothyronine level value																				
+KoGES:0000157	Free T4	equivalent	blood thyroxine level value																				
+KoGES:0000158	TSH	equivalent	blood thyroid stimulating hormone level value																				
+KoGES:0000159	Anti-microsomal Ab	equivalent	thyroid peroxidase antibody measurement value																				
+KoGES:0000160	RF	equivalent	rheumatoid factor measurement value																				
+KoGES:0000161	Osteocalcin	equivalent	blood osteocalcin level value																				
+KoGES:0000162	C-telopeptide	equivalent	blood type I collagen C-terminal telopeptide level value																				
+KoGES:0000163	Vitamin D	equivalent	blood vitamin D level value																				
+KoGES:0000164	Estradiol	equivalent	blood estradiol level value																				
+KoGES:0000165	Cadmium(Cd)	equivalent	blood cadmium level value																				
+KoGES:0000166	Lead(Pb)	equivalent	blood lead level value	OK to use lead atom?																			
+KoGES:0000167	Aluminum(Al)	equivalent	blood aluminum level value	atom or ion?																			
+KoGES:0000168	Zinc(Zn)	equivalent	blood zinc level value	OK to use atom?																			
+KoGES:0000169	Blood type	equivalent	blood type determination value																				
+KoGES:0000171	Hepatitis B antibody	equivalent	Hepatits B antibody measurement value																				
+KoGES:0000172	Hepatitis C antibody	equivalent	Hepatits C antibody measurement value																				
+KoGES:0000173	Hepatitis A antibody (HAV)	equivalent	Hepatits A antibody measurement value																				
+KoGES:0000174	HPV(Human Papillomavirus)	subclass	blood measurement value	there's no such thing as an HPV blood test?																			
+KoGES:0000175	Helicobacter pylori	equivalent	Helicobacter pylori antibody measurement value																				
+KoGES:0000176	Carcinoembryonic antigen (CEA)	equivalent	carcinoembryonic antigen measurement value																				
+KoGES:0000177	Cancer antigen 125 (CA125)	equivalent	cancer antigen 125 measurement value																				
+KoGES:0000178	DHEA-S	equivalent	blood dehydroepiandrosterone sulfate level value																				
+KoGES:0000179	IGF-1	equivalent	blood insulin-like growth factor I level value																				
+KoGES:0000180	Testosterone	equivalent	blood testosterone level value																				
+KoGES:0000181	Luteinizing hormone (LH)	equivalent	blood lutenizing hormone level value																				
+KoGES:0000182	Follicle Stimulation Hormone (FSH)	equivalent	blood follicle stimulating hormone level value																				
+KoGES:0000183	Prostate Specific Antigen (PSA)	equivalent	blood prostate-specific antigen level value																				
+KoGES:0000184	Lactate Dehydrogenase (LDH)	equivalent	lactate dehydrogenase measurement value																				
+KoGES:0000185	Telomere length	equivalent	blood telomere length value																				
+KoGES:0000186	Apo E genotype	equivalent	blood apolipoprotein E level value	Not sure if this is quite right																			
+KoGES:0000187	Substudy Urine test	equivalent	urine measurement value																				
+KoGES:0000188	Ketone	equivalent	urine ketone body level value																				
+KoGES:0000189	Bilirubin	equivalent	urine bilirubin level value																				
+KoGES:0000190	Urobilinogen	equivalent	urine urobilinogen level value	NCIT does have a term for this - but have not used NCIT so far																			
+KoGES:0000191	Nitrite	equivalent	urine nitrite level value																				
+KoGES:0000192	Urinary specific gravity	equivalent	urine specific gravity value																				
+KoGES:0000193	Hematuria	equivalent	blood presence in urine value	No check for blood, though HP does have a term for 'blood in urine'. I think looking at the measurement is better here though																			
+KoGES:0000194	Color	equivalent	urine color value																				
+KoGES:0000195	R.B.C.	equivalent	urine erythrocyte level value	CMO only has RBC for blood samples																			
+KoGES:0000196	W.B.C.	equivalent	urine leukocyte level value	CMO only has WBC for blood samples																			
+KoGES:0000197	E.P. cells	equivalent	urine epithelial cell level value																				
+KoGES:0000198	Casts	equivalent	urine cast level value																				
+KoGES:0000199	Bacteria	equivalent	urine bacteria count value	No check for bacteria, though HP does have a term for 'bacteria in urine'. I think looking at the measurement is better here though																			
+KoGES:0000200	Crystals	equivalent	presence of crystals in urine value																				
+KoGES:0000201	Protein, total	equivalent	urine total protein level value																				
+KoGES:0000202	Creatinine (Urine)	equivalent	urine creatinine level value																				
+KoGES:0000203	Uric acid	equivalent	urine uric acid level value	CMO only has blood uric acid																			
+KoGES:0000204	Calcium (Urine)	equivalent	urine calcium level value																				
+KoGES:0000205	Sodium (Urine)	equivalent	urine sodium level value																				
+KoGES:0000206	Potassium (Urine)	equivalent	urine potassium level value																				
+KoGES:0000207	Vitamin C	equivalent	urine vitamin C level value	no CMO term for vit C levels in urine																			
+KoGES:0000208	Microalbumin	equivalent	urine albumin excretion rate value	not sure if the excretion rate assay is the correct match, but this is the only thing I could find																			

--- a/mappings/maelstrom-mapping.tsv
+++ b/mappings/maelstrom-mapping.tsv
@@ -1,0 +1,1002 @@
+ID	Label	Mapping Type	GECKO Mapping	Parent	Comment
+ID	LABEL	CLASS_TYPE	C %		A comment
+MAELSTROM:Administrative_information	Administrative information	equivalent	survey administration		
+MAELSTROM:Identifiers	Identifiers	equivalent	unique identifiers	MAELSTROM:Administrative_information	
+MAELSTROM:Date_time_related_info	Date and time-related information	equivalent	date and time-related information	MAELSTROM:Administrative_information	
+MAELSTROM:Questionnaire_interview_related_info	Questionnaire and interview-related information	subclass	survey administration	MAELSTROM:Administrative_information	
+MAELSTROM:Physical_measure_biosamp_related_info	Physical and cognitive measure and biosample-related information	subclass	survey administration	MAELSTROM:Administrative_information	
+MAELSTROM:Data_sample_center	Data and sample collection center-related information	subclass	survey administration	MAELSTROM:Administrative_information	
+MAELSTROM:Other_admin_info	Other administrative information	subclass	survey administration	MAELSTROM:Administrative_information	
+MAELSTROM:Cognitive_psychological_measures	Cognition, personality and psychological measures and assessments		Maelstrom		No mapping in CINECA
+MAELSTROM:Cognitive_functioning	Cognitive functioning			MAELSTROM:Cognitive_psychological_measures	
+MAELSTROM:Personality	Personality			MAELSTROM:Cognitive_psychological_measures	
+MAELSTROM:Psychological_emotional_distress	Psychological distress and emotions			MAELSTROM:Cognitive_psychological_measures	
+MAELSTROM:Other_psycholog_measures	Other psychological measures and assessments			MAELSTROM:Cognitive_psychological_measures	
+MAELSTROM:Diseases	Diseases	equivalent	diseases		
+MAELSTROM:Infectious_dis	Certain infectious and parasitic diseases (A00-B99)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Neoplasms	Neoplasms (C00-D48)	equivalent	oncological	MAELSTROM:Diseases	maybe not equiv because this could include non-cancerous
+MAELSTROM:Blood_immune_dis	Diseases of the blood and blood-forming organs and certain disorders involving the immune mechanism (D50-D89)	equivalent	blood-related disorders	MAELSTROM:Diseases	maybe not equiv because this includes immune disorders
+MAELSTROM:Endocrine_metabolic_dis	Endocrine, nutritional and metabolic diseases (E00-E90)	equivalent	endocrine/nutritional/metabolic disorders	MAELSTROM:Diseases	
+MAELSTROM:Mental_behav_dis	Mental and behavioural disorders (F00-F99)	equivalent	mental and behaviour disorders	MAELSTROM:Diseases	
+MAELSTROM:Nervous_sys_dis	Diseases of the nervous system (G00-G99)	equivalent	nervous system	MAELSTROM:Diseases	
+MAELSTROM:Eye_adnexa_dis	Diseases of the eye and adnexa (H00-H59)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Ear_mastoid_dis	Diseases of the ear and mastoid process (H60-H95)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Circulatory_sys_dis	Diseases of the circulatory system (I00-I99)	equivalent	circulatory system	MAELSTROM:Diseases	
+MAELSTROM:Respiratory_sys_dis	Diseases of the respiratory system (J00-J99)	equivalent	respiratory system	MAELSTROM:Diseases	
+MAELSTROM:Digestive_sys_dis	Diseases of the digestive system (K00-K93)	equivalent	digestive system	MAELSTROM:Diseases	
+MAELSTROM:Skin_subcutaneous_dis	Diseases of the skin and subcutaneous tissue (L00-L99)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Musculoskeletal_sys_dis	Diseases of the musculoskeletal system and connective tissue (M00-M99)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Genitourinary_sys_dis	Diseases of the genitourinary system (N00-N99)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Pregnancy_childbirth	Pregnancy, childbirth and the puerperium (O00-O9A)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Perinatal_cond	Certain conditions originating in the perinatal period (P00-P96)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Cong_malform_chrom_abnor	Congenital malformations, deformations and chromosomal abnormalities (Q00-Q99)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Injury_poisoning	Injury, poisoning and certain other consequences of external causes (S00-T98)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Morbidity_mortality_ext	External causes of morbidity and mortality (V01-Y98)	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:Other_dis	Diseases without precise specification or falling into multiple categories	subclass	diseases	MAELSTROM:Diseases	
+MAELSTROM:End_of_life	Death		Maelstrom		No mapping in CINECA
+MAELSTROM:Life_status	Vital status			MAELSTROM:End_of_life	
+MAELSTROM:Cause_death	Cause of death			MAELSTROM:End_of_life	
+MAELSTROM:Other_death	Other end of life or death-related information			MAELSTROM:End_of_life	
+MAELSTROM:Health_community_care_utilization	Health and community care services utilization		Maelstrom		No mapping in CINECA. This is distinct from 'physician/practitioner info', though that may be a subclass of this
+MAELSTROM:Visit_health_prof	Visits to health professionals			MAELSTROM:Health_community_care_utilization	
+MAELSTROM:Hospitalizations	Hospitalizations			MAELSTROM:Health_community_care_utilization	
+MAELSTROM:Community_care	Community and social care			MAELSTROM:Health_community_care_utilization	
+MAELSTROM:Other_health_and_community_care	Other health and community care			MAELSTROM:Health_community_care_utilization	
+MAELSTROM:Health_status_functional_limitations	Perception of health, quality of life, development and functional limitations		Maelstrom		No mapping in CINECA
+MAELSTROM:Perc_health	Perception of health			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Qual_life	Quality of life			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Life_dev	Life course development (under development)			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Act_daily_living	Functional limitations			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Use_devices	Use of assistive devices			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Other	Other perception of health, quality of life and functional limitation-related information			MAELSTROM:Health_status_functional_limitations	
+MAELSTROM:Laboratory_measures	Laboratory measures	equivalent	laboratory measures		this may not be equiv because this seems to also cover biosamples, maybe this is lab + biosamples?
+MAELSTROM:Hematology	Hematology	subclass	laboratory measures	MAELSTROM:Laboratory_measures	maybe blood but that's not under lab measure (its under biosample and we still want to collect data about types of biosamples)
+MAELSTROM:Biochemistry	Biochemistry	subclass	laboratory measures	MAELSTROM:Laboratory_measures	see above
+MAELSTROM:Microbiology	Microbiology	equivalent	microbiology	MAELSTROM:Laboratory_measures	
+MAELSTROM:Virology	Virology	subclass	laboratory measures	MAELSTROM:Laboratory_measures	
+MAELSTROM:Immunology	Immunology	subclass	laboratory measures	MAELSTROM:Laboratory_measures	
+MAELSTROM:Toxicology	Toxicology	subclass	laboratory measures	MAELSTROM:Laboratory_measures	
+MAELSTROM:Histology	Histology	subclass	laboratory measures	MAELSTROM:Laboratory_measures	
+MAELSTROM:Genomics	Genomics	equivalent	genomics	MAELSTROM:Laboratory_measures	
+MAELSTROM:Other_lab_measures	Other laboratory measures	subclass	laboratory measures	MAELSTROM:Laboratory_measures	
+MAELSTROM:Life_events_plans_beliefs	Life events, life plans, beliefs and values		Maelstrom		No mapping in CINECA
+MAELSTROM:Life_events	Life events			MAELSTROM:Life_events_plans_beliefs	
+MAELSTROM:Life_plans	Life plans			MAELSTROM:Life_events_plans_beliefs	
+MAELSTROM:Beliefs_values	Beliefs and values (under development)			MAELSTROM:Life_events_plans_beliefs	
+MAELSTROM:Other_life_events	Other life events, plans and beliefs (under development)			MAELSTROM:Life_events_plans_beliefs	
+MAELSTROM:Lifestyle_behaviours	Lifestyle and behaviours	equivalent	lifestyle and behaviours		
+MAELSTROM:Tobacco	Tobacco	equivalent	tobacco	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Alcohol	Alcohol	equivalent	alcohol	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Drugs	Drugs	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Nutrition	Nutrition	equivalent	nutrition	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Breastfeeding	Breastfeeding	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Phys_act	Physical activity	equivalent	physical activity	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Transportation	Transportation	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Pers_hygiene	Personal hygiene	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Sleep	Sleep	equivalent	sleep	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Sex_behav	Sexual behaviours and orientation	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Leisure_act	Leisure activities	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Tech_devices	Technological devices	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Misbehav_crim	Misbehaviour and criminality	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Other_lifestyle	Other and unspecified lifestyle information	subclass	lifestyle and behaviours	MAELSTROM:Lifestyle_behaviours	
+MAELSTROM:Medication_supplements	Medication and supplements	equivalent	medication history		
+MAELSTROM:Medication_suppl	Medication and supplement intake	equivalent	disease(s) treated with medication	MAELSTROM:Medication_supplements	I'm assuming CINECA associated diseases is talking about taking meds for a disease
+MAELSTROM:Posology_protocol	Posology and protocol of administration	equivalent	posology|administration method of medication	MAELSTROM:Medication_supplements	CINECA posology and CINECA 'admin method' should be children of this
+MAELSTROM:Other_pharmacological_inter	Other and unspecified pharmacological interventions	subclass	medication history	MAELSTROM:Medication_supplements	
+MAELSTROM:Non_pharmacological_interventions	Non-pharmacological interventions	equivalent	non-pharmacological interventions		
+MAELSTROM:Surgical_inter	Surgical interventions	equivalent	surgical interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Radiological_inter	Radiological interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Physical_inter	Physical therapy interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Cognitive_psycho_sensory_inter	Cognitive, psychological and sensory interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Educational_inter	Educational and health promotion interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Biosample_analyses	Laboratory diagnosis interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Other_non_pharmacological_inter	Other and unspecified non-pharmacological interventions	subclass	non-pharmacological interventions	MAELSTROM:Non_pharmacological_interventions	
+MAELSTROM:Physical_environment	Physical environment		Maelstrom		No mapping in CINECA
+MAELSTROM:Housing	Housing characteristics			MAELSTROM:Physical_environment	
+MAELSTROM:Neighborhood	Built environment/neighbourhood characteristics			MAELSTROM:Physical_environment	
+MAELSTROM:Workplace	Workplace characteristics			MAELSTROM:Physical_environment	
+MAELSTROM:Radiation_exp	Radiation exposure			MAELSTROM:Physical_environment	
+MAELSTROM:Chemical_exp	Chemical exposure			MAELSTROM:Physical_environment	
+MAELSTROM:Biological_exp	Biological exposure			MAELSTROM:Physical_environment	
+MAELSTROM:Other_environment	Other physical environment characteristics			MAELSTROM:Physical_environment	
+MAELSTROM:Physical_measures	Physical measures and assessments	equivalent	physiological measurements		
+MAELSTROM:Reproduction	Reproduction	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Menstr_menop_andropause	Puberty, menstruation, menopause and andropause			MAELSTROM:Reproduction	will adopt subclass from Reproduction
+MAELSTROM:Contraception	Contraception			MAELSTROM:Reproduction	will adopt subclass from Reproduction
+MAELSTROM:Pregnancy_delivery	Pregnancy, delivery and birth			MAELSTROM:Reproduction	will adopt subclass from Reproduction
+MAELSTROM:Reprod_sexual_problems	Fertility and sexual health			MAELSTROM:Reproduction	will adopt subclass from Reproduction
+MAELSTROM:Other_reproductive	Other reproductive health-related information			MAELSTROM:Reproduction	will adopt subclass from Reproduction
+MAELSTROM:Physical_characteristics	Physical characteristics	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Anthropo_measures	Anthropometry	equivalent	anthropometry	MAELSTROM:Physical_measures	
+MAELSTROM:Circulation_respiration	Circulation and respiration		circulation and respiration	MAELSTROM:Physical_measures	
+MAELSTROM:Muscles_skeleton_mobility	Muscles, skeleton and mobility	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Sensory_pain	Sensory and pain	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Brain_nerves	Brain and nerves	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Skin_subcutaneous	Skin and subcutaneous tissue	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Speech_voice	Speech and voice	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Digestion	Digestion	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Other_phys_measures	Other physical measures and assessments	subclass	physiological measurements	MAELSTROM:Physical_measures	
+MAELSTROM:Preschool_school_work	Preschool, school and work life		Maelstrom		No mapping in CINECA
+MAELSTROM:Preschool	Preschool life			MAELSTROM:Preschool_school_work	
+MAELSTROM:School	School life			MAELSTROM:Preschool_school_work	
+MAELSTROM:Work	Work life			MAELSTROM:Preschool_school_work	
+MAELSTROM:Other_school_work	Other preschool, school or work life-related information			MAELSTROM:Preschool_school_work	
+MAELSTROM:Social_environment	Social environment and relationships		Maelstrom		No mapping in CINECA
+MAELSTROM:Soc_network	Social network			MAELSTROM:Social_environment	
+MAELSTROM:Soc_participation	Social participation			MAELSTROM:Social_environment	
+MAELSTROM:Soc_support	Social support			MAELSTROM:Social_environment	
+MAELSTROM:Parenting	Parenting and familial environment			MAELSTROM:Social_environment	
+MAELSTROM:Other_soc_characteristics	Other social environment characteristics			MAELSTROM:Social_environment	
+MAELSTROM:Sociodemographic_economic_characteristics	Socio-demographic and economic characteristics	equivalent	socio-demographic and economic characteristics		
+MAELSTROM:Age	Age/birthdate	equivalent	age/birthdate	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Sex	Sex/gender	equivalent	gender|biological sex	MAELSTROM:Sociodemographic_economic_characteristics	gender and biological sex should be children
+MAELSTROM:Twin	Twin	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Marital_status	Marital/partner status	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Family_hh_struct	Family and household structure	equivalent	family and household structure	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Education	Education	equivalent	education	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Residence	Residence	equivalent	residence	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Birth_place	Birthplace	equivalent	birthplace	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Citizenship	Citizenship and immigrant status	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Ethnic_race_religion	Ethnicity, race and religion	equivalent	ethnicity/race	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Language	Language	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Labour_retirement	Labour force and retirement	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Income	Income, possessions, and benefits	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Other_sociodemogr_chars	Other socio-demographic and economic characteristics	subclass	socio-demographic and economic characteristics	MAELSTROM:Sociodemographic_economic_characteristics	
+MAELSTROM:Symptoms_signs	Symptoms and signs	equivalent	signs and symptoms		
+MAELSTROM:Circulatory_respiratory_sympt	Symptoms and signs involving the circulatory and respiratory systems (R00-R09)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Digestive_sympt	Symptoms and signs involving the digestive system and abdomen (R10-R19)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Skin_subcut_sympt	Symptoms and signs involving the skin and subcutaneous tissue (R20-R23)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Nervous_musculoskeletal_sympt	Symptoms and signs involving nervous and musculoskeletal systems (R25-R29)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Urinary_sympt	Symptoms and signs involving the urinary system (R30-R39)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Cognitive_perc_emotional_sympt	Symptoms and signs involving cognition, perception, emotional state and behaviour (R40-R46)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Speech_voice_sympt	Symptoms and signs involving speech and voice (R47-R49)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:General_sympt	General symptoms and signs (R50-R69)	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+MAELSTROM:Other_sympt	Symptoms related to multiple categories	subclass	signs and symptoms	MAELSTROM:Symptoms_signs	
+	Social environment and relationships		Maelstrom		No mapping in CINECA
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					
+					

--- a/mappings/saprin-mapping.tsv
+++ b/mappings/saprin-mapping.tsv
@@ -1,146 +1,146 @@
-Field Label	Class Type	GECKO Label	Comment																			
-LABEL	CLASS_TYPE	C % SPLIT=|																				
-Base Entities		SAPRIN																				
-Location																						
-Type (Location)																						
-Area																						
-Coordinate																						
-Household		residence																				
-Identifier (Household)		residence																				
-Individual		family and household structure																				
-Identifier (Individual)																						
-External identifier (Individual)																						
-Surname																						
-Alternative surname																						
-First name 1																						
-First name 2																						
-Civilian ID number																						
-Citizenship		residence																				
-Nationality		ethnicity/race																				
-Sex		biological sex																				
-Birth (Individual)																						
-EndEvent (Individual)																						
-MotherId																						
-FatherId																						
-MotherSurname																						
-MotherFirstName																						
-FatherSurname																						
-FatherFirstName																						
-Events		SAPRIN																				
-Migration		residence	Maybe?																			
-Date (Migration)		residence	Maybe?																			
-Type (Migration)		residence	Maybe?																			
-Direction		residence	Maybe?																			
-Origin		residence	Maybe?																			
-Destination		residence	Maybe?																			
-Unit																						
-Birth																						
-Date (Birth)		age/birthdate																				
-Birth weight																						
-BirthCertificate																						
-DateRegistered																						
-PregnancyOutcome		pregnancy history																				
-Date (PregnancyOutcome)		pregnancy history																				
-Type (PregnancyOutcome)		pregnancy history																				
-Place (PregnancyOutcome)		pregnancy history																				
-BirthAttendant		pregnancy history																				
-LiveBirths		pregnancy history																				
-Stillborn		pregnancy history																				
-Death																						
-Date (Death)																						
-Place (Death)																						
-DeathCertificate																						
-Verbal autopsy																						
-Enumeration																						
-Date (Enumeration)																						
-Membership Events																						
-Date (Membership Events)																						
-Type (Membership Events)																						
-Household Headship		family and household structure																				
-Date (Household Headship)																						
-Type (Household Headship)																						
-UnionEvent																						
-Date (UnionEvent)																						
-Type (UnionEvent)																						
-Observation																						
-Date (Observation)																						
-Location (Observation)																						
-DataCollector																						
-Respondent																						
-Episodes		SAPRIN																				
-Residence																						
-Individual (Residence)																						
-Location (Residence)																						
-StartEvent (Residence)																						
-EndEvent (Residence)																						
-HouseholdResidence																						
-Household (HouseholdResidence)																						
-Location (HouseholdResidence)																						
-External identifier (HouseholdResidence)																						
-StartEvent (HouseholdResidence)																						
-EndEvent (HouseholdResidence)																						
-Membership Episodes																						
-Individual (Membership Episodes)																						
-Household (Membership Episodes)																						
-StartEvent (Membership Episodes)																						
-EndEvent (Membership Episodes)																						
-Household Head Relationship																						
-Membership (Household Head Relationship)																						
-Relationship																						
-StartEvent (Household Head Relationship)																						
-EndEvent (Household Head Relationship)																						
-Union																						
-Individual1																						
-Individual2																						
-StartEvent (Union)																						
-MarriageDate																						
-EndEvent (Union)																						
-Pregnancy		pregnancy history																				
-Woman		pregnancy history																				
-ANCVisits		pregnancy history																				
-Duration		pregnancy history																				
-Outcome		pregnancy history																				
-Social support																						
-Grantholder																						
-Beneficiary																						
-Type (Social support)																						
-StartDate																						
-EndDate																						
-StatusObservation		SAPRIN																				
-Individual StatusObservation																						
-Individual (Individual StatusObservation)																						
-Observation (Individual StatusObservation)																						
-ResidentStatus		residence																				
-MotherStatus																						
-FatherStatus																						
-HighestSchoolLevelCompleted		education																				
-HighestNonSchoolEducation		education																				
-CurrentEducation		education																				
-Currently employed		occupation																				
-Not employed		occupation																				
-EmploymentSector		occupation																				
-EmploymentType		occupation																				
-Employer		occupation																				
-FinancialStatus																						
-MaritalStatus		marital status value																				
-PartnershipStatus																						
-HealthStatus																						
-Tuberculosis		diagnosis of tuberculosis																				
-HIV		diagnosis of HIV																				
-If HIV+		diagnosis of HIV																				
-If HIV-		diagnosis of HIV																				
-HIVResult		diagnosis of HIV																				
-Hypertension		diagnosis of hypertension																				
-Diabetes		diagnosis of diabetes																				
-Health care utilisation																						
-Vaccination history (child <=6yr)		clinical history	do we want to be more specific?																			
-Household Status Observation																						
-Water source																						
-Toilet																						
-Electricity supply																						
-Cooking fuel																						
-Dwelling construction																						
-Assets																						
-Crime																						
-Financial situation																						
-Food security																						
+ID	Field Label	Class Type	GECKO Label	Comment																			
+ID		CLASS_TYPE	C % SPLIT=|																				
+SAPRIN:Base_Entities	Base Entities		SAPRIN																				
+SAPRIN:Location	Location																						
+SAPRIN:Type_Location	Type (Location)																						
+SAPRIN:Area	Area																						
+SAPRIN:Coordinate	Coordinate																						
+SAPRIN:Household	Household		residence																				
+SAPRIN:Identifier_Household	Identifier (Household)		residence																				
+SAPRIN:Individual	Individual		family and household structure																				
+SAPRIN:Identifier_Individual	Identifier (Individual)																						
+SAPRIN:External_identifier_Individual	External identifier (Individual)																						
+SAPRIN:Surname	Surname																						
+SAPRIN:Alternative_surname	Alternative surname																						
+SAPRIN:First_name_1	First name 1																						
+SAPRIN:First_name_2	First name 2																						
+SAPRIN:Civilian_ID_number	Civilian ID number																						
+SAPRIN:Citizenship	Citizenship		residence																				
+SAPRIN:Nationality	Nationality		ethnicity/race																				
+SAPRIN:Sex	Sex		biological sex																				
+SAPRIN:Birth_Individual	Birth (Individual)																						
+SAPRIN:EndEvent_Individual	EndEvent (Individual)																						
+SAPRIN:MotherId	MotherId																						
+SAPRIN:FatherId	FatherId																						
+SAPRIN:MotherSurname	MotherSurname																						
+SAPRIN:MotherFirstName	MotherFirstName																						
+SAPRIN:FatherSurname	FatherSurname																						
+SAPRIN:FatherFirstName	FatherFirstName																						
+SAPRIN:Events	Events		SAPRIN																				
+SAPRIN:Migration	Migration		residence	Maybe?																			
+SAPRIN:Date_Migration	Date (Migration)		residence	Maybe?																			
+SAPRIN:Type_Migration	Type (Migration)		residence	Maybe?																			
+SAPRIN:Direction	Direction		residence	Maybe?																			
+SAPRIN:Origin	Origin		residence	Maybe?																			
+SAPRIN:Destination	Destination		residence	Maybe?																			
+SAPRIN:Unit	Unit																						
+SAPRIN:Birth	Birth																						
+SAPRIN:Date_Birth	Date (Birth)		age/birthdate																				
+SAPRIN:Birth_weight	Birth weight																						
+SAPRIN:BirthCertificate	BirthCertificate																						
+SAPRIN:DateRegistered	DateRegistered																						
+SAPRIN:PregnancyOutcome	PregnancyOutcome		pregnancy history																				
+SAPRIN:Date_PregnancyOutcome	Date (PregnancyOutcome)		pregnancy history																				
+SAPRIN:Type_PregnancyOutcome	Type (PregnancyOutcome)		pregnancy history																				
+SAPRIN:Place_PregnancyOutcome	Place (PregnancyOutcome)		pregnancy history																				
+SAPRIN:BirthAttendant	BirthAttendant		pregnancy history																				
+SAPRIN:LiveBirths	LiveBirths		pregnancy history																				
+SAPRIN:Stillborn	Stillborn		pregnancy history																				
+SAPRIN:Death	Death																						
+SAPRIN:Date_Death	Date (Death)																						
+SAPRIN:Place_Death	Place (Death)																						
+SAPRIN:DeathCertificate	DeathCertificate																						
+SAPRIN:Verbal_autopsy	Verbal autopsy																						
+SAPRIN:Enumeration	Enumeration																						
+SAPRIN:Date_Enumeration	Date (Enumeration)																						
+SAPRIN:Membership_Events	Membership Events																						
+SAPRIN:Date_Membership_Events	Date (Membership Events)																						
+SAPRIN:Type_Membership_Events	Type (Membership Events)																						
+SAPRIN:Household_Headship	Household Headship		family and household structure																				
+SAPRIN:Date_Household_Headship	Date (Household Headship)																						
+SAPRIN:Type_Household_Headship	Type (Household Headship)																						
+SAPRIN:UnionEvent	UnionEvent																						
+SAPRIN:Date_UnionEvent	Date (UnionEvent)																						
+SAPRIN:Type_UnionEvent	Type (UnionEvent)																						
+SAPRIN:Observation	Observation																						
+SAPRIN:Date_Observation	Date (Observation)																						
+SAPRIN:Location_Observation	Location (Observation)																						
+SAPRIN:DataCollector	DataCollector																						
+SAPRIN:Respondent	Respondent																						
+SAPRIN:Episodes	Episodes		SAPRIN																				
+SAPRIN:Residence	Residence																						
+SAPRIN:Individual_Residence	Individual (Residence)																						
+SAPRIN:Location_Residence	Location (Residence)																						
+SAPRIN:StartEvent_Residence	StartEvent (Residence)																						
+SAPRIN:EndEvent_Residence	EndEvent (Residence)																						
+SAPRIN:HouseholdResidence	HouseholdResidence																						
+SAPRIN:Household_HouseholdResidence	Household (HouseholdResidence)																						
+SAPRIN:Location_HouseholdResidence	Location (HouseholdResidence)																						
+SAPRIN:External_identifier_HouseholdResidence	External identifier (HouseholdResidence)																						
+SAPRIN:StartEvent_HouseholdResidence	StartEvent (HouseholdResidence)																						
+SAPRIN:EndEvent_HouseholdResidence	EndEvent (HouseholdResidence)																						
+SAPRIN:Membership_Episodes	Membership Episodes																						
+SAPRIN:Individual_Membership_Episodes	Individual (Membership Episodes)																						
+SAPRIN:Household_Membership_Episodes	Household (Membership Episodes)																						
+SAPRIN:StartEvent_Membership_Episodes	StartEvent (Membership Episodes)																						
+SAPRIN:EndEvent_Membership_Episodes	EndEvent (Membership Episodes)																						
+SAPRIN:Household_Head_Relationship	Household Head Relationship																						
+SAPRIN:Membership_Household_Head_Relationship	Membership (Household Head Relationship)																						
+SAPRIN:Relationship	Relationship																						
+SAPRIN:StartEvent_Household_Head_Relationship	StartEvent (Household Head Relationship)																						
+SAPRIN:EndEvent_Household_Head_Relationship	EndEvent (Household Head Relationship)																						
+SAPRIN:Union	Union																						
+SAPRIN:Individual1	Individual1																						
+SAPRIN:Individual2	Individual2																						
+SAPRIN:StartEvent_Union	StartEvent (Union)																						
+SAPRIN:MarriageDate	MarriageDate																						
+SAPRIN:EndEvent_Union	EndEvent (Union)																						
+SAPRIN:Pregnancy	Pregnancy		pregnancy history																				
+SAPRIN:Woman	Woman		pregnancy history																				
+SAPRIN:ANCVisits	ANCVisits		pregnancy history																				
+SAPRIN:Duration	Duration		pregnancy history																				
+SAPRIN:Outcome	Outcome		pregnancy history																				
+SAPRIN:Social_support	Social support																						
+SAPRIN:Grantholder	Grantholder																						
+SAPRIN:Beneficiary	Beneficiary																						
+SAPRIN:Type_Social_support	Type (Social support)																						
+SAPRIN:StartDate	StartDate																						
+SAPRIN:EndDate	EndDate																						
+SAPRIN:StatusObservation	StatusObservation		SAPRIN																				
+SAPRIN:Individual_StatusObservation	Individual StatusObservation																						
+SAPRIN:Individual_Individual_StatusObservation	Individual (Individual StatusObservation)																						
+SAPRIN:Observation_Individual_StatusObservation	Observation (Individual StatusObservation)																						
+SAPRIN:ResidentStatus	ResidentStatus		residence																				
+SAPRIN:MotherStatus	MotherStatus																						
+SAPRIN:FatherStatus	FatherStatus																						
+SAPRIN:HighestSchoolLevelCompleted	HighestSchoolLevelCompleted		education																				
+SAPRIN:HighestNonSchoolEducation	HighestNonSchoolEducation		education																				
+SAPRIN:CurrentEducation	CurrentEducation		education																				
+SAPRIN:Currently_employed	Currently employed		occupation																				
+SAPRIN:Not_employed	Not employed		occupation																				
+SAPRIN:EmploymentSector	EmploymentSector		occupation																				
+SAPRIN:EmploymentType	EmploymentType		occupation																				
+SAPRIN:Employer	Employer		occupation																				
+SAPRIN:FinancialStatus	FinancialStatus																						
+SAPRIN:MaritalStatus	MaritalStatus		marital status value																				
+SAPRIN:PartnershipStatus	PartnershipStatus																						
+SAPRIN:HealthStatus	HealthStatus																						
+SAPRIN:Tuberculosis	Tuberculosis		diagnosis of tuberculosis																				
+SAPRIN:HIV	HIV		diagnosis of HIV																				
+SAPRIN:If_HIVPos	If HIV+		diagnosis of HIV																				
+SAPRIN:If_HIVNeg	If HIV-		diagnosis of HIV																				
+SAPRIN:HIVResult	HIVResult		diagnosis of HIV																				
+SAPRIN:Hypertension	Hypertension		diagnosis of hypertension																				
+SAPRIN:Diabetes	Diabetes		diagnosis of diabetes																				
+SAPRIN:Health_care_utilisation	Health care utilisation																						
+SAPRIN:Vaccination_history	Vaccination history (child <=6yr)		clinical history	do we want to be more specific?																			
+SAPRIN:Household_Status_Observation	Household Status Observation																						
+SAPRIN:Water_source	Water source																						
+SAPRIN:Toilet	Toilet																						
+SAPRIN:Electricity_supply	Electricity supply																						
+SAPRIN:Cooking_fuel	Cooking fuel																						
+SAPRIN:Dwelling_construction	Dwelling construction																						
+SAPRIN:Assets	Assets																						
+SAPRIN:Crime	Crime																						
+SAPRIN:Financial_situation	Financial situation																						
+SAPRIN:Food_security	Food security																						

--- a/mappings/saprin-mapping.tsv
+++ b/mappings/saprin-mapping.tsv
@@ -1,146 +1,146 @@
-Field ID	Field Label	Class Type	GECKO Label	Comment																			
-ID	LABEL	CLASS_TYPE	C % SPLIT=|																				
-SAPRIN:Base_Entities	Base Entities																						
-SAPRIN:Location	Location																						
-SAPRIN:Type_Location	Type (Location)																						
-SAPRIN:Area	Area																						
-SAPRIN:Coordinate	Coordinate																						
-SAPRIN:Household	Household		residence																				
-SAPRIN:Identifier_Household	Identifier (Household)		residence																				
-SAPRIN:Individual	Individual		family and household structure																				
-SAPRIN:Identifier_Individual	Identifier (Individual)																						
-SAPRIN:External_identifier_Individual	External identifier (Individual)																						
-SAPRIN:Surname	Surname																						
-SAPRIN:Alternative_surname	Alternative surname																						
-SAPRIN:First_name_1	First name 1																						
-SAPRIN:First_name_2	First name 2																						
-SAPRIN:Civilian_ID_number	Civilian ID number																						
-SAPRIN:Citizenship	Citizenship		residence																				
-SAPRIN:Nationality	Nationality		ethnicity/race																				
-SAPRIN:Sex	Sex		biological sex																				
-SAPRIN:Birth_Individual	Birth (Individual)																						
-SAPRIN:EndEvent_Individual	EndEvent (Individual)																						
-SAPRIN:MotherId	MotherId																						
-SAPRIN:FatherId	FatherId																						
-SAPRIN:MotherSurname	MotherSurname																						
-SAPRIN:MotherFirstName	MotherFirstName																						
-SAPRIN:FatherSurname	FatherSurname																						
-SAPRIN:FatherFirstName	FatherFirstName																						
-SAPRIN:Events	Events																						
-SAPRIN:Migration	Migration		residence	Maybe?																			
-SAPRIN:Date_Migration	Date (Migration)		residence	Maybe?																			
-SAPRIN:Type_Migration	Type (Migration)		residence	Maybe?																			
-SAPRIN:Direction	Direction		residence	Maybe?																			
-SAPRIN:Origin	Origin		residence	Maybe?																			
-SAPRIN:Destination	Destination		residence	Maybe?																			
-SAPRIN:Unit	Unit																						
-SAPRIN:Birth	Birth																						
-SAPRIN:Date_Birth	Date (Birth)		age/birthdate																				
-SAPRIN:Birth_weight	Birth weight																						
-SAPRIN:BirthCertificate	BirthCertificate																						
-SAPRIN:DateRegistered	DateRegistered																						
-SAPRIN:PregnancyOutcome	PregnancyOutcome		pregnancy history																				
-SAPRIN:Date_PregnancyOutcome	Date (PregnancyOutcome)		pregnancy history																				
-SAPRIN:Type_PregnancyOutcome	Type (PregnancyOutcome)		pregnancy history																				
-SAPRIN:Place_PregnancyOutcome	Place (PregnancyOutcome)		pregnancy history																				
-SAPRIN:BirthAttendant	BirthAttendant		pregnancy history																				
-SAPRIN:LiveBirths	LiveBirths		pregnancy history																				
-SAPRIN:Stillborn	Stillborn		pregnancy history																				
-SAPRIN:Death	Death																						
-SAPRIN:Date_Death	Date (Death)																						
-SAPRIN:Place_Death	Place (Death)																						
-SAPRIN:DeathCertificate	DeathCertificate																						
-SAPRIN:Verbal_autopsy	Verbal autopsy																						
-SAPRIN:Enumeration	Enumeration																						
-SAPRIN:Date_Enumeration	Date (Enumeration)																						
-SAPRIN:Membership_Events	Membership Events																						
-SAPRIN:Date_Membership_Events	Date (Membership Events)																						
-SAPRIN:Type_Membership_Events	Type (Membership Events)																						
-SAPRIN:Household_Headship	Household Headship		family and household structure																				
-SAPRIN:Date_Household_Headship	Date (Household Headship)																						
-SAPRIN:Type_Household_Headship	Type (Household Headship)																						
-SAPRIN:UnionEvent	UnionEvent																						
-SAPRIN:Date_UnionEvent	Date (UnionEvent)																						
-SAPRIN:Type_UnionEvent	Type (UnionEvent)																						
-SAPRIN:Observation	Observation																						
-SAPRIN:Date_Observation	Date (Observation)																						
-SAPRIN:Location_Observation	Location (Observation)																						
-SAPRIN:DataCollector	DataCollector																						
-SAPRIN:Respondent	Respondent																						
-SAPRIN:Episodes	Episodes																						
-SAPRIN:Residence	Residence																						
-SAPRIN:Individual_Residence	Individual (Residence)																						
-SAPRIN:Location_Residence	Location (Residence)																						
-SAPRIN:StartEvent_Residence	StartEvent (Residence)																						
-SAPRIN:EndEvent_Residence	EndEvent (Residence)																						
-SAPRIN:HouseholdResidence	HouseholdResidence																						
-SAPRIN:Household_HouseholdResidence	Household (HouseholdResidence)																						
-SAPRIN:Location_HouseholdResidence	Location (HouseholdResidence)																						
-SAPRIN:External_identifier_HouseholdResidence	External identifier (HouseholdResidence)																						
-SAPRIN:StartEvent_HouseholdResidence	StartEvent (HouseholdResidence)																						
-SAPRIN:EndEvent_HouseholdResidence	EndEvent (HouseholdResidence)																						
-SAPRIN:Membership_Episodes	Membership Episodes																						
-SAPRIN:Individual_Membership_Episodes	Individual (Membership Episodes)																						
-SAPRIN:Household_Membership_Episodes	Household (Membership Episodes)																						
-SAPRIN:StartEvent_Membership_Episodes	StartEvent (Membership Episodes)																						
-SAPRIN:EndEvent_Membership_Episodes	EndEvent (Membership Episodes)																						
-SAPRIN:Household_Head_Relationship	Household Head Relationship																						
-SAPRIN:Membership_Household_Head_Relationship	Membership (Household Head Relationship)																						
-SAPRIN:Relationship	Relationship																						
-SAPRIN:StartEvent_Household_Head_Relationship	StartEvent (Household Head Relationship)																						
-SAPRIN:EndEvent_Household_Head_Relationship	EndEvent (Household Head Relationship)																						
-SAPRIN:Union	Union																						
-SAPRIN:Individual1	Individual1																						
-SAPRIN:Individual2	Individual2																						
-SAPRIN:StartEvent_Union	StartEvent (Union)																						
-SAPRIN:MarriageDate	MarriageDate																						
-SAPRIN:EndEvent_Union	EndEvent (Union)																						
-SAPRIN:Pregnancy	Pregnancy		pregnancy history																				
-SAPRIN:Woman	Woman		pregnancy history																				
-SAPRIN:ANCVisits	ANCVisits		pregnancy history																				
-SAPRIN:Duration	Duration		pregnancy history																				
-SAPRIN:Outcome	Outcome		pregnancy history																				
-SAPRIN:Social_support	Social support																						
-SAPRIN:Grantholder	Grantholder																						
-SAPRIN:Beneficiary	Beneficiary																						
-SAPRIN:Type_Social_support	Type (Social support)																						
-SAPRIN:StartDate	StartDate																						
-SAPRIN:EndDate	EndDate																						
-SAPRIN:StatusObservation	StatusObservation																						
-SAPRIN:Individual_StatusObservation	Individual StatusObservation																						
-SAPRIN:Individual_Individual_StatusObservation	Individual (Individual StatusObservation)																						
-SAPRIN:Observation_Individual_StatusObservation	Observation (Individual StatusObservation)																						
-SAPRIN:ResidentStatus	ResidentStatus		residence																				
-SAPRIN:MotherStatus	MotherStatus																						
-SAPRIN:FatherStatus	FatherStatus																						
-SAPRIN:HighestSchoolLevelCompleted	HighestSchoolLevelCompleted		education																				
-SAPRIN:HighestNonSchoolEducation	HighestNonSchoolEducation		education																				
-SAPRIN:CurrentEducation	CurrentEducation		education																				
-SAPRIN:Currently_employed	Currently employed		occupation																				
-SAPRIN:Not_employed	Not employed		occupation																				
-SAPRIN:EmploymentSector	EmploymentSector		occupation																				
-SAPRIN:EmploymentType	EmploymentType		occupation																				
-SAPRIN:Employer	Employer		occupation																				
-SAPRIN:FinancialStatus	FinancialStatus																						
-SAPRIN:MaritalStatus	MaritalStatus		marital status value																				
-SAPRIN:PartnershipStatus	PartnershipStatus																						
-SAPRIN:HealthStatus	HealthStatus																						
-SAPRIN:Tuberculosis	Tuberculosis		diagnosis of tuberculosis																				
-SAPRIN:HIV	HIV		diagnosis of HIV																				
-SAPRIN:If_HIVPos	If HIV+		diagnosis of HIV																				
-SAPRIN:If_HIVNeg	If HIV-		diagnosis of HIV																				
-SAPRIN:HIVResult	HIVResult		diagnosis of HIV																				
-SAPRIN:Hypertension	Hypertension		diagnosis of hypertension																				
-SAPRIN:Diabetes	Diabetes		diagnosis of diabetes																				
-SAPRIN:Health_care_utilisation	Health care utilisation																						
-SAPRIN:Vaccination_history	Vaccination history (child <=6yr)																						
-SAPRIN:Household_Status_Observation	Household Status Observation																						
-SAPRIN:Water_source	Water source																						
-SAPRIN:Toilet	Toilet																						
-SAPRIN:Electricity_supply	Electricity supply																						
-SAPRIN:Cooking_fuel	Cooking fuel																						
-SAPRIN:Dwelling_construction	Dwelling construction																						
-SAPRIN:Assets	Assets																						
-SAPRIN:Crime	Crime																						
-SAPRIN:Financial_situation	Financial situation																						
-SAPRIN:Food_security	Food security																						
+Field Label	Class Type	GECKO Label	Comment																			
+LABEL	CLASS_TYPE	C % SPLIT=|																				
+Base Entities		SAPRIN																				
+Location																						
+Type (Location)																						
+Area																						
+Coordinate																						
+Household		residence																				
+Identifier (Household)		residence																				
+Individual		family and household structure																				
+Identifier (Individual)																						
+External identifier (Individual)																						
+Surname																						
+Alternative surname																						
+First name 1																						
+First name 2																						
+Civilian ID number																						
+Citizenship		residence																				
+Nationality		ethnicity/race																				
+Sex		biological sex																				
+Birth (Individual)																						
+EndEvent (Individual)																						
+MotherId																						
+FatherId																						
+MotherSurname																						
+MotherFirstName																						
+FatherSurname																						
+FatherFirstName																						
+Events		SAPRIN																				
+Migration		residence	Maybe?																			
+Date (Migration)		residence	Maybe?																			
+Type (Migration)		residence	Maybe?																			
+Direction		residence	Maybe?																			
+Origin		residence	Maybe?																			
+Destination		residence	Maybe?																			
+Unit																						
+Birth																						
+Date (Birth)		age/birthdate																				
+Birth weight																						
+BirthCertificate																						
+DateRegistered																						
+PregnancyOutcome		pregnancy history																				
+Date (PregnancyOutcome)		pregnancy history																				
+Type (PregnancyOutcome)		pregnancy history																				
+Place (PregnancyOutcome)		pregnancy history																				
+BirthAttendant		pregnancy history																				
+LiveBirths		pregnancy history																				
+Stillborn		pregnancy history																				
+Death																						
+Date (Death)																						
+Place (Death)																						
+DeathCertificate																						
+Verbal autopsy																						
+Enumeration																						
+Date (Enumeration)																						
+Membership Events																						
+Date (Membership Events)																						
+Type (Membership Events)																						
+Household Headship		family and household structure																				
+Date (Household Headship)																						
+Type (Household Headship)																						
+UnionEvent																						
+Date (UnionEvent)																						
+Type (UnionEvent)																						
+Observation																						
+Date (Observation)																						
+Location (Observation)																						
+DataCollector																						
+Respondent																						
+Episodes		SAPRIN																				
+Residence																						
+Individual (Residence)																						
+Location (Residence)																						
+StartEvent (Residence)																						
+EndEvent (Residence)																						
+HouseholdResidence																						
+Household (HouseholdResidence)																						
+Location (HouseholdResidence)																						
+External identifier (HouseholdResidence)																						
+StartEvent (HouseholdResidence)																						
+EndEvent (HouseholdResidence)																						
+Membership Episodes																						
+Individual (Membership Episodes)																						
+Household (Membership Episodes)																						
+StartEvent (Membership Episodes)																						
+EndEvent (Membership Episodes)																						
+Household Head Relationship																						
+Membership (Household Head Relationship)																						
+Relationship																						
+StartEvent (Household Head Relationship)																						
+EndEvent (Household Head Relationship)																						
+Union																						
+Individual1																						
+Individual2																						
+StartEvent (Union)																						
+MarriageDate																						
+EndEvent (Union)																						
+Pregnancy		pregnancy history																				
+Woman		pregnancy history																				
+ANCVisits		pregnancy history																				
+Duration		pregnancy history																				
+Outcome		pregnancy history																				
+Social support																						
+Grantholder																						
+Beneficiary																						
+Type (Social support)																						
+StartDate																						
+EndDate																						
+StatusObservation		SAPRIN																				
+Individual StatusObservation																						
+Individual (Individual StatusObservation)																						
+Observation (Individual StatusObservation)																						
+ResidentStatus		residence																				
+MotherStatus																						
+FatherStatus																						
+HighestSchoolLevelCompleted		education																				
+HighestNonSchoolEducation		education																				
+CurrentEducation		education																				
+Currently employed		occupation																				
+Not employed		occupation																				
+EmploymentSector		occupation																				
+EmploymentType		occupation																				
+Employer		occupation																				
+FinancialStatus																						
+MaritalStatus		marital status value																				
+PartnershipStatus																						
+HealthStatus																						
+Tuberculosis		diagnosis of tuberculosis																				
+HIV		diagnosis of HIV																				
+If HIV+		diagnosis of HIV																				
+If HIV-		diagnosis of HIV																				
+HIVResult		diagnosis of HIV																				
+Hypertension		diagnosis of hypertension																				
+Diabetes		diagnosis of diabetes																				
+Health care utilisation																						
+Vaccination history (child <=6yr)		clinical history	do we want to be more specific?																			
+Household Status Observation																						
+Water source																						
+Toilet																						
+Electricity supply																						
+Cooking fuel																						
+Dwelling construction																						
+Assets																						
+Crime																						
+Financial situation																						
+Food security																						

--- a/mappings/vukuzazi-mapping.tsv
+++ b/mappings/vukuzazi-mapping.tsv
@@ -1,414 +1,414 @@
-Field ID	Field Label	Class Type	GECKO Label	Comment																					
-ID	LABEL	CLASS_TYPE	C % SPLIT=|																						
-VZ:BPMeasuredEver	BP Measured Ever		blood pressure																						
-VZ:HighBPInformedEver	Ever Been Informed of High BP																								
-VZ:HighBPInformed12mo	Informed of High BP in 12 Months																								
-VZ:HighBPConsult6mo	High BP Consultation 6 months																								
-VZ:HighBPTx2wks	High BP Treatment in the Last 2 Weeks																								
-VZ:BPReferralExist	Referral due to Existing High Blood Pressure																								
-VZ:BPReferralExistReason	Reasons for Referral due to Existing High Blood Pressure																								
-VZ:BPReferralNonExist	Referral due to Non Existing High Blood Pressure																								
-VZ:BPReferralNonExistReason	Reasons for Referral due to Non Existing High Blood Pressure																								
-VZ:HighBPConsultHealer	High BP Consultation With Traditional Healer																								
-VZ:HighBPHerbalCurr	Currently Taking Herbal Treatment for Raised BP																								
-VZ:BSugarMeasuredEver	Blood Sugar Measured Ever																								
-VZ:HighBSugarInformedEver	High Blood Sugar Informed Ever																								
-VZ:HighBSugarInformed12mo	High Blood Sugar Informed Past 12 Months																								
-VZ:HighBSugarConsult6mo	High Blood Sugar Consultation Past 6 months																								
-VZ:HighBSugarTx2wks	High Blood Sugar Treatment Past 2 Weeks																								
-VZ:InsulinTxCurr	Currently Taking Insulin for Diabetes		history of medication for diabetes																						
-VZ:HighBSugarConsultHealer	High Blood Sugar Consultation With Traditional Healer																								
-VZ:CholestMeasuredEver	Cholesterol Measured Ever		blood total cholesterol level value																						
-VZ:HighCholestInformedEver	High Cholesterol Informed Ever		occurrence of high cholesterol																						
-VZ:HighCholestInformed12mo	High Cholesterol Informed Past 12 Months		occurrence of high cholesterol																						
-VZ:HighCholestTx2wks	High Cholesterol Treatment Past 2 Weeks		history of medication for high cholesterol																						
-VZ:HighCholestConsultHealer	High Cholesterol Consultation With Traditional Healer		occurrence of high cholesterol																						
-VZ:HighCholestHerbalCurr	Currently Taking Herbal Treatment for Raised Cholesterol		history of medication for high cholesterol	does herbal fall under this? or should this be non-pharmocological?																					
-VZ:HeartAttackEver	Heart Attack Ever																								
-VZ:HeartAttackAspirinTxCurr	Currently Taking Aspirin Treatment																								
-VZ:HeartAttackStatinsTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Heart Disease																								
-VZ:ParentHistHeartAttack	Parental History of Heart Attack																								
-VZ:HadStrokeEver	History of Stroke																								
-VZ:StrokeAspirinTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Stroke																								
-VZ:ParentHistStroke	Parental History of Stroke																								
-VZ:CancerTxEver	Cancer Treatment Before																								
-VZ:CurrSmoker	Currently Smoking Tobacco																								
-VZ:CurrSmokerDaily	Smoke Tobacco Products Daily																								
-VZ:StopSmoking12mo	Quit Stopping Tobacco																								
-VZ:EverSmoked	Ever Smoked Tobacco Products																								
-VZ:EverSmokedDaily	Ever Smoked Tobacco Products Daily																								
-VZ:EverConsumedAlcohol	Ever Consumed Alcohol																								
-VZ:ConsumedAlcohol12mo	Consumed Alcohol Last 12 Months																								
-VZ:StoppedAlcoholHealth	Stopped Alcohol for Health Reasons																								
-VZ:ConsumedAlcohol30d	Consumed Alcohol Last 30 days																								
-VZ:TBTxCurrent	TB Current Treatment																								
-VZ:ReceivedTBInjections	TB Current Treatment																								
-VZ:TBTxEver	Ever had TB Treatment																								
-VZ:HomesteadMemberTBEver	Homestead Member TB Ever																								
-VZ:HomesteadMemberTBCurr	Homestead (or residential plot) currently on TB treatment																								
-VZ:CoughCurr	currently have a cough?																								
-VZ:FeverCurr	Have a fever currently																								
-VZ:NightSweatsCurr	Night Sweats																								
-VZ:WeightLoss6mo	Weight Loss in 6 months																								
-VZ:OtherSymptoms	Other TB Symptoms																								
-VZ:Fatigue	Fatigue																								
-VZ:Haemoptysis	Haemoptysis																								
-VZ:Chestpain	Chestpain																								
-VZ:Lymphadenitis	Lymphadenitis																								
-VZ:TBSymptDur	Duration of the TB symptoms(weeks)																								
-VZ:HighAsthmaInformedEver	High Asthma InformededEver																								
-VZ:HighAsthmaInformed12mo	Been told of high Asthma																								
-VZ:HighhAsthmaTx2wks	Taken any medication for asthma/COPD prescribed by a doctor or other health worker																								
-VZ:BreathShortness	Shortness of breath after exercise or physical activity																								
-VZ:WakeUpBreathShortness	Wake up at night because of difficulties in breathing/shortness of breath																								
-VZ:NightWheezing	NightWheezing																								
-VZ:ReceivedHIVTestResult	Received HIV Test Result																								
-VZ:HadPosHIVResult	Had Positive HIV Result																								
-VZ:CurrentlyOnART	Currently On ART Treatment																								
-VZ:ARTDefault	Ever Defaulted ART treatment																								
-VZ:ConcurrMed1Curr	Taking Concurrent Medication 1																								
-VZ:ConcurrMed2Curr	Taking Concurrent Medication 2																								
-VZ:ConcurrMed3Curr	Taking Concurrent Medication 3																								
-VZ:ConcurrMed4Curr	Taking Concurrent Medication 4																								
-VZ:ConcurrMed2Adher	Adherence Concurrent Medication 2																								
-VZ:ConcurrMed3Adher	Adherence Concurrent Medication 3																								
-VZ:ConcurrMed4Adher	Adherence Concurrent Medication 4																								
-VZ:ConcurrMed5Adher	Adherence Concurrent Medication 5																								
-VZ:ConcurrMed1Stopped	Stopped Concurrent Medication 1																								
-VZ:ConcurrMed2Stopped	Stopped Concurrent Medication 2																								
-VZ:ConcurrMed3Stopped	Stopped Concurrent Medication 3																								
-VZ:ConcurrMed4Stopped	Stopped Concurrent Medication 4																								
-VZ:ConcurrMed5Stopped	Stopped Concurrent Medication 5																								
-VZ:IsPregant	Is Pregant																								
-VZ:AllComplete	All Complete																								
-VZ:CxrScreeningResult	Chest X Ray Screening Result																								
-VZ:ReferalBasisCxr	Chest X Referal Basis																								
-VZ:CXRScore	Chest X Ray Score																								
-VZ:SputumReferral	Sputum Referral																								
-VZ:CxrMOConclusion	Chest X Ray Medical Officer Conclusion																								
-VZ:CxrMODiagnosticOther	Chest X Ray Medical Officer Diagnostic Other																								
-VZ:CxrMOReport	Chest X Ray Medical Officer Report																								
-VZ:CxrRadiologistDiagnosticOther	Chest X Ray Radiologist Diagnostic Other																								
-VZ:CxrRadiologistReport	Chest X Ray Radiologist Report																								
-VZ:HIVElisaReview	HIV Elisa Medical Officer Review																								
-VZ:CD4Review	CD4 Medical Officer Review																								
-VZ:VLReview	Viral Load Medical Officer Review																								
-VZ:GeneXpertReview	GeneXpert Medical Officer Review																								
-VZ:RifampicinReview	Rifampicin Medical Officer Review																								
-VZ:LiquidCultureReview	LiquidCulture Medical Officer Review																								
-VZ:SolidCultureReview	SolidCulture Medical Officer Review																								
-VZ:HBA1CPercentReview	HBA1CPercent Medical Officer Review																								
-VZ:CXRInterpretation	Medical Officer CXR Interpretation																								
-VZ:CXRInterpretationDesc	Medical Officer CXR Interpretation Description																								
-VZ:MOSuggestedOutcome	Medical Officer Suggested Outcome																								
-VZ:MOFinalOutcome	Medical Officer Final Outcome																								
-VZ:MOSuggestedSecondRoundOutcome	Medical Officer Suggested Second Outcome																								
-VZ:MOSecondRoundOutcome	Medical Officer Second Round Final Outcome																								
-VZ:DiabetesMessage	Medical Officer Diabetes Message																								
-VZ:HIVMessage	Medical Officer HIV Message																								
-VZ:CxrMessage	Medical Officer Chest X-Ray Message																								
-VZ:SecondRoundMessage	Medical Officer Second Round Message																								
-VZ:MOSecondRoundMessage	System Algorythm Flaged Conditions																								
-VZ:MOAgreeSecondRoundMessage	Medical Officer Agreement with System Generated Message																								
-VZ:MOOutcomeDesc	Medical Officer Outcome Description																								
-VZ:MOSuggestedSecondCondition	Medical Officer Suggested Second Condition																								
-VZ:MOAgreeSecondRoundOutcome	Medical Officer Agreement with Second Outcome																								
-VZ:MOSecondRoundOutcomeDesc	Medical Officer Outcome Description																								
-VZ:MOConditions	Medical Officer Conditions																								
-VZ:BPReferallFU	BP Referral from Follow up Visit																								
-VZ:DiabetesReferallFU	Diabetes Referral from Follow up Visit																								
-VZ:HIVReferallFU	HIV Referral from Follow up Visit																								
-VZ:TBReferallFU	TB Referral from Follow up Visit																								
-VZ:InducedTBSputumHome	Homestead Induced TB Sputum Collected																								
-VZ:SpontTBSputumHome	Homestead Spontatneous TB Sputum Collected																								
-VZ:HomeTBSputumOutcome	Home TB Sputum Outcomeollected																								
-VZ:FUGlucose	Follow Up Glucose																								
-VZ:FUGlucoseResult	Follow Up Glucose Result																								
-VZ:FUDiabetesDiagnosis	FUDiabetesDiagnosis																								
-VZ:FUDiabetesClinicDate	Follow Up Target Clinic/Hospital Date for Diabetes																								
-VZ:FUSystolicBp	Clinical Systolic Blood pressure reading																								
-VZ:FUDiastolicBp	Clinical Diastolic Blood pressure reading																								
-VZ:FUBpDiagnosis	FUBpDiagnosis																								
-VZ:FUTBpClinicDate	Follow Up Target Clinic/Hospital for Blood Pressure																								
-VZ:FUHIVStatusInformed	Follow Up Target Clinic/Hospital Date																								
-VZ:SST1Collected	SST1 Collected																								
-VZ:SST1NotCollectedReason	SST1 Not Collected Reason																								
-VZ:EDT1Collected	EDT1 Collected																								
-VZ:EDT1NotCollectedReason	EDT1 Not Collected Reasonn																								
-VZ:EDT2Collected	EDT2 Collected																								
-VZ:EDT2NotCollectedReason	EDT2 Not Collected Reasonn																								
-VZ:EDT3_1Collected	EDT3_1 Collected																								
-VZ:EDT3_1NotCollectedReason	EDT3_1 Not Collected Reasonn																								
-VZ:EDT3_2Collected	EDT3_2 Collected																								
-VZ:EDT3_2NotCollectedReason	EDT3_2 Not Collected Reasonn																								
-VZ:PAX1Collected	PAX1 Collected																								
-VZ:PAX1NotCollectedReason	PAX1 Not Collected Reason																								
-VZ:Ssp1Collected	Ssp1 Collected																								
-VZ:SpontaneousSputumObtained	Spontaneous Sputum Obtained																								
-VZ:SpontaneousSputumNotObtainedReason	Spontaneous Sputum Not Obtained Reason																								
-VZ:InducedSputumObtained	Induced Sputum Obtained																								
-VZ:InducedSputumNotObtainedReason	Induced Sputum Not Obtained Reason																								
-VZ:SSPBottleCollected	SSP Bottle Collected																								
-VZ:InducedSputumNotObtainedOtherReasonExplain	Induced Sputum Not Obtained Other Reason Explain																								
-VZ:SwabSample1Collected	Swab Sample1 Collected																								
-VZ:SwabSample1NotCollectedReason	Swab Sample1 Not Collected Reason																								
-VZ:SwabSample2Collected	Swab Sample2 Collected																								
-VZ:SwabSample2NotCollectedReason	Swab Sample2 Not Collected Reason																								
-VZ:UrineSampleCollected	Urine Sample Collected																								
-VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason																								
-VZ:UrineSampleCollected	Urine Sample Collected																								
-VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason																								
-VZ:PregTestResult	pregnancy Test Result																								
-VZ:PregTestResultNotified	pregnancy Test Result Notified																								
-VZ:BloodGlucoseFailFU	Failed to measure Blood Glucose at Home Follow Up visit																								
-VZ:BPFailFU	Failed to measure Blood Pressure at Home Follow Up visit																								
-VZ:NewHIVReferralFailFU	Failed to refer New HIV Positive case to Clinic at Home Follow Up visit																								
-VZ:CD4LabStatus	CD4 quantity not sufficient, specimen missing, or unable to run																								
-VZ:CD4LabComment	CD4 quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:HIVELisaLabStatus	HIV ELISA quantity not sufficient, specimen missing, or unable to run																								
-VZ:HIVELisaLabComment	HIV ELISA quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:VLLabStatus	VL quantity not sufficient, specimen missing, or unable to run																								
-VZ:VLLabComment	VL quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:HbA1LabStatus	Hb A1c quantity not sufficient, specimen missing, or unable to run																								
-VZ:HbA1LabComment	Hb A1c quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:GeneXpertLabStatus	Gene Xpert quantity not sufficient, specimen missing, or unable to run																								
-VZ:GeneXpertLabComment	Gene Xpert quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:MGITCultureLabStatus	MGIT culture quantity not sufficient, specimen missing, or unable to run																								
-VZ:MGITCultureLabComment	MGIT culture quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:SolidCultureLabStatus	Solid culture quantity not sufficient, specimen missing, or unable to run																								
-VZ:SolidCultureLabComment	Solid culture quantity not sufficient, specimen missing, or unable to run comment																								
-VZ:PhoneCallFail	Phone Call Attempts failed to contact Participant																								
-VZ:HomeVisitFail	Home Visit Attempts failed to contact Participant																								
-VZ:SputumPosRefFail	Failed to refer Positive Sputum case to Clinic or Hospital																								
-VZ:ConsentInformedHIV	Has the participant consented to be informed about their HIV results																								
-VZ:FUCXROtherReferral	Participant Has Diagnosis Other than TB that requires referral to the clinic or hospital																								
-VZ:CancerType	Cancer Type																								
-VZ:AgeStartedSmoking	Age Started Smoking Tobacco		tobacco																						
-VZ:YearsAgoStartedSmoking	Years Ago Individual Started Smoking		tobacco																						
-VZ:MonthsAgoStartedSmoking	Months Ago Individual Started Smoking		tobacco																						
-VZ:WeeksAgoStartedSmoking	Weeks Ago Individual Started Smoking		tobacco																						
-VZ:ManufacturedCigarettesDaily	Manufactured Cigarettes Smoked Daily		tobacco																						
-VZ:ManufacturedCigarettesWeekly	Manufactured Cigarettes Smoked Weekly		tobacco																						
-VZ:HandRolledCigarettesDaily	Hand Rolled Cigarettes Smoked Daily		tobacco																						
-VZ:HandRolledCigarettesWeekly	Hand Rolled Cigarettes Smoked Weekly		tobacco																						
-VZ:PipedTobaccoDaily	Piped Tobacco Cigarettes Smoked Daily		tobacco																						
-VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
-VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
-VZ:CigarsRcherootsDaily	Cigars or Cheroots Daily		tobacco																						
-VZ:CigarsORcherootsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
-VZ:ShishaSessionsDaily	Cigars or Cheroots Smoked Daily		tobacco																						
-VZ:ShishaSessionsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
-VZ:OtherTobaccoSpecifyDaily	Other Tobacco Smoked Daily		tobacco																						
-VZ:OtherTobaccoWeekly	Other Tobacco Smoked Weekly		tobacco																						
-VZ:OtherTobaccoSpecifyDailySpec	Other Tobacco Specify Daily		tobacco																						
-VZ:OtherTobaccoWeeklySpec	Other Tobacco Specify Weekly		tobacco																						
-VZ:ConsumptionFrequency	Alcohol Consumption Frequency		alcohol																						
-VZ:ConsumedAlcoholOccassions	Occassions Consumed Alcohol		alcohol																						
-VZ:DrinksConsumedOccassions	Drinks Consumed During Occassion		alcohol																						
-VZ:DrinksPerOccassion	Drinks Per Occassion		alcohol																						
-VZ:SixDrinksPerOccassion	Six Drinks Per Occassion or More Consumed		alcohol																						
-VZ:LastWeekMondayDrinks	Last Week Monday Drinks		alcohol																						
-VZ:LastWeekTuesdayDrinks	Last Week Tuesday Drinks		alcohol																						
-VZ:LastWeekWednesdayDrinks	Last Week Wednesday Drinks		alcohol																						
-VZ:LastWeekThursdayDrinks	Last Week Thursday Drinks		alcohol																						
-VZ:LastWeekFridayDrinks	Last Week Friday Drinks		alcohol																						
-VZ:LastWeekSaturdayDrinks	Last Week Saturday Drinks		alcohol																						
-VZ:LastWeekSundayDrinks	Last Week Sunday Drinks		alcohol																						
-VZ:ConsumedHomeBredAlcohol	Consumed Home Bred Alcohol		alcohol																						
-VZ:NumberHomeBredSpirits	Number Home Bred Spirits		alcohol																						
-VZ:NumberHomeBredBeer	Number Home Bred Beer		alcohol																						
-VZ:NumberAlcoholImported	Number Alcohol Imported		alcohol																						
-VZ:NumberAlcoholForbidden	Number Alcohol Forbidden		alcohol																						
-VZ:NumberAlcoholUntaxed	Number of Alcohol Untaxed		alcohol																						
-VZ:NumberTBTxEver	Number of Times On TB Treatment		history of medication for tuberculosis																						
-VZ:LastTBDateCompletion	TB Completion Date		history of medication for tuberculosis																						
-VZ:CoughDuration	Cough Duration		occurrence of cough																						
-VZ:CoughSputum	Cough Sputum		occurrence of cough																						
-VZ:FeverDuration	Fever Duration		occurrence of fever																						
-VZ:NightSweatsDuration	Night Sweats Duration		occurrence of night sweats																						
-VZ:WeightLossNumber	Weight Loss Number		occurrence of weight loss																						
-VZ:HIVPosResult1stDate	Date of First HIV Positive Result		diagnosis of HIV																						
-VZ:ARTInitiationDate	Date Of ART Initiation																								
-VZ:ARTDefaultTimes	Number of Times ART Defaulted																								
-VZ:LastHIVNegResultDate	Date of Last HIV Negative Result		diagnosis of HIV																						
-VZ:Medication1	Medication 1																								
-VZ:Medication2	Medication 2																								
-VZ:Medication3	Medication 3																								
-VZ:Medication4	Medication 4																								
-VZ:Medication5	Medication 5																								
-VZ:Medication6	Medication 6																								
-VZ:Medication7	Medication 7																								
-VZ:Medication8	Medication 8																								
-VZ:Medication1StartDate	Medication 1 Start Date																								
-VZ:Medication2StartDate	Medication 2 Start Date																								
-VZ:Medication3StartDate	Medication 3 Start Date																								
-VZ:Medication4StartDate	Medication 4 Start Date																								
-VZ:Medication5StartDate	Medication 5 Start Date																								
-VZ:Medication6StartDate	Medication 6 Start Date																								
-VZ:Medication7StartDate	Medication 7 Start Date																								
-VZ:Medication8StartDate	Medication 8 Start Date																								
-VZ:Medication9StartDate	Medication 9 Start Date																								
-VZ:ConcurrMed1	Concurrent Medication 1																								
-VZ:ConcurrMed2	Concurrent Medication 2																								
-VZ:ConcurrMed3	Concurrent Medication 3																								
-VZ:ConcurrMed4	Concurrent Medication 4																								
-VZ:ConcurrMed5	Concurrent Medication 5																								
-VZ:ConcurrMedIndica1	Concurrent Medication Indication 1																								
-VZ:ConcurrMedIndica2	Concurrent Medication Indication 2																								
-VZ:ConcurrMedIndica3	Concurrent Medication Indication 3																								
-VZ:ConcurrMedIndica4	Concurrent Medication Indication 4																								
-VZ:ConcurrMedIndica5	Concurrent Medication Indication 5																								
-VZ:ConcurrMed1StartDate	Concurrent Medication 1 Start Date																								
-VZ:ConcurrMed2StartDate	Concurrent Medication 2 Start Date																								
-VZ:ConcurrMed3StartDate	Concurrent Medication 3 Start Date																								
-VZ:ConcurrMed4StartDate	Concurrent Medication 4 Start Date																								
-VZ:ConcurrMed5StartDate	Concurrent Medication 5 Start Date																								
-VZ:ConcurrMed5Curr	Taking Concurrent Medication 5																								
-VZ:ConcurrMed1Adher	Adherence Concurrent Medication 1																								
-VZ:TimeLastMeal	Time Last Meal																								
-VZ:LastMenstrualDate	Date of Last Menstrual																								
-VZ:FoodVoucherId	Food Voucher Id																								
-VZ:FoodPackId	Food Pack Id																								
-VZ:NotAllCompleteReaons	Not All Complete Reasons																								
-VZ:SST1	SST1																								
-VZ:EDT1	EDT1																								
-VZ:EDT2	EDT2																								
-VZ:EDT3_1	EDT3_1																								
-VZ:EDT3_2	EDT3_2																								
-VZ:PAX1	PAX1																								
-VZ:Ssp1	Ssp1																								
-VZ:SSPBottle	SSPBottle																								
-VZ:SwabSample1CollectedId	Swab Sample1 Collected Id																								
-VZ:SwabSample2CollectedId	Swab Sample2 Collected Id																								
-VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
-VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
-VZ:PregTestDeviceId	pregnancy Test Device Id																								
-VZ:CxrRadiologistConclusion	Chest X Ray Radiologist Conclusion																								
-VZ:MOLungField	Medical Officer LungFields																								
-VZ:RadiologistLungField	Radiologist LungFields																								
-VZ:UrineRefusal	Refused Urine Sample COllection																								
-VZ:HeightCm	Height in Cm		height																						
-VZ:WeightKg	Weight in Kg		weight																						
-VZ:WaistCircumferenceCm	Waist Circumference in Cm		waist circumference value																						
-VZ:BPCuffSize	BP Cuff Size																								
-VZ:BPFirstSystolic	BP First Systolic																								
-VZ:BPFirstDiastolic	BP First Diastolic																								
-VZ:BPSecondSystolic	BP Second Systolic																								
-VZ:BPSecondDiastolic	BP Second Diastolic																								
-VZ:BPThirdSystolic	BP Third Systolic																								
-VZ:BPThirdDiastolic	BP Third Diastolic																								
-VZ:BPForthSystolic	BP Forth Systolic																								
-VZ:BPForthDiastolic	BP Forth Diastolic																								
-VZ:LowestBpSystolic	BP Lowest Systolic																								
-VZ:LowestBpDiastolic	BP Lowest Diastolic																								
-VZ:HipCircumference	Hip Circumference		hip circumference value																						
-VZ:ArmCircumference	Arm Circumference																								
-VZ:HeartRateFirstReading	Heart Rate First Reading		heart rate																						
-VZ:HeartRateSecondReading	Heart Rate Second Reading		heart rate																						
-VZ:HeartRateThirdReading	Heart RateThird Reading		heart rate																						
-VZ:HeartRateForthReading	Heart Rate Forth Reading		heart rate																						
-VZ:Pregnant	Pregnant		pregnancy history																						
-VZ:ActiveTB	CXR proposed diagnostic-ActiveTB		diagnosis of tuberculosis																						
-VZ:OldTB	CXR proposed diagnostic-OldTB		diagnosis of tuberculosis																						
-VZ:ProbableTB	CXR proposed diagnostic-ProbableTB		diagnosis of tuberculosis																						
-VZ:OtherInfection	CXR proposed diagnostic-OtherInfection																								
-VZ:InflammatoryDisorder	CXR proposed diagnostic-InflammatoryDisorder																								
-VZ:Neoplasm	CXR proposed diagnostic-Neoplasm																								
-VZ:Trauma	CXR proposed diagnostic-Trauma																								
-VZ:CongenitalAbnormality	CXR proposed diagnostic-CongenitalAbnormality																								
-VZ:CardiacDisorder	CXR proposed diagnostic-CardiacDisorder																								
-VZ:VascularDisorder	CXR proposed diagnostic-VascularDisorder																								
-VZ:DegenerativeDisorder	CXR proposed diagnostic-DegenerativeDisorder																								
-VZ:LeftLung	CXR pattern Left lung field & pleura																								
-VZ:RightLung	CXR pattern Right lung field & pleura																								
-VZ:TBDiagnosticOther	TB Diagnostic Other		diagnosis of tuberculosis																						
-VZ:MOTBDiagnosticOther	Medical Officer Diagnostic TB Diagnostic Other		diagnosis of tuberculosis																						
-VZ:RadLeftLungNormal	Radiologist Left Lung Normal																								
-VZ:RadLeftLungConsolid	Radiologist Left Lung Consolidation																								
-VZ:RadLeftLungCavitation	Radiologist Left Lung Cavitation																								
-VZ:RadLeftLungNodules	Radiologist Left Lung Nodules																								
-VZ:RadLeftLungMass	Radiologist Left Lung Mass																								
-VZ:RadLeftLungReticular	Radiologist Left Lung ReticularOpacities																								
-VZ:RadLeftLungFibrosis	Radiologist Left Lung Fibrosis																								
-VZ:RadLeftLungCalcification	Radiologist Left Lung Calcification																								
-VZ:RadLeftLungPleuralThick	Radiologist Left Lung Pleural Thickening																								
-VZ:RadLeftLungPleuralEffusion	Radiologist Left Lung PleuralEffusion																								
-VZ:RadLeftLungNodeEnlarge	Radiologist Left Lung Node Enlargement																								
-VZ:RadLeftLungOther	Radiologist Left Lung Other																								
-VZ:RadRightLungNormal	Radiologist Right Lung Normal																								
-VZ:RadRightLungConsolid	Radiologist Right Lung Consolidation																								
-VZ:RadRightLungCavitation	Radiologist Right Lung Cavitation																								
-VZ:RadRightLungNodules	Radiologist Right Lung Nodules																								
-VZ:RadRightLungMass	Radiologist Right Lung Mass																								
-VZ:RadRightLungReticular	Radiologist Right Lung ReticularOpacities																								
-VZ:RadRightLungFibrosis	Radiologist Right Lung Fibrosis																								
-VZ:RadRightLungCalcification	Radiologist Right Lung Calcification																								
-VZ:RadRightLungPleuralThick	Radiologist Right Lung Pleural Thickening																								
-VZ:RadRightLungPleuralEffusion	Radiologist Right Lung Pleural Effusion																								
-VZ:RadRightLungNodeEnlarge	Radiologist Right Lung Node Enlargement																								
-VZ:RadRightLungOther	Radiologist Right Lung Other																								
-VZ:WillingSurveyedAttempt1	Willing Surveyed Attempt 1																								
-VZ:RadActiveTB	Radiologist Diagnostic ActiveTB		diagnosis of tuberculosis																						
-VZ:RadOldTB	Radiologist Diagnostic OldTB		diagnosis of tuberculosis																						
-VZ:RadProbableTB	Radiologist Diagnostic ProbableTB		diagnosis of tuberculosis																						
-VZ:RadOtherInfection	Radiologist Diagnostic Other Infection																								
-VZ:RadInflammatoryDisorder	Radiologist Diagnostic Inflammatory Disorder																								
-VZ:RadNeoplasm	Radiologistr Diagnostic Neoplasm																								
-VZ:RadTrauma	Radiologist Diagnostic Trauma																								
-VZ:RadCongenitalAbnormality	Radiologist Diagnostic CongenitalAbnormality																								
-VZ:RadCardiacDisorder	Radiologist Diagnostic CardiacDisorder																								
-VZ:RadVascularDisorder	Radiologist Diagnostic VascularDisorder																								
-VZ:RadDegenerativeDisorder	Radiologist Diagnostic Degenerative Disorder																								
-VZ:RadTBDiagnosticOther	Radiologist TB Diagnostic Other		diagnosis of tuberculosis																						
-VZ:LabResultDate	Lab Result Date																								
-VZ:AbnormalResult	Is Result Abnormal?																								
-VZ:ClinicalReview	Needs Clinical Review?																								
-VZ:CD4LymphPercent	CD4 Lymphocytes %																								
-VZ:CD4LymphAb	CD4 Lymphocytes Abs																								
-VZ:CD4CD8Ratio	CD4/CD8 Ratio																								
-VZ:CD8LymphPercent	CD8 Lymphocytes %																								
-VZ:CD8LymphAb	CD8 Lymphocytes Abs																								
-VZ:HBA1c	HBA1c																								
-VZ:HBA1C%	HBA1C%																								
-VZ:Glucose	Glucose Average (calculated)																								
-VZ:Rifampicin	Rifampicin Resistance																								
-VZ:GeneXpert	TB GeneXpert Test Result																								
-VZ:LiquidCulture	Liquid Culture Result(MGIT)																								
-VZ:SolidCulture	Solid Culture Result(7H11)																								
-VZ:SolidIncub	Solid Culture Incubation																								
-VZ:HIVElisa	HIV Elisa Result																								
-VZ:VL	HIV Viral Load Result																								
-VZ:MOLeftLungNormal	Medical Officer Left Lung Normal																								
-VZ:MOLeftLungConsolid	Medical Officer Left Lung Consolidation																								
-VZ:MOLeftLungCavitation	Medical Officer Left Lung Cavitation																								
-VZ:MOLeftLungNodules	Medical Officer Left Lung Nodules																								
-VZ:MOLeftLungMass	Medical Officer Left Lung Mass																								
-VZ:MOLeftLungReticular	Medical Officer Left Lung Reticular Opacities																								
-VZ:MOLeftLungFibrosis	Medical Officer Left Lung Fibrosis																								
-VZ:MOLeftLungCalcification	Medical Officer Left Lung calcification																								
-VZ:MOLeftLungPleuralThick	Medical Officer Left Lung Pleural Thickening																								
-VZ:MOLeftLungPleuralEffusion	Medical Officer Left Lung Pleural Effusion																								
-VZ:MOLeftLungNodeEnlarge	Medical Officer Left Lung Node Enlargement																								
-VZ:MOLeftLungOther	Medical Officer Left Lung Other																								
-VZ:MORightLungNormal	Medical Officer Right Lung Normal																								
-VZ:MORightLungConsolid	Medical Officer Right Lung Consolidation																								
-VZ:MORightLungCavitation	Medical Officer Right Lung Cavitation																								
-VZ:MORightLungNodules	Medical Officer Right Lung Nodules																								
-VZ:MORightLungMass	Medical Officer Right Lung Mass																								
-VZ:MORightLungReticular	Medical Officer Right Lung ReticularOpacities																								
-VZ:MORightLungFibrosis	Medical Officer Right Lung Fibrosis																								
-VZ:MORightLungCalcification	Medical Officer Right Lung Calcification																								
-VZ:MORightLungPleuralThick	Medical Officer Right Lung Pleural Thickening																								
-VZ:MORightLungPleuralEffusion	Medical Officer Right Lung Pleural Effusion																								
-VZ:MORightLungNodeEnlarge	Medical Officer Right Lung Node Enlargement																								
-VZ:MORightLungOther	Medical Officer Right Lung Other																								
-VZ:MOActiveTB	Medical Officer Diagnostic ActiveTB		diagnosis of tuberculosis																						
-VZ:MOOldTB	Medical Officer Diagnostic OldTB		diagnosis of tuberculosis																						
-VZ:MOProbableTB	Medical Officer Diagnostic ProbableTB		diagnosis of tuberculosis																						
-VZ:MOOtherInfection	Medical Officer Diagnostic Other Infection																								
-VZ:MOInflammatoryDisorder	Medical Officer Diagnostic Inflammatory Disorder																								
-VZ:MONeoplasm	Medical Officer Diagnostic Neoplasm																								
-VZ:MOTrauma	Medical Officer Diagnostic Trauma																								
-VZ:MOCongenitalAbnormality	Medical Officer Diagnostic CongenitalAbnormality																								
-VZ:MOCardiacDisorder	Medical Officer Diagnostic CardiacDisorder																								
-VZ:MOVascularDisorder	Medical Officer Diagnostic VascularDisorder																								
+Field Label	Class Type	GECKO Label	Comment																					
+LABEL	CLASS_TYPE	C % SPLIT=|																						
+BP Measured Ever		blood pressure	not quite right- this is asking if you've ever had itmeasured																					
+Ever Been Informed of High BP		occurrence of high blood pressure																						
+Informed of High BP in 12 Months		occurrence of high blood pressure																						
+High BP Consultation 6 months		occurrence of high blood pressure																						
+High BP Treatment in the Last 2 Weeks		history of medication for hypertension	should we differentiate between medication for hypertension & med for high BP?																					
+Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
+Reasons for Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
+Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
+Reasons for Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
+High BP Consultation With Traditional Healer		occurrence of high blood pressure																						
+Currently Taking Herbal Treatment for Raised BP		history of non-pharmacological treatment for high blood pressure																						
+Blood Sugar Measured Ever		blood glucose level value	this is not quite right - this is asking if you've ever had it measured																					
+High Blood Sugar Informed Ever		occurrence of hyperglycemia																						
+High Blood Sugar Informed Past 12 Months		occurrence of hyperglycemia																						
+High Blood Sugar Consultation Past 6 months		occurrence of hyperglycemia																						
+High Blood Sugar Treatment Past 2 Weeks		history of medication for hyperglycemia																						
+Currently Taking Insulin for Diabetes		history of medication for diabetes																						
+High Blood Sugar Consultation With Traditional Healer		occurrence of hyperglycemia																						
+Cholesterol Measured Ever		blood total cholesterol level value	not quite right- this is asking if you've ever had itmeasured																					
+High Cholesterol Informed Ever		occurrence of high cholesterol																						
+High Cholesterol Informed Past 12 Months		occurrence of high cholesterol																						
+High Cholesterol Treatment Past 2 Weeks		history of medication for high cholesterol																						
+High Cholesterol Consultation With Traditional Healer		occurrence of high cholesterol																						
+Currently Taking Herbal Treatment for Raised Cholesterol		history of non-pharmacological treatment for high cholesterol																						
+Heart Attack Ever		occurrence of heart attack																						
+Currently Taking Aspirin Treatment		use of asprin																						
+Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Heart Disease		use of statins																						
+Parental History of Heart Attack		family clinical history																						
+History of Stroke		occurrence of stroke																						
+Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Stroke		use of statins																						
+Parental History of Stroke		family clinical history																						
+Cancer Treatment Before		Vukuzazi	is this non-pharmacological (potential surgery) or medication for cancer?																					
+Currently Smoking Tobacco		tobacco																						
+Smoke Tobacco Products Daily		tobacco																						
+Quit Stopping Tobacco		tobacco																						
+Ever Smoked Tobacco Products		tobacco																						
+Ever Smoked Tobacco Products Daily		tobacco																						
+Ever Consumed Alcohol		alcohol																						
+Consumed Alcohol Last 12 Months		alcohol																						
+Stopped Alcohol for Health Reasons		alcohol																						
+Consumed Alcohol Last 30 days		alcohol																						
+TB Current Treatment		history of medication for tuberculosis																						
+TB Current Treatment		history of medication for tuberculosis																						
+Ever had TB Treatment		history of medication for tuberculosis																						
+Homestead Member TB Ever		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
+Homestead (or residential plot) currently on TB treatment		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
+currently have a cough?		occurrence of cough																						
+Have a fever currently		occurrence of fever																						
+Night Sweats		occurrence of night sweats																						
+Weight Loss in 6 months		occurrence of weight loss																						
+Other TB Symptoms		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
+Fatigue		occurrence of fatigue																						
+Haemoptysis		occurrence of hemoptysis																						
+Chestpain		occurrence of chest pain																						
+Lymphadenitis		occurrence of lymphadenitis																						
+Duration of the TB symptoms(weeks)		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
+High Asthma InformededEver		diagnosis of asthma																						
+Been told of high Asthma		diagnosis of asthma																						
+Taken any medication for asthma/COPD prescribed by a doctor or other health worker		history of medication for chronic obstructive pulmonary disease|history of medication for asthma																						
+Shortness of breath after exercise or physical activity		occurrence of exertional dyspnea																						
+Wake up at night because of difficulties in breathing/shortness of breath		occurrence of dyspnea																						
+NightWheezing		occurrence of wheezing																						
+Received HIV Test Result		Vukuzazi																						
+Had Positive HIV Result		diagnosis of HIV																						
+Currently On ART Treatment		history of medication for HIV																						
+Ever Defaulted ART treatment		history of medication for HIV																						
+Taking Concurrent Medication 1		medication	not sure if we can be more specific on these																					
+Taking Concurrent Medication 2		medication																						
+Taking Concurrent Medication 3		medication																						
+Taking Concurrent Medication 4		medication																						
+Adherence Concurrent Medication 2		medication																						
+Adherence Concurrent Medication 3		medication																						
+Adherence Concurrent Medication 4		medication																						
+Adherence Concurrent Medication 5		medication																						
+Stopped Concurrent Medication 1		medication																						
+Stopped Concurrent Medication 2		medication																						
+Stopped Concurrent Medication 3		medication																						
+Stopped Concurrent Medication 4		medication																						
+Stopped Concurrent Medication 5		medication																						
+Is Pregant		pregnancy history																						
+All Complete		Vukuzazi																						
+Chest X Ray Screening Result		X-ray imaging result																						
+Chest X Referal Basis		X-ray imaging result																						
+Chest X Ray Score		X-ray imaging result																						
+Sputum Referral		Vukuzazi																						
+Chest X Ray Medical Officer Conclusion		X-ray imaging result																						
+Chest X Ray Medical Officer Diagnostic Other		X-ray imaging result																						
+Chest X Ray Medical Officer Report		X-ray imaging result																						
+Chest X Ray Radiologist Diagnostic Other		X-ray imaging result																						
+Chest X Ray Radiologist Report		X-ray imaging result																						
+HIV Elisa Medical Officer Review		diagnosis of HIV																						
+CD4 Medical Officer Review		blood lymphocyte count value																						
+Viral Load Medical Officer Review		diagnosis of HIV																						
+GeneXpert Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+Rifampicin Medical Officer Review		Vukuzazi	not a diagnosis necessarily?																					
+LiquidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+SolidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+HBA1CPercent Medical Officer Review		blood hemoglobin A1c level value																						
+Medical Officer CXR Interpretation		X-ray imaging result																						
+Medical Officer CXR Interpretation Description		X-ray imaging result																						
+Medical Officer Suggested Outcome		Vukuzazi																						
+Medical Officer Final Outcome		Vukuzazi																						
+Medical Officer Suggested Second Outcome		Vukuzazi																						
+Medical Officer Second Round Final Outcome		Vukuzazi																						
+Medical Officer Diabetes Message		diagnosis of diabetes																						
+Medical Officer HIV Message		diagnosis of HIV																						
+Medical Officer Chest X-Ray Message		X-ray imaging result																						
+Medical Officer Second Round Message		Vukuzazi																						
+System Algorythm Flaged Conditions		Vukuzazi																						
+Medical Officer Agreement with System Generated Message		Vukuzazi																						
+Medical Officer Outcome Description		Vukuzazi																						
+Medical Officer Suggested Second Condition		Vukuzazi																						
+Medical Officer Agreement with Second Outcome		Vukuzazi																						
+Medical Officer Outcome Description		Vukuzazi																						
+Medical Officer Conditions		Vukuzazi																						
+BP Referral from Follow up Visit		occurrence of high blood pressure																						
+Diabetes Referral from Follow up Visit		diagnosis of diabetes																						
+HIV Referral from Follow up Visit		diagnosis of HIV																						
+TB Referral from Follow up Visit		diagnosis of tuberculosis																						
+Homestead Induced TB Sputum Collected		sputum sample collected																						
+Homestead Spontatneous TB Sputum Collected		sputum sample collected																						
+Home TB Sputum Outcomeollected		sputum sample collected																						
+Follow Up Glucose		blood glucose level value																						
+Follow Up Glucose Result		blood glucose level value																						
+FUDiabetesDiagnosis		diagnosis of diabetes																						
+Follow Up Target Clinic/Hospital Date for Diabetes		diagnosis of diabetes																						
+Clinical Systolic Blood pressure reading		systolic blood pressure value																						
+Clinical Diastolic Blood pressure reading		diastolic blood pressure value																						
+FUBpDiagnosis		occurrence of high blood pressure																						
+Follow Up Target Clinic/Hospital for Blood Pressure		occurrence of high blood pressure																						
+Follow Up Target Clinic/Hospital Date		diagnosis of HIV																						
+SST1 Collected		Vukuzazi																						
+SST1 Not Collected Reason		Vukuzazi																						
+EDT1 Collected		Vukuzazi																						
+EDT1 Not Collected Reasonn		Vukuzazi																						
+EDT2 Collected		Vukuzazi																						
+EDT2 Not Collected Reasonn		Vukuzazi																						
+EDT3_1 Collected		Vukuzazi																						
+EDT3_1 Not Collected Reasonn		Vukuzazi																						
+EDT3_2 Collected		Vukuzazi																						
+EDT3_2 Not Collected Reasonn		Vukuzazi																						
+PAX1 Collected		Vukuzazi																						
+PAX1 Not Collected Reason		Vukuzazi																						
+Ssp1 Collected		sputum sample collected																						
+Spontaneous Sputum Obtained		sputum sample collected																						
+Spontaneous Sputum Not Obtained Reason		sputum sample collected																						
+Induced Sputum Obtained		sputum sample collected																						
+Induced Sputum Not Obtained Reason		sputum sample collected																						
+SSP Bottle Collected		sputum sample collected																						
+Induced Sputum Not Obtained Other Reason Explain		sputum sample collected																						
+Swab Sample1 Collected		saliva																						
+Swab Sample1 Not Collected Reason		saliva																						
+Swab Sample2 Collected		saliva																						
+Swab Sample2 Not Collected Reason		saliva																						
+Urine Sample Collected		urine																						
+Urine Sample Not Collected Reason		urine																						
+Urine Sample Collected		urine																						
+Urine Sample Not Collected Reason		urine																						
+pregnancy Test Result		pregnancy history																						
+pregnancy Test Result Notified		pregnancy history																						
+Failed to measure Blood Glucose at Home Follow Up visit		blood glucose level value	more about adherence?																					
+Failed to measure Blood Pressure at Home Follow Up visit		blood pressure measurement value	more about adherence?																					
+Failed to refer New HIV Positive case to Clinic at Home Follow Up visit		Vukuzazi																						
+CD4 quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+CD4 quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+HIV ELISA quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+HIV ELISA quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VL quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VL quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+Hb A1c quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+Hb A1c quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+Gene Xpert quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+Gene Xpert quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+MGIT culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+MGIT culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+Solid culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+Solid culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+Phone Call Attempts failed to contact Participant		Vukuzazi																						
+Home Visit Attempts failed to contact Participant		Vukuzazi																						
+Failed to refer Positive Sputum case to Clinic or Hospital		Vukuzazi																						
+Has the participant consented to be informed about their HIV results		Vukuzazi																						
+Participant Has Diagnosis Other than TB that requires referral to the clinic or hospital		diseases																						
+Cancer Type		clinical history of cancer																						
+Age Started Smoking Tobacco		tobacco																						
+Years Ago Individual Started Smoking		tobacco																						
+Months Ago Individual Started Smoking		tobacco																						
+Weeks Ago Individual Started Smoking		tobacco																						
+Manufactured Cigarettes Smoked Daily		tobacco																						
+Manufactured Cigarettes Smoked Weekly		tobacco																						
+Hand Rolled Cigarettes Smoked Daily		tobacco																						
+Hand Rolled Cigarettes Smoked Weekly		tobacco																						
+Piped Tobacco Cigarettes Smoked Daily		tobacco																						
+Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+Cigars or Cheroots Daily		tobacco																						
+Cigars or Cheroots Smoked Weekly		tobacco																						
+Cigars or Cheroots Smoked Daily		tobacco																						
+Cigars or Cheroots Smoked Weekly		tobacco																						
+Other Tobacco Smoked Daily		tobacco																						
+Other Tobacco Smoked Weekly		tobacco																						
+Other Tobacco Specify Daily		tobacco																						
+Other Tobacco Specify Weekly		tobacco																						
+Alcohol Consumption Frequency		alcohol																						
+Occassions Consumed Alcohol		alcohol																						
+Drinks Consumed During Occassion		alcohol																						
+Drinks Per Occassion		alcohol																						
+Six Drinks Per Occassion or More Consumed		alcohol																						
+Last Week Monday Drinks		alcohol																						
+Last Week Tuesday Drinks		alcohol																						
+Last Week Wednesday Drinks		alcohol																						
+Last Week Thursday Drinks		alcohol																						
+Last Week Friday Drinks		alcohol																						
+Last Week Saturday Drinks		alcohol																						
+Last Week Sunday Drinks		alcohol																						
+Consumed Home Bred Alcohol		alcohol																						
+Number Home Bred Spirits		alcohol																						
+Number Home Bred Beer		alcohol																						
+Number Alcohol Imported		alcohol																						
+Number Alcohol Forbidden		alcohol																						
+Number of Alcohol Untaxed		alcohol																						
+Number of Times On TB Treatment		history of medication for tuberculosis																						
+TB Completion Date		history of medication for tuberculosis																						
+Cough Duration		occurrence of cough																						
+Cough Sputum		sputum sample collected																						
+Fever Duration		occurrence of fever																						
+Night Sweats Duration		occurrence of night sweats																						
+Weight Loss Number		occurrence of weight loss																						
+Date of First HIV Positive Result		diagnosis of HIV																						
+Date Of ART Initiation		history of medication for HIV																						
+Number of Times ART Defaulted		history of medication for HIV																						
+Date of Last HIV Negative Result		diagnosis of HIV																						
+Medication 1		medication																						
+Medication 2		medication																						
+Medication 3		medication																						
+Medication 4		medication																						
+Medication 5		medication																						
+Medication 6		medication																						
+Medication 7		medication																						
+Medication 8		medication																						
+Medication 1 Start Date		medication																						
+Medication 2 Start Date		medication																						
+Medication 3 Start Date		medication																						
+Medication 4 Start Date		medication																						
+Medication 5 Start Date		medication																						
+Medication 6 Start Date		medication																						
+Medication 7 Start Date		medication																						
+Medication 8 Start Date		medication																						
+Medication 9 Start Date		medication																						
+Concurrent Medication 1		medication																						
+Concurrent Medication 2		medication																						
+Concurrent Medication 3		medication																						
+Concurrent Medication 4		medication																						
+Concurrent Medication 5		medication																						
+Concurrent Medication Indication 1		medication																						
+Concurrent Medication Indication 2		medication																						
+Concurrent Medication Indication 3		medication																						
+Concurrent Medication Indication 4		medication																						
+Concurrent Medication Indication 5		medication																						
+Concurrent Medication 1 Start Date		medication																						
+Concurrent Medication 2 Start Date		medication																						
+Concurrent Medication 3 Start Date		medication																						
+Concurrent Medication 4 Start Date		medication																						
+Concurrent Medication 5 Start Date		medication																						
+Taking Concurrent Medication 5		medication																						
+Adherence Concurrent Medication 1		medication																						
+Time Last Meal		information about diet																						
+Date of Last Menstrual		menstrual cycle history																						
+Food Voucher Id		information about diet																						
+Food Pack Id		information about diet																						
+Not All Complete Reasons		Vukuzazi																						
+SST1		Vukuzazi																						
+EDT1		Vukuzazi																						
+EDT2		Vukuzazi																						
+EDT3_1		Vukuzazi																						
+EDT3_2		Vukuzazi																						
+PAX1		Vukuzazi																						
+Ssp1		sputum sample collected																						
+SSPBottle		sputum sample collected																						
+Swab Sample1 Collected Id		saliva																						
+Swab Sample2 Collected Id		saliva																						
+Urine Sample Collected Id		urine																						
+Urine Sample Collected Id		urine																						
+pregnancy Test Device Id		pregnancy history																						
+Chest X Ray Radiologist Conclusion		X-ray imaging result																						
+Medical Officer LungFields		Vukuzazi	is this part of X-ray?																					
+Radiologist LungFields		Vukuzazi	is this part of X-ray?																					
+Refused Urine Sample COllection		urine																						
+Height in Cm		height																						
+Weight in Kg		weight																						
+Waist Circumference in Cm		waist circumference value																						
+BP Cuff Size		Vukuzazi	administrative?																					
+BP First Systolic		systolic blood pressure value																						
+BP First Diastolic		diastolic blood pressure value																						
+BP Second Systolic		systolic blood pressure value																						
+BP Second Diastolic		diastolic blood pressure value																						
+BP Third Systolic		systolic blood pressure value																						
+BP Third Diastolic		diastolic blood pressure value																						
+BP Forth Systolic		systolic blood pressure value																						
+BP Forth Diastolic		diastolic blood pressure value																						
+BP Lowest Systolic		systolic blood pressure value																						
+BP Lowest Diastolic		diastolic blood pressure value																						
+Hip Circumference		hip circumference value																						
+Arm Circumference		arm circumference value																						
+Heart Rate First Reading		heart rate																						
+Heart Rate Second Reading		heart rate																						
+Heart RateThird Reading		heart rate																						
+Heart Rate Forth Reading		heart rate																						
+Pregnant		pregnancy history																						
+CXR proposed diagnostic-ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
+CXR proposed diagnostic-OldTB		X-ray imaging result|diagnosis of tuberculosis																						
+CXR proposed diagnostic-ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
+CXR proposed diagnostic-OtherInfection		X-ray imaging result|diagnosis of bacterial infection																						
+CXR proposed diagnostic-InflammatoryDisorder		X-ray imaging result|diagnosis of inflammatory disorder																						
+CXR proposed diagnostic-Neoplasm		X-ray imaging result	oncological?																					
+CXR proposed diagnostic-Trauma		X-ray imaging result																						
+CXR proposed diagnostic-CongenitalAbnormality		X-ray imaging result																						
+CXR proposed diagnostic-CardiacDisorder		X-ray imaging result|circulatory system																						
+CXR proposed diagnostic-VascularDisorder		X-ray imaging result|circulatory system																						
+CXR proposed diagnostic-DegenerativeDisorder		X-ray imaging result																						
+CXR pattern Left lung field & pleura		X-ray imaging result																						
+CXR pattern Right lung field & pleura		X-ray imaging result																						
+TB Diagnostic Other		diagnosis of tuberculosis																						
+Medical Officer Diagnostic TB Diagnostic Other		diagnosis of tuberculosis																						
+Radiologist Left Lung Normal		X-ray imaging result																						
+Radiologist Left Lung Consolidation		X-ray imaging result																						
+Radiologist Left Lung Cavitation		X-ray imaging result																						
+Radiologist Left Lung Nodules		X-ray imaging result																						
+Radiologist Left Lung Mass		X-ray imaging result																						
+Radiologist Left Lung ReticularOpacities		X-ray imaging result																						
+Radiologist Left Lung Fibrosis		X-ray imaging result																						
+Radiologist Left Lung Calcification		X-ray imaging result																						
+Radiologist Left Lung Pleural Thickening		X-ray imaging result																						
+Radiologist Left Lung PleuralEffusion		X-ray imaging result																						
+Radiologist Left Lung Node Enlargement		X-ray imaging result																						
+Radiologist Left Lung Other		X-ray imaging result																						
+Radiologist Right Lung Normal		X-ray imaging result																						
+Radiologist Right Lung Consolidation		X-ray imaging result																						
+Radiologist Right Lung Cavitation		X-ray imaging result																						
+Radiologist Right Lung Nodules		X-ray imaging result																						
+Radiologist Right Lung Mass		X-ray imaging result																						
+Radiologist Right Lung ReticularOpacities		X-ray imaging result																						
+Radiologist Right Lung Fibrosis		X-ray imaging result																						
+Radiologist Right Lung Calcification		X-ray imaging result																						
+Radiologist Right Lung Pleural Thickening		X-ray imaging result																						
+Radiologist Right Lung Pleural Effusion		X-ray imaging result																						
+Radiologist Right Lung Node Enlargement		X-ray imaging result																						
+Radiologist Right Lung Other		X-ray imaging result																						
+Willing Surveyed Attempt 1		Vukuzazi																						
+Radiologist Diagnostic ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
+Radiologist Diagnostic OldTB		X-ray imaging result|diagnosis of tuberculosis																						
+Radiologist Diagnostic ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
+Radiologist Diagnostic Other Infection		X-ray imaging result|diagnosis of bacterial infection																						
+Radiologist Diagnostic Inflammatory Disorder		X-ray imaging result|diagnosis of inflammatory disorder																						
+Radiologistr Diagnostic Neoplasm		X-ray imaging result	should this be oncological?																					
+Radiologist Diagnostic Trauma		X-ray imaging result																						
+Radiologist Diagnostic CongenitalAbnormality		X-ray imaging result																						
+Radiologist Diagnostic CardiacDisorder		X-ray imaging result|circulatory system																						
+Radiologist Diagnostic VascularDisorder		X-ray imaging result|circulatory system																						
+Radiologist Diagnostic Degenerative Disorder		X-ray imaging result																						
+Radiologist TB Diagnostic Other		X-ray imaging result|diagnosis of tuberculosis																						
+Lab Result Date		Vukuzazi																						
+Is Result Abnormal?		Vukuzazi																						
+Needs Clinical Review?		Vukuzazi																						
+CD4 Lymphocytes %		blood lymphocyte count value																						
+CD4 Lymphocytes Abs		blood lymphocyte count value																						
+CD4/CD8 Ratio		blood lymphocyte count value																						
+CD8 Lymphocytes %		blood lymphocyte count value																						
+CD8 Lymphocytes Abs		blood lymphocyte count value																						
+HBA1c		blood hemoglobin A1c level value																						
+HBA1C%		blood hemoglobin A1c level value																						
+Glucose Average (calculated)		blood glucose level value																						
+Rifampicin Resistance		Vukuzazi																						
+TB GeneXpert Test Result		Vukuzazi																						
+Liquid Culture Result(MGIT)		diagnosis of tuberculosis																						
+Solid Culture Result(7H11)		diagnosis of tuberculosis																						
+Solid Culture Incubation		diagnosis of tuberculosis																						
+HIV Elisa Result		diagnosis of HIV	or should this be blood test?																					
+HIV Viral Load Result		diagnosis of HIV	or should this be blood test?																					
+Medical Officer Left Lung Normal		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Consolidation		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Cavitation		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Nodules		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Mass		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Reticular Opacities		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Fibrosis		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung calcification		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
+Medical Officer Left Lung Other		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Normal		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Consolidation		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Cavitation		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Nodules		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Mass		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung ReticularOpacities		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Fibrosis		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Calcification		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
+Medical Officer Right Lung Other		Vukuzazi	are these from X-ray?																					
+Medical Officer Diagnostic ActiveTB		diagnosis of tuberculosis																						
+Medical Officer Diagnostic OldTB		diagnosis of tuberculosis																						
+Medical Officer Diagnostic ProbableTB		diagnosis of tuberculosis																						
+Medical Officer Diagnostic Other Infection		diagnosis of bacterial infection																						
+Medical Officer Diagnostic Inflammatory Disorder		diagnosis of inflammatory disorder																						
+Medical Officer Diagnostic Neoplasm		oncological 	may not be cancer though																					
+Medical Officer Diagnostic Trauma		Vukuzazi	where does trauma fall under?																					
+Medical Officer Diagnostic CongenitalAbnormality		Vukuzazi	where does cong abnormality fall under? diseases?																					
+Medical Officer Diagnostic CardiacDisorder		circulatory system																						
+Medical Officer Diagnostic VascularDisorder		circulatory system																						

--- a/mappings/vukuzazi-mapping.tsv
+++ b/mappings/vukuzazi-mapping.tsv
@@ -1,414 +1,414 @@
-Field Label	Class Type	GECKO Label	Comment																					
-LABEL	CLASS_TYPE	C % SPLIT=|																						
-BP Measured Ever		blood pressure	not quite right- this is asking if you've ever had itmeasured																					
-Ever Been Informed of High BP		occurrence of high blood pressure																						
-Informed of High BP in 12 Months		occurrence of high blood pressure																						
-High BP Consultation 6 months		occurrence of high blood pressure																						
-High BP Treatment in the Last 2 Weeks		history of medication for hypertension	should we differentiate between medication for hypertension & med for high BP?																					
-Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
-Reasons for Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
-Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
-Reasons for Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
-High BP Consultation With Traditional Healer		occurrence of high blood pressure																						
-Currently Taking Herbal Treatment for Raised BP		history of non-pharmacological treatment for high blood pressure																						
-Blood Sugar Measured Ever		blood glucose level value	this is not quite right - this is asking if you've ever had it measured																					
-High Blood Sugar Informed Ever		occurrence of hyperglycemia																						
-High Blood Sugar Informed Past 12 Months		occurrence of hyperglycemia																						
-High Blood Sugar Consultation Past 6 months		occurrence of hyperglycemia																						
-High Blood Sugar Treatment Past 2 Weeks		history of medication for hyperglycemia																						
-Currently Taking Insulin for Diabetes		history of medication for diabetes																						
-High Blood Sugar Consultation With Traditional Healer		occurrence of hyperglycemia																						
-Cholesterol Measured Ever		blood total cholesterol level value	not quite right- this is asking if you've ever had itmeasured																					
-High Cholesterol Informed Ever		occurrence of high cholesterol																						
-High Cholesterol Informed Past 12 Months		occurrence of high cholesterol																						
-High Cholesterol Treatment Past 2 Weeks		history of medication for high cholesterol																						
-High Cholesterol Consultation With Traditional Healer		occurrence of high cholesterol																						
-Currently Taking Herbal Treatment for Raised Cholesterol		history of non-pharmacological treatment for high cholesterol																						
-Heart Attack Ever		occurrence of heart attack																						
-Currently Taking Aspirin Treatment		use of asprin																						
-Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Heart Disease		use of statins																						
-Parental History of Heart Attack		family clinical history																						
-History of Stroke		occurrence of stroke																						
-Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Stroke		use of statins																						
-Parental History of Stroke		family clinical history																						
-Cancer Treatment Before		Vukuzazi	is this non-pharmacological (potential surgery) or medication for cancer?																					
-Currently Smoking Tobacco		tobacco																						
-Smoke Tobacco Products Daily		tobacco																						
-Quit Stopping Tobacco		tobacco																						
-Ever Smoked Tobacco Products		tobacco																						
-Ever Smoked Tobacco Products Daily		tobacco																						
-Ever Consumed Alcohol		alcohol																						
-Consumed Alcohol Last 12 Months		alcohol																						
-Stopped Alcohol for Health Reasons		alcohol																						
-Consumed Alcohol Last 30 days		alcohol																						
-TB Current Treatment		history of medication for tuberculosis																						
-TB Current Treatment		history of medication for tuberculosis																						
-Ever had TB Treatment		history of medication for tuberculosis																						
-Homestead Member TB Ever		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
-Homestead (or residential plot) currently on TB treatment		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
-currently have a cough?		occurrence of cough																						
-Have a fever currently		occurrence of fever																						
-Night Sweats		occurrence of night sweats																						
-Weight Loss in 6 months		occurrence of weight loss																						
-Other TB Symptoms		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
-Fatigue		occurrence of fatigue																						
-Haemoptysis		occurrence of hemoptysis																						
-Chestpain		occurrence of chest pain																						
-Lymphadenitis		occurrence of lymphadenitis																						
-Duration of the TB symptoms(weeks)		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
-High Asthma InformededEver		diagnosis of asthma																						
-Been told of high Asthma		diagnosis of asthma																						
-Taken any medication for asthma/COPD prescribed by a doctor or other health worker		history of medication for chronic obstructive pulmonary disease|history of medication for asthma																						
-Shortness of breath after exercise or physical activity		occurrence of exertional dyspnea																						
-Wake up at night because of difficulties in breathing/shortness of breath		occurrence of dyspnea																						
-NightWheezing		occurrence of wheezing																						
-Received HIV Test Result		Vukuzazi																						
-Had Positive HIV Result		diagnosis of HIV																						
-Currently On ART Treatment		history of medication for HIV																						
-Ever Defaulted ART treatment		history of medication for HIV																						
-Taking Concurrent Medication 1		medication	not sure if we can be more specific on these																					
-Taking Concurrent Medication 2		medication																						
-Taking Concurrent Medication 3		medication																						
-Taking Concurrent Medication 4		medication																						
-Adherence Concurrent Medication 2		medication																						
-Adherence Concurrent Medication 3		medication																						
-Adherence Concurrent Medication 4		medication																						
-Adherence Concurrent Medication 5		medication																						
-Stopped Concurrent Medication 1		medication																						
-Stopped Concurrent Medication 2		medication																						
-Stopped Concurrent Medication 3		medication																						
-Stopped Concurrent Medication 4		medication																						
-Stopped Concurrent Medication 5		medication																						
-Is Pregant		pregnancy history																						
-All Complete		Vukuzazi																						
-Chest X Ray Screening Result		X-ray imaging result																						
-Chest X Referal Basis		X-ray imaging result																						
-Chest X Ray Score		X-ray imaging result																						
-Sputum Referral		Vukuzazi																						
-Chest X Ray Medical Officer Conclusion		X-ray imaging result																						
-Chest X Ray Medical Officer Diagnostic Other		X-ray imaging result																						
-Chest X Ray Medical Officer Report		X-ray imaging result																						
-Chest X Ray Radiologist Diagnostic Other		X-ray imaging result																						
-Chest X Ray Radiologist Report		X-ray imaging result																						
-HIV Elisa Medical Officer Review		diagnosis of HIV																						
-CD4 Medical Officer Review		blood lymphocyte count value																						
-Viral Load Medical Officer Review		diagnosis of HIV																						
-GeneXpert Medical Officer Review		diagnosis of tuberculosis	TB test review																					
-Rifampicin Medical Officer Review		Vukuzazi	not a diagnosis necessarily?																					
-LiquidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
-SolidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
-HBA1CPercent Medical Officer Review		blood hemoglobin A1c level value																						
-Medical Officer CXR Interpretation		X-ray imaging result																						
-Medical Officer CXR Interpretation Description		X-ray imaging result																						
-Medical Officer Suggested Outcome		Vukuzazi																						
-Medical Officer Final Outcome		Vukuzazi																						
-Medical Officer Suggested Second Outcome		Vukuzazi																						
-Medical Officer Second Round Final Outcome		Vukuzazi																						
-Medical Officer Diabetes Message		diagnosis of diabetes																						
-Medical Officer HIV Message		diagnosis of HIV																						
-Medical Officer Chest X-Ray Message		X-ray imaging result																						
-Medical Officer Second Round Message		Vukuzazi																						
-System Algorythm Flaged Conditions		Vukuzazi																						
-Medical Officer Agreement with System Generated Message		Vukuzazi																						
-Medical Officer Outcome Description		Vukuzazi																						
-Medical Officer Suggested Second Condition		Vukuzazi																						
-Medical Officer Agreement with Second Outcome		Vukuzazi																						
-Medical Officer Outcome Description		Vukuzazi																						
-Medical Officer Conditions		Vukuzazi																						
-BP Referral from Follow up Visit		occurrence of high blood pressure																						
-Diabetes Referral from Follow up Visit		diagnosis of diabetes																						
-HIV Referral from Follow up Visit		diagnosis of HIV																						
-TB Referral from Follow up Visit		diagnosis of tuberculosis																						
-Homestead Induced TB Sputum Collected		sputum sample collected																						
-Homestead Spontatneous TB Sputum Collected		sputum sample collected																						
-Home TB Sputum Outcomeollected		sputum sample collected																						
-Follow Up Glucose		blood glucose level value																						
-Follow Up Glucose Result		blood glucose level value																						
-FUDiabetesDiagnosis		diagnosis of diabetes																						
-Follow Up Target Clinic/Hospital Date for Diabetes		diagnosis of diabetes																						
-Clinical Systolic Blood pressure reading		systolic blood pressure value																						
-Clinical Diastolic Blood pressure reading		diastolic blood pressure value																						
-FUBpDiagnosis		occurrence of high blood pressure																						
-Follow Up Target Clinic/Hospital for Blood Pressure		occurrence of high blood pressure																						
-Follow Up Target Clinic/Hospital Date		diagnosis of HIV																						
-SST1 Collected		Vukuzazi																						
-SST1 Not Collected Reason		Vukuzazi																						
-EDT1 Collected		Vukuzazi																						
-EDT1 Not Collected Reasonn		Vukuzazi																						
-EDT2 Collected		Vukuzazi																						
-EDT2 Not Collected Reasonn		Vukuzazi																						
-EDT3_1 Collected		Vukuzazi																						
-EDT3_1 Not Collected Reasonn		Vukuzazi																						
-EDT3_2 Collected		Vukuzazi																						
-EDT3_2 Not Collected Reasonn		Vukuzazi																						
-PAX1 Collected		Vukuzazi																						
-PAX1 Not Collected Reason		Vukuzazi																						
-Ssp1 Collected		sputum sample collected																						
-Spontaneous Sputum Obtained		sputum sample collected																						
-Spontaneous Sputum Not Obtained Reason		sputum sample collected																						
-Induced Sputum Obtained		sputum sample collected																						
-Induced Sputum Not Obtained Reason		sputum sample collected																						
-SSP Bottle Collected		sputum sample collected																						
-Induced Sputum Not Obtained Other Reason Explain		sputum sample collected																						
-Swab Sample1 Collected		saliva																						
-Swab Sample1 Not Collected Reason		saliva																						
-Swab Sample2 Collected		saliva																						
-Swab Sample2 Not Collected Reason		saliva																						
-Urine Sample Collected		urine																						
-Urine Sample Not Collected Reason		urine																						
-Urine Sample Collected		urine																						
-Urine Sample Not Collected Reason		urine																						
-pregnancy Test Result		pregnancy history																						
-pregnancy Test Result Notified		pregnancy history																						
-Failed to measure Blood Glucose at Home Follow Up visit		blood glucose level value	more about adherence?																					
-Failed to measure Blood Pressure at Home Follow Up visit		blood pressure measurement value	more about adherence?																					
-Failed to refer New HIV Positive case to Clinic at Home Follow Up visit		Vukuzazi																						
-CD4 quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-CD4 quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-HIV ELISA quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-HIV ELISA quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-VL quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-VL quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-Hb A1c quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-Hb A1c quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-Gene Xpert quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-Gene Xpert quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-MGIT culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-MGIT culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-Solid culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
-Solid culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
-Phone Call Attempts failed to contact Participant		Vukuzazi																						
-Home Visit Attempts failed to contact Participant		Vukuzazi																						
-Failed to refer Positive Sputum case to Clinic or Hospital		Vukuzazi																						
-Has the participant consented to be informed about their HIV results		Vukuzazi																						
-Participant Has Diagnosis Other than TB that requires referral to the clinic or hospital		diseases																						
-Cancer Type		clinical history of cancer																						
-Age Started Smoking Tobacco		tobacco																						
-Years Ago Individual Started Smoking		tobacco																						
-Months Ago Individual Started Smoking		tobacco																						
-Weeks Ago Individual Started Smoking		tobacco																						
-Manufactured Cigarettes Smoked Daily		tobacco																						
-Manufactured Cigarettes Smoked Weekly		tobacco																						
-Hand Rolled Cigarettes Smoked Daily		tobacco																						
-Hand Rolled Cigarettes Smoked Weekly		tobacco																						
-Piped Tobacco Cigarettes Smoked Daily		tobacco																						
-Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
-Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
-Cigars or Cheroots Daily		tobacco																						
-Cigars or Cheroots Smoked Weekly		tobacco																						
-Cigars or Cheroots Smoked Daily		tobacco																						
-Cigars or Cheroots Smoked Weekly		tobacco																						
-Other Tobacco Smoked Daily		tobacco																						
-Other Tobacco Smoked Weekly		tobacco																						
-Other Tobacco Specify Daily		tobacco																						
-Other Tobacco Specify Weekly		tobacco																						
-Alcohol Consumption Frequency		alcohol																						
-Occassions Consumed Alcohol		alcohol																						
-Drinks Consumed During Occassion		alcohol																						
-Drinks Per Occassion		alcohol																						
-Six Drinks Per Occassion or More Consumed		alcohol																						
-Last Week Monday Drinks		alcohol																						
-Last Week Tuesday Drinks		alcohol																						
-Last Week Wednesday Drinks		alcohol																						
-Last Week Thursday Drinks		alcohol																						
-Last Week Friday Drinks		alcohol																						
-Last Week Saturday Drinks		alcohol																						
-Last Week Sunday Drinks		alcohol																						
-Consumed Home Bred Alcohol		alcohol																						
-Number Home Bred Spirits		alcohol																						
-Number Home Bred Beer		alcohol																						
-Number Alcohol Imported		alcohol																						
-Number Alcohol Forbidden		alcohol																						
-Number of Alcohol Untaxed		alcohol																						
-Number of Times On TB Treatment		history of medication for tuberculosis																						
-TB Completion Date		history of medication for tuberculosis																						
-Cough Duration		occurrence of cough																						
-Cough Sputum		sputum sample collected																						
-Fever Duration		occurrence of fever																						
-Night Sweats Duration		occurrence of night sweats																						
-Weight Loss Number		occurrence of weight loss																						
-Date of First HIV Positive Result		diagnosis of HIV																						
-Date Of ART Initiation		history of medication for HIV																						
-Number of Times ART Defaulted		history of medication for HIV																						
-Date of Last HIV Negative Result		diagnosis of HIV																						
-Medication 1		medication																						
-Medication 2		medication																						
-Medication 3		medication																						
-Medication 4		medication																						
-Medication 5		medication																						
-Medication 6		medication																						
-Medication 7		medication																						
-Medication 8		medication																						
-Medication 1 Start Date		medication																						
-Medication 2 Start Date		medication																						
-Medication 3 Start Date		medication																						
-Medication 4 Start Date		medication																						
-Medication 5 Start Date		medication																						
-Medication 6 Start Date		medication																						
-Medication 7 Start Date		medication																						
-Medication 8 Start Date		medication																						
-Medication 9 Start Date		medication																						
-Concurrent Medication 1		medication																						
-Concurrent Medication 2		medication																						
-Concurrent Medication 3		medication																						
-Concurrent Medication 4		medication																						
-Concurrent Medication 5		medication																						
-Concurrent Medication Indication 1		medication																						
-Concurrent Medication Indication 2		medication																						
-Concurrent Medication Indication 3		medication																						
-Concurrent Medication Indication 4		medication																						
-Concurrent Medication Indication 5		medication																						
-Concurrent Medication 1 Start Date		medication																						
-Concurrent Medication 2 Start Date		medication																						
-Concurrent Medication 3 Start Date		medication																						
-Concurrent Medication 4 Start Date		medication																						
-Concurrent Medication 5 Start Date		medication																						
-Taking Concurrent Medication 5		medication																						
-Adherence Concurrent Medication 1		medication																						
-Time Last Meal		information about diet																						
-Date of Last Menstrual		menstrual cycle history																						
-Food Voucher Id		information about diet																						
-Food Pack Id		information about diet																						
-Not All Complete Reasons		Vukuzazi																						
-SST1		Vukuzazi																						
-EDT1		Vukuzazi																						
-EDT2		Vukuzazi																						
-EDT3_1		Vukuzazi																						
-EDT3_2		Vukuzazi																						
-PAX1		Vukuzazi																						
-Ssp1		sputum sample collected																						
-SSPBottle		sputum sample collected																						
-Swab Sample1 Collected Id		saliva																						
-Swab Sample2 Collected Id		saliva																						
-Urine Sample Collected Id		urine																						
-Urine Sample Collected Id		urine																						
-pregnancy Test Device Id		pregnancy history																						
-Chest X Ray Radiologist Conclusion		X-ray imaging result																						
-Medical Officer LungFields		Vukuzazi	is this part of X-ray?																					
-Radiologist LungFields		Vukuzazi	is this part of X-ray?																					
-Refused Urine Sample COllection		urine																						
-Height in Cm		height																						
-Weight in Kg		weight																						
-Waist Circumference in Cm		waist circumference value																						
-BP Cuff Size		Vukuzazi	administrative?																					
-BP First Systolic		systolic blood pressure value																						
-BP First Diastolic		diastolic blood pressure value																						
-BP Second Systolic		systolic blood pressure value																						
-BP Second Diastolic		diastolic blood pressure value																						
-BP Third Systolic		systolic blood pressure value																						
-BP Third Diastolic		diastolic blood pressure value																						
-BP Forth Systolic		systolic blood pressure value																						
-BP Forth Diastolic		diastolic blood pressure value																						
-BP Lowest Systolic		systolic blood pressure value																						
-BP Lowest Diastolic		diastolic blood pressure value																						
-Hip Circumference		hip circumference value																						
-Arm Circumference		arm circumference value																						
-Heart Rate First Reading		heart rate																						
-Heart Rate Second Reading		heart rate																						
-Heart RateThird Reading		heart rate																						
-Heart Rate Forth Reading		heart rate																						
-Pregnant		pregnancy history																						
-CXR proposed diagnostic-ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
-CXR proposed diagnostic-OldTB		X-ray imaging result|diagnosis of tuberculosis																						
-CXR proposed diagnostic-ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
-CXR proposed diagnostic-OtherInfection		X-ray imaging result|diagnosis of bacterial infection																						
-CXR proposed diagnostic-InflammatoryDisorder		X-ray imaging result|diagnosis of inflammatory disorder																						
-CXR proposed diagnostic-Neoplasm		X-ray imaging result	oncological?																					
-CXR proposed diagnostic-Trauma		X-ray imaging result																						
-CXR proposed diagnostic-CongenitalAbnormality		X-ray imaging result																						
-CXR proposed diagnostic-CardiacDisorder		X-ray imaging result|circulatory system																						
-CXR proposed diagnostic-VascularDisorder		X-ray imaging result|circulatory system																						
-CXR proposed diagnostic-DegenerativeDisorder		X-ray imaging result																						
-CXR pattern Left lung field & pleura		X-ray imaging result																						
-CXR pattern Right lung field & pleura		X-ray imaging result																						
-TB Diagnostic Other		diagnosis of tuberculosis																						
-Medical Officer Diagnostic TB Diagnostic Other		diagnosis of tuberculosis																						
-Radiologist Left Lung Normal		X-ray imaging result																						
-Radiologist Left Lung Consolidation		X-ray imaging result																						
-Radiologist Left Lung Cavitation		X-ray imaging result																						
-Radiologist Left Lung Nodules		X-ray imaging result																						
-Radiologist Left Lung Mass		X-ray imaging result																						
-Radiologist Left Lung ReticularOpacities		X-ray imaging result																						
-Radiologist Left Lung Fibrosis		X-ray imaging result																						
-Radiologist Left Lung Calcification		X-ray imaging result																						
-Radiologist Left Lung Pleural Thickening		X-ray imaging result																						
-Radiologist Left Lung PleuralEffusion		X-ray imaging result																						
-Radiologist Left Lung Node Enlargement		X-ray imaging result																						
-Radiologist Left Lung Other		X-ray imaging result																						
-Radiologist Right Lung Normal		X-ray imaging result																						
-Radiologist Right Lung Consolidation		X-ray imaging result																						
-Radiologist Right Lung Cavitation		X-ray imaging result																						
-Radiologist Right Lung Nodules		X-ray imaging result																						
-Radiologist Right Lung Mass		X-ray imaging result																						
-Radiologist Right Lung ReticularOpacities		X-ray imaging result																						
-Radiologist Right Lung Fibrosis		X-ray imaging result																						
-Radiologist Right Lung Calcification		X-ray imaging result																						
-Radiologist Right Lung Pleural Thickening		X-ray imaging result																						
-Radiologist Right Lung Pleural Effusion		X-ray imaging result																						
-Radiologist Right Lung Node Enlargement		X-ray imaging result																						
-Radiologist Right Lung Other		X-ray imaging result																						
-Willing Surveyed Attempt 1		Vukuzazi																						
-Radiologist Diagnostic ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
-Radiologist Diagnostic OldTB		X-ray imaging result|diagnosis of tuberculosis																						
-Radiologist Diagnostic ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
-Radiologist Diagnostic Other Infection		X-ray imaging result|diagnosis of bacterial infection																						
-Radiologist Diagnostic Inflammatory Disorder		X-ray imaging result|diagnosis of inflammatory disorder																						
-Radiologistr Diagnostic Neoplasm		X-ray imaging result	should this be oncological?																					
-Radiologist Diagnostic Trauma		X-ray imaging result																						
-Radiologist Diagnostic CongenitalAbnormality		X-ray imaging result																						
-Radiologist Diagnostic CardiacDisorder		X-ray imaging result|circulatory system																						
-Radiologist Diagnostic VascularDisorder		X-ray imaging result|circulatory system																						
-Radiologist Diagnostic Degenerative Disorder		X-ray imaging result																						
-Radiologist TB Diagnostic Other		X-ray imaging result|diagnosis of tuberculosis																						
-Lab Result Date		Vukuzazi																						
-Is Result Abnormal?		Vukuzazi																						
-Needs Clinical Review?		Vukuzazi																						
-CD4 Lymphocytes %		blood lymphocyte count value																						
-CD4 Lymphocytes Abs		blood lymphocyte count value																						
-CD4/CD8 Ratio		blood lymphocyte count value																						
-CD8 Lymphocytes %		blood lymphocyte count value																						
-CD8 Lymphocytes Abs		blood lymphocyte count value																						
-HBA1c		blood hemoglobin A1c level value																						
-HBA1C%		blood hemoglobin A1c level value																						
-Glucose Average (calculated)		blood glucose level value																						
-Rifampicin Resistance		Vukuzazi																						
-TB GeneXpert Test Result		Vukuzazi																						
-Liquid Culture Result(MGIT)		diagnosis of tuberculosis																						
-Solid Culture Result(7H11)		diagnosis of tuberculosis																						
-Solid Culture Incubation		diagnosis of tuberculosis																						
-HIV Elisa Result		diagnosis of HIV	or should this be blood test?																					
-HIV Viral Load Result		diagnosis of HIV	or should this be blood test?																					
-Medical Officer Left Lung Normal		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Consolidation		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Cavitation		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Nodules		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Mass		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Reticular Opacities		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Fibrosis		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung calcification		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
-Medical Officer Left Lung Other		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Normal		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Consolidation		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Cavitation		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Nodules		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Mass		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung ReticularOpacities		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Fibrosis		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Calcification		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
-Medical Officer Right Lung Other		Vukuzazi	are these from X-ray?																					
-Medical Officer Diagnostic ActiveTB		diagnosis of tuberculosis																						
-Medical Officer Diagnostic OldTB		diagnosis of tuberculosis																						
-Medical Officer Diagnostic ProbableTB		diagnosis of tuberculosis																						
-Medical Officer Diagnostic Other Infection		diagnosis of bacterial infection																						
-Medical Officer Diagnostic Inflammatory Disorder		diagnosis of inflammatory disorder																						
-Medical Officer Diagnostic Neoplasm		oncological 	may not be cancer though																					
-Medical Officer Diagnostic Trauma		Vukuzazi	where does trauma fall under?																					
-Medical Officer Diagnostic CongenitalAbnormality		Vukuzazi	where does cong abnormality fall under? diseases?																					
-Medical Officer Diagnostic CardiacDisorder		circulatory system																						
-Medical Officer Diagnostic VascularDisorder		circulatory system																						
+ID	Field Label	Class Type	GECKO Label	Comment																					
+ID		CLASS_TYPE	C % SPLIT=|																						
+VZ:BPMeasuredEver	BP Measured Ever		blood pressure	not quite right- this is asking if you've ever had itmeasured																					
+VZ:HighBPInformedEver	Ever Been Informed of High BP		occurrence of high blood pressure																						
+VZ:HighBPInformed12mo	Informed of High BP in 12 Months		occurrence of high blood pressure																						
+VZ:HighBPConsult6mo	High BP Consultation 6 months		occurrence of high blood pressure																						
+VZ:HighBPTx2wks	High BP Treatment in the Last 2 Weeks		history of medication for hypertension	should we differentiate between medication for hypertension & med for high BP?																					
+VZ:BPReferralExist	Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
+VZ:BPReferralExistReason	Reasons for Referral due to Existing High Blood Pressure		occurrence of high blood pressure																						
+VZ:BPReferralNonExist	Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
+VZ:BPReferralNonExistReason	Reasons for Referral due to Non Existing High Blood Pressure		occurrence of high blood pressure	or not?																					
+VZ:HighBPConsultHealer	High BP Consultation With Traditional Healer		occurrence of high blood pressure																						
+VZ:HighBPHerbalCurr	Currently Taking Herbal Treatment for Raised BP		history of non-pharmacological treatment for high blood pressure																						
+VZ:BSugarMeasuredEver	Blood Sugar Measured Ever		blood glucose level value	this is not quite right - this is asking if you've ever had it measured																					
+VZ:HighBSugarInformedEver	High Blood Sugar Informed Ever		occurrence of hyperglycemia																						
+VZ:HighBSugarInformed12mo	High Blood Sugar Informed Past 12 Months		occurrence of hyperglycemia																						
+VZ:HighBSugarConsult6mo	High Blood Sugar Consultation Past 6 months		occurrence of hyperglycemia																						
+VZ:HighBSugarTx2wks	High Blood Sugar Treatment Past 2 Weeks		history of medication for hyperglycemia																						
+VZ:InsulinTxCurr	Currently Taking Insulin for Diabetes		history of medication for diabetes																						
+VZ:HighBSugarConsultHealer	High Blood Sugar Consultation With Traditional Healer		occurrence of hyperglycemia																						
+VZ:CholestMeasuredEver	Cholesterol Measured Ever		blood total cholesterol level value	not quite right- this is asking if you've ever had itmeasured																					
+VZ:HighCholestInformedEver	High Cholesterol Informed Ever		occurrence of high cholesterol																						
+VZ:HighCholestInformed12mo	High Cholesterol Informed Past 12 Months		occurrence of high cholesterol																						
+VZ:HighCholestTx2wks	High Cholesterol Treatment Past 2 Weeks		history of medication for high cholesterol																						
+VZ:HighCholestConsultHealer	High Cholesterol Consultation With Traditional Healer		occurrence of high cholesterol																						
+VZ:HighCholestHerbalCurr	Currently Taking Herbal Treatment for Raised Cholesterol		history of non-pharmacological treatment for high cholesterol																						
+VZ:HeartAttackEver	Heart Attack Ever		occurrence of heart attack																						
+VZ:HeartAttackAspirinTxCurr	Currently Taking Aspirin Treatment		use of asprin																						
+VZ:HeartAttackStatinsTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Heart Disease		use of statins																						
+VZ:ParentHistHeartAttack	Parental History of Heart Attack		family clinical history																						
+VZ:HadStrokeEver	History of Stroke		occurrence of stroke																						
+VZ:StrokeAspirinTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Stroke		use of statins																						
+VZ:ParentHistStroke	Parental History of Stroke		family clinical history																						
+VZ:CancerTxEver	Cancer Treatment Before		Vukuzazi	is this non-pharmacological (potential surgery) or medication for cancer?																					
+VZ:CurrSmoker	Currently Smoking Tobacco		tobacco																						
+VZ:CurrSmokerDaily	Smoke Tobacco Products Daily		tobacco																						
+VZ:StopSmoking12mo	Quit Stopping Tobacco		tobacco																						
+VZ:EverSmoked	Ever Smoked Tobacco Products		tobacco																						
+VZ:EverSmokedDaily	Ever Smoked Tobacco Products Daily		tobacco																						
+VZ:EverConsumedAlcohol	Ever Consumed Alcohol		alcohol																						
+VZ:ConsumedAlcohol12mo	Consumed Alcohol Last 12 Months		alcohol																						
+VZ:StoppedAlcoholHealth	Stopped Alcohol for Health Reasons		alcohol																						
+VZ:ConsumedAlcohol30d	Consumed Alcohol Last 30 days		alcohol																						
+VZ:TBTxCurrent	TB Current Treatment		history of medication for tuberculosis																						
+VZ:ReceivedTBInjections	TB Current Treatment		history of medication for tuberculosis																						
+VZ:TBTxEver	Ever had TB Treatment		history of medication for tuberculosis																						
+VZ:HomesteadMemberTBEver	Homestead Member TB Ever		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
+VZ:HomesteadMemberTBCurr	Homestead (or residential plot) currently on TB treatment		diagnosis of tuberculosis	homestead? is this potentially family clinical history instead?																					
+VZ:CoughCurr	currently have a cough?		occurrence of cough																						
+VZ:FeverCurr	Have a fever currently		occurrence of fever																						
+VZ:NightSweatsCurr	Night Sweats		occurrence of night sweats																						
+VZ:WeightLoss6mo	Weight Loss in 6 months		occurrence of weight loss																						
+VZ:OtherSymptoms	Other TB Symptoms		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
+VZ:Fatigue	Fatigue		occurrence of fatigue																						
+VZ:Haemoptysis	Haemoptysis		occurrence of hemoptysis																						
+VZ:Chestpain	Chestpain		occurrence of chest pain																						
+VZ:Lymphadenitis	Lymphadenitis		occurrence of lymphadenitis																						
+VZ:TBSymptDur	Duration of the TB symptoms(weeks)		signs and symptoms	may be too broad but I don't know if it makes sense to make a 'TB symptoms' term																					
+VZ:HighAsthmaInformedEver	High Asthma InformededEver		diagnosis of asthma																						
+VZ:HighAsthmaInformed12mo	Been told of high Asthma		diagnosis of asthma																						
+VZ:HighhAsthmaTx2wks	Taken any medication for asthma/COPD prescribed by a doctor or other health worker		history of medication for chronic obstructive pulmonary disease|history of medication for asthma																						
+VZ:BreathShortness	Shortness of breath after exercise or physical activity		occurrence of exertional dyspnea																						
+VZ:WakeUpBreathShortness	Wake up at night because of difficulties in breathing/shortness of breath		occurrence of dyspnea																						
+VZ:NightWheezing	NightWheezing		occurrence of wheezing																						
+VZ:ReceivedHIVTestResult	Received HIV Test Result		Vukuzazi																						
+VZ:HadPosHIVResult	Had Positive HIV Result		diagnosis of HIV																						
+VZ:CurrentlyOnART	Currently On ART Treatment		history of medication for HIV																						
+VZ:ARTDefault	Ever Defaulted ART treatment		history of medication for HIV																						
+VZ:ConcurrMed1Curr	Taking Concurrent Medication 1		medication history	not sure if we can be more specific on these																					
+VZ:ConcurrMed2Curr	Taking Concurrent Medication 2		medication history																						
+VZ:ConcurrMed3Curr	Taking Concurrent Medication 3		medication history																						
+VZ:ConcurrMed4Curr	Taking Concurrent Medication 4		medication history																						
+VZ:ConcurrMed2Adher	Adherence Concurrent Medication 2		medication history																						
+VZ:ConcurrMed3Adher	Adherence Concurrent Medication 3		medication history																						
+VZ:ConcurrMed4Adher	Adherence Concurrent Medication 4		medication history																						
+VZ:ConcurrMed5Adher	Adherence Concurrent Medication 5		medication history																						
+VZ:ConcurrMed1Stopped	Stopped Concurrent Medication 1		medication history																						
+VZ:ConcurrMed2Stopped	Stopped Concurrent Medication 2		medication history																						
+VZ:ConcurrMed3Stopped	Stopped Concurrent Medication 3		medication history																						
+VZ:ConcurrMed4Stopped	Stopped Concurrent Medication 4		medication history																						
+VZ:ConcurrMed5Stopped	Stopped Concurrent Medication 5		medication history																						
+VZ:IsPregant	Is Pregant		pregnancy history																						
+VZ:AllComplete	All Complete		Vukuzazi																						
+VZ:CxrScreeningResult	Chest X Ray Screening Result		X-ray imaging result																						
+VZ:ReferalBasisCxr	Chest X Referal Basis		X-ray imaging result																						
+VZ:CXRScore	Chest X Ray Score		X-ray imaging result																						
+VZ:SputumReferral	Sputum Referral		Vukuzazi																						
+VZ:CxrMOConclusion	Chest X Ray Medical Officer Conclusion		X-ray imaging result																						
+VZ:CxrMODiagnosticOther	Chest X Ray Medical Officer Diagnostic Other		X-ray imaging result																						
+VZ:CxrMOReport	Chest X Ray Medical Officer Report		X-ray imaging result																						
+VZ:CxrRadiologistDiagnosticOther	Chest X Ray Radiologist Diagnostic Other		X-ray imaging result																						
+VZ:CxrRadiologistReport	Chest X Ray Radiologist Report		X-ray imaging result																						
+VZ:HIVElisaReview	HIV Elisa Medical Officer Review		diagnosis of HIV																						
+VZ:CD4Review	CD4 Medical Officer Review		blood lymphocyte count value																						
+VZ:VLReview	Viral Load Medical Officer Review		diagnosis of HIV																						
+VZ:GeneXpertReview	GeneXpert Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+VZ:RifampicinReview	Rifampicin Medical Officer Review		Vukuzazi	not a diagnosis necessarily?																					
+VZ:LiquidCultureReview	LiquidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+VZ:SolidCultureReview	SolidCulture Medical Officer Review		diagnosis of tuberculosis	TB test review																					
+VZ:HBA1CPercentReview	HBA1CPercent Medical Officer Review		blood hemoglobin A1c level value																						
+VZ:CXRInterpretation	Medical Officer CXR Interpretation		X-ray imaging result																						
+VZ:CXRInterpretationDesc	Medical Officer CXR Interpretation Description		X-ray imaging result																						
+VZ:MOSuggestedOutcome	Medical Officer Suggested Outcome		Vukuzazi																						
+VZ:MOFinalOutcome	Medical Officer Final Outcome		Vukuzazi																						
+VZ:MOSuggestedSecondRoundOutcome	Medical Officer Suggested Second Outcome		Vukuzazi																						
+VZ:MOSecondRoundOutcome	Medical Officer Second Round Final Outcome		Vukuzazi																						
+VZ:DiabetesMessage	Medical Officer Diabetes Message		diagnosis of diabetes																						
+VZ:HIVMessage	Medical Officer HIV Message		diagnosis of HIV																						
+VZ:CxrMessage	Medical Officer Chest X-Ray Message		X-ray imaging result																						
+VZ:SecondRoundMessage	Medical Officer Second Round Message		Vukuzazi																						
+VZ:MOSecondRoundMessage	System Algorythm Flaged Conditions		Vukuzazi																						
+VZ:MOAgreeSecondRoundMessage	Medical Officer Agreement with System Generated Message		Vukuzazi																						
+VZ:MOOutcomeDesc	Medical Officer Outcome Description		Vukuzazi																						
+VZ:MOSuggestedSecondCondition	Medical Officer Suggested Second Condition		Vukuzazi																						
+VZ:MOAgreeSecondRoundOutcome	Medical Officer Agreement with Second Outcome		Vukuzazi																						
+VZ:MOSecondRoundOutcomeDesc	Medical Officer Outcome Description		Vukuzazi																						
+VZ:MOConditions	Medical Officer Conditions		Vukuzazi																						
+VZ:BPReferallFU	BP Referral from Follow up Visit		occurrence of high blood pressure																						
+VZ:DiabetesReferallFU	Diabetes Referral from Follow up Visit		diagnosis of diabetes																						
+VZ:HIVReferallFU	HIV Referral from Follow up Visit		diagnosis of HIV																						
+VZ:TBReferallFU	TB Referral from Follow up Visit		diagnosis of tuberculosis																						
+VZ:InducedTBSputumHome	Homestead Induced TB Sputum Collected		sputum sample collected																						
+VZ:SpontTBSputumHome	Homestead Spontatneous TB Sputum Collected		sputum sample collected																						
+VZ:HomeTBSputumOutcome	Home TB Sputum Outcomeollected		sputum sample collected																						
+VZ:FUGlucose	Follow Up Glucose		blood glucose level value																						
+VZ:FUGlucoseResult	Follow Up Glucose Result		blood glucose level value																						
+VZ:FUDiabetesDiagnosis	FUDiabetesDiagnosis		diagnosis of diabetes																						
+VZ:FUDiabetesClinicDate	Follow Up Target Clinic/Hospital Date for Diabetes		diagnosis of diabetes																						
+VZ:FUSystolicBp	Clinical Systolic Blood pressure reading		systolic blood pressure value																						
+VZ:FUDiastolicBp	Clinical Diastolic Blood pressure reading		diastolic blood pressure value																						
+VZ:FUBpDiagnosis	FUBpDiagnosis		occurrence of high blood pressure																						
+VZ:FUTBpClinicDate	Follow Up Target Clinic/Hospital for Blood Pressure		occurrence of high blood pressure																						
+VZ:FUHIVStatusInformed	Follow Up Target Clinic/Hospital Date		diagnosis of HIV																						
+VZ:SST1Collected	SST1 Collected		Vukuzazi																						
+VZ:SST1NotCollectedReason	SST1 Not Collected Reason		Vukuzazi																						
+VZ:EDT1Collected	EDT1 Collected		Vukuzazi																						
+VZ:EDT1NotCollectedReason	EDT1 Not Collected Reasonn		Vukuzazi																						
+VZ:EDT2Collected	EDT2 Collected		Vukuzazi																						
+VZ:EDT2NotCollectedReason	EDT2 Not Collected Reasonn		Vukuzazi																						
+VZ:EDT3_1Collected	EDT3_1 Collected		Vukuzazi																						
+VZ:EDT3_1NotCollectedReason	EDT3_1 Not Collected Reasonn		Vukuzazi																						
+VZ:EDT3_2Collected	EDT3_2 Collected		Vukuzazi																						
+VZ:EDT3_2NotCollectedReason	EDT3_2 Not Collected Reasonn		Vukuzazi																						
+VZ:PAX1Collected	PAX1 Collected		Vukuzazi																						
+VZ:PAX1NotCollectedReason	PAX1 Not Collected Reason		Vukuzazi																						
+VZ:Ssp1Collected	Ssp1 Collected		sputum sample collected																						
+VZ:SpontaneousSputumObtained	Spontaneous Sputum Obtained		sputum sample collected																						
+VZ:SpontaneousSputumNotObtainedReason	Spontaneous Sputum Not Obtained Reason		sputum sample collected																						
+VZ:InducedSputumObtained	Induced Sputum Obtained		sputum sample collected																						
+VZ:InducedSputumNotObtainedReason	Induced Sputum Not Obtained Reason		sputum sample collected																						
+VZ:SSPBottleCollected	SSP Bottle Collected		sputum sample collected																						
+VZ:InducedSputumNotObtainedOtherReasonExplain	Induced Sputum Not Obtained Other Reason Explain		sputum sample collected																						
+VZ:SwabSample1Collected	Swab Sample1 Collected		saliva																						
+VZ:SwabSample1NotCollectedReason	Swab Sample1 Not Collected Reason		saliva																						
+VZ:SwabSample2Collected	Swab Sample2 Collected		saliva																						
+VZ:SwabSample2NotCollectedReason	Swab Sample2 Not Collected Reason		saliva																						
+VZ:UrineSampleCollected	Urine Sample Collected		urine																						
+VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason		urine																						
+VZ:UrineSampleCollected	Urine Sample Collected		urine																						
+VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason		urine																						
+VZ:PregTestResult	pregnancy Test Result		pregnancy history																						
+VZ:PregTestResultNotified	pregnancy Test Result Notified		pregnancy history																						
+VZ:BloodGlucoseFailFU	Failed to measure Blood Glucose at Home Follow Up visit		blood glucose level value	more about adherence?																					
+VZ:BPFailFU	Failed to measure Blood Pressure at Home Follow Up visit		blood pressure measurement value	more about adherence?																					
+VZ:NewHIVReferralFailFU	Failed to refer New HIV Positive case to Clinic at Home Follow Up visit		Vukuzazi																						
+VZ:CD4LabStatus	CD4 quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:CD4LabComment	CD4 quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:HIVELisaLabStatus	HIV ELISA quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:HIVELisaLabComment	HIV ELISA quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:VLLabStatus	VL quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:VLLabComment	VL quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:HbA1LabStatus	Hb A1c quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:HbA1LabComment	Hb A1c quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:GeneXpertLabStatus	Gene Xpert quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:GeneXpertLabComment	Gene Xpert quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:MGITCultureLabStatus	MGIT culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:MGITCultureLabComment	MGIT culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:SolidCultureLabStatus	Solid culture quantity not sufficient, specimen missing, or unable to run		Vukuzazi																						
+VZ:SolidCultureLabComment	Solid culture quantity not sufficient, specimen missing, or unable to run comment		Vukuzazi																						
+VZ:PhoneCallFail	Phone Call Attempts failed to contact Participant		Vukuzazi																						
+VZ:HomeVisitFail	Home Visit Attempts failed to contact Participant		Vukuzazi																						
+VZ:SputumPosRefFail	Failed to refer Positive Sputum case to Clinic or Hospital		Vukuzazi																						
+VZ:ConsentInformedHIV	Has the participant consented to be informed about their HIV results		Vukuzazi																						
+VZ:FUCXROtherReferral	Participant Has Diagnosis Other than TB that requires referral to the clinic or hospital		diseases																						
+VZ:CancerType	Cancer Type		clinical history of cancer																						
+VZ:AgeStartedSmoking	Age Started Smoking Tobacco		tobacco																						
+VZ:YearsAgoStartedSmoking	Years Ago Individual Started Smoking		tobacco																						
+VZ:MonthsAgoStartedSmoking	Months Ago Individual Started Smoking		tobacco																						
+VZ:WeeksAgoStartedSmoking	Weeks Ago Individual Started Smoking		tobacco																						
+VZ:ManufacturedCigarettesDaily	Manufactured Cigarettes Smoked Daily		tobacco																						
+VZ:ManufacturedCigarettesWeekly	Manufactured Cigarettes Smoked Weekly		tobacco																						
+VZ:HandRolledCigarettesDaily	Hand Rolled Cigarettes Smoked Daily		tobacco																						
+VZ:HandRolledCigarettesWeekly	Hand Rolled Cigarettes Smoked Weekly		tobacco																						
+VZ:PipedTobaccoDaily	Piped Tobacco Cigarettes Smoked Daily		tobacco																						
+VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+VZ:CigarsRcherootsDaily	Cigars or Cheroots Daily		tobacco																						
+VZ:CigarsORcherootsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
+VZ:ShishaSessionsDaily	Cigars or Cheroots Smoked Daily		tobacco																						
+VZ:ShishaSessionsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
+VZ:OtherTobaccoSpecifyDaily	Other Tobacco Smoked Daily		tobacco																						
+VZ:OtherTobaccoWeekly	Other Tobacco Smoked Weekly		tobacco																						
+VZ:OtherTobaccoSpecifyDailySpec	Other Tobacco Specify Daily		tobacco																						
+VZ:OtherTobaccoWeeklySpec	Other Tobacco Specify Weekly		tobacco																						
+VZ:ConsumptionFrequency	Alcohol Consumption Frequency		alcohol																						
+VZ:ConsumedAlcoholOccassions	Occassions Consumed Alcohol		alcohol																						
+VZ:DrinksConsumedOccassions	Drinks Consumed During Occassion		alcohol																						
+VZ:DrinksPerOccassion	Drinks Per Occassion		alcohol																						
+VZ:SixDrinksPerOccassion	Six Drinks Per Occassion or More Consumed		alcohol																						
+VZ:LastWeekMondayDrinks	Last Week Monday Drinks		alcohol																						
+VZ:LastWeekTuesdayDrinks	Last Week Tuesday Drinks		alcohol																						
+VZ:LastWeekWednesdayDrinks	Last Week Wednesday Drinks		alcohol																						
+VZ:LastWeekThursdayDrinks	Last Week Thursday Drinks		alcohol																						
+VZ:LastWeekFridayDrinks	Last Week Friday Drinks		alcohol																						
+VZ:LastWeekSaturdayDrinks	Last Week Saturday Drinks		alcohol																						
+VZ:LastWeekSundayDrinks	Last Week Sunday Drinks		alcohol																						
+VZ:ConsumedHomeBredAlcohol	Consumed Home Bred Alcohol		alcohol																						
+VZ:NumberHomeBredSpirits	Number Home Bred Spirits		alcohol																						
+VZ:NumberHomeBredBeer	Number Home Bred Beer		alcohol																						
+VZ:NumberAlcoholImported	Number Alcohol Imported		alcohol																						
+VZ:NumberAlcoholForbidden	Number Alcohol Forbidden		alcohol																						
+VZ:NumberAlcoholUntaxed	Number of Alcohol Untaxed		alcohol																						
+VZ:NumberTBTxEver	Number of Times On TB Treatment		history of medication for tuberculosis																						
+VZ:LastTBDateCompletion	TB Completion Date		history of medication for tuberculosis																						
+VZ:CoughDuration	Cough Duration		occurrence of cough																						
+VZ:CoughSputum	Cough Sputum		sputum sample collected																						
+VZ:FeverDuration	Fever Duration		occurrence of fever																						
+VZ:NightSweatsDuration	Night Sweats Duration		occurrence of night sweats																						
+VZ:WeightLossNumber	Weight Loss Number		occurrence of weight loss																						
+VZ:HIVPosResult1stDate	Date of First HIV Positive Result		diagnosis of HIV																						
+VZ:ARTInitiationDate	Date Of ART Initiation		history of medication for HIV																						
+VZ:ARTDefaultTimes	Number of Times ART Defaulted		history of medication for HIV																						
+VZ:LastHIVNegResultDate	Date of Last HIV Negative Result		diagnosis of HIV																						
+VZ:Medication1	Medication 1		medication history																						
+VZ:Medication2	Medication 2		medication history																						
+VZ:Medication3	Medication 3		medication history																						
+VZ:Medication4	Medication 4		medication history																						
+VZ:Medication5	Medication 5		medication history																						
+VZ:Medication6	Medication 6		medication history																						
+VZ:Medication7	Medication 7		medication history																						
+VZ:Medication8	Medication 8		medication history																						
+VZ:Medication1StartDate	Medication 1 Start Date		medication history																						
+VZ:Medication2StartDate	Medication 2 Start Date		medication history																						
+VZ:Medication3StartDate	Medication 3 Start Date		medication history																						
+VZ:Medication4StartDate	Medication 4 Start Date		medication history																						
+VZ:Medication5StartDate	Medication 5 Start Date		medication history																						
+VZ:Medication6StartDate	Medication 6 Start Date		medication history																						
+VZ:Medication7StartDate	Medication 7 Start Date		medication history																						
+VZ:Medication8StartDate	Medication 8 Start Date		medication history																						
+VZ:Medication9StartDate	Medication 9 Start Date		medication history																						
+VZ:ConcurrMed1	Concurrent Medication 1		medication history																						
+VZ:ConcurrMed2	Concurrent Medication 2		medication history																						
+VZ:ConcurrMed3	Concurrent Medication 3		medication history																						
+VZ:ConcurrMed4	Concurrent Medication 4		medication history																						
+VZ:ConcurrMed5	Concurrent Medication 5		medication history																						
+VZ:ConcurrMedIndica1	Concurrent Medication Indication 1		medication history																						
+VZ:ConcurrMedIndica2	Concurrent Medication Indication 2		medication history																						
+VZ:ConcurrMedIndica3	Concurrent Medication Indication 3		medication history																						
+VZ:ConcurrMedIndica4	Concurrent Medication Indication 4		medication history																						
+VZ:ConcurrMedIndica5	Concurrent Medication Indication 5		medication history																						
+VZ:ConcurrMed1StartDate	Concurrent Medication 1 Start Date		medication history																						
+VZ:ConcurrMed2StartDate	Concurrent Medication 2 Start Date		medication history																						
+VZ:ConcurrMed3StartDate	Concurrent Medication 3 Start Date		medication history																						
+VZ:ConcurrMed4StartDate	Concurrent Medication 4 Start Date		medication history																						
+VZ:ConcurrMed5StartDate	Concurrent Medication 5 Start Date		medication history																						
+VZ:ConcurrMed5Curr	Taking Concurrent Medication 5		medication history																						
+VZ:ConcurrMed1Adher	Adherence Concurrent Medication 1		medication history																						
+VZ:TimeLastMeal	Time Last Meal		information about diet																						
+VZ:LastMenstrualDate	Date of Last Menstrual		menstrual cycle history																						
+VZ:FoodVoucherId	Food Voucher Id		information about diet																						
+VZ:FoodPackId	Food Pack Id		information about diet																						
+VZ:NotAllCompleteReaons	Not All Complete Reasons		Vukuzazi																						
+VZ:SST1	SST1		Vukuzazi																						
+VZ:EDT1	EDT1		Vukuzazi																						
+VZ:EDT2	EDT2		Vukuzazi																						
+VZ:EDT3_1	EDT3_1		Vukuzazi																						
+VZ:EDT3_2	EDT3_2		Vukuzazi																						
+VZ:PAX1	PAX1		Vukuzazi																						
+VZ:Ssp1	Ssp1		sputum sample collected																						
+VZ:SSPBottle	SSPBottle		sputum sample collected																						
+VZ:SwabSample1CollectedId	Swab Sample1 Collected Id		saliva																						
+VZ:SwabSample2CollectedId	Swab Sample2 Collected Id		saliva																						
+VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
+VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
+VZ:PregTestDeviceId	pregnancy Test Device Id		pregnancy history																						
+VZ:CxrRadiologistConclusion	Chest X Ray Radiologist Conclusion		X-ray imaging result																						
+VZ:MOLungField	Medical Officer LungFields		Vukuzazi	is this part of X-ray?																					
+VZ:RadiologistLungField	Radiologist LungFields		Vukuzazi	is this part of X-ray?																					
+VZ:UrineRefusal	Refused Urine Sample COllection		urine																						
+VZ:HeightCm	Height in Cm		height																						
+VZ:WeightKg	Weight in Kg		weight																						
+VZ:WaistCircumferenceCm	Waist Circumference in Cm		waist circumference value																						
+VZ:BPCuffSize	BP Cuff Size		Vukuzazi	administrative?																					
+VZ:BPFirstSystolic	BP First Systolic		systolic blood pressure value																						
+VZ:BPFirstDiastolic	BP First Diastolic		diastolic blood pressure value																						
+VZ:BPSecondSystolic	BP Second Systolic		systolic blood pressure value																						
+VZ:BPSecondDiastolic	BP Second Diastolic		diastolic blood pressure value																						
+VZ:BPThirdSystolic	BP Third Systolic		systolic blood pressure value																						
+VZ:BPThirdDiastolic	BP Third Diastolic		diastolic blood pressure value																						
+VZ:BPForthSystolic	BP Forth Systolic		systolic blood pressure value																						
+VZ:BPForthDiastolic	BP Forth Diastolic		diastolic blood pressure value																						
+VZ:LowestBpSystolic	BP Lowest Systolic		systolic blood pressure value																						
+VZ:LowestBpDiastolic	BP Lowest Diastolic		diastolic blood pressure value																						
+VZ:HipCircumference	Hip Circumference		hip circumference value																						
+VZ:ArmCircumference	Arm Circumference		arm circumference value																						
+VZ:HeartRateFirstReading	Heart Rate First Reading		heart rate																						
+VZ:HeartRateSecondReading	Heart Rate Second Reading		heart rate																						
+VZ:HeartRateThirdReading	Heart RateThird Reading		heart rate																						
+VZ:HeartRateForthReading	Heart Rate Forth Reading		heart rate																						
+VZ:Pregnant	Pregnant		pregnancy history																						
+VZ:ActiveTB	CXR proposed diagnostic-ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:OldTB	CXR proposed diagnostic-OldTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:ProbableTB	CXR proposed diagnostic-ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:OtherInfection	CXR proposed diagnostic-OtherInfection		X-ray imaging result|diagnosis of bacterial infection																						
+VZ:InflammatoryDisorder	CXR proposed diagnostic-InflammatoryDisorder		X-ray imaging result|diagnosis of inflammatory disorder																						
+VZ:Neoplasm	CXR proposed diagnostic-Neoplasm		X-ray imaging result	oncological?																					
+VZ:Trauma	CXR proposed diagnostic-Trauma		X-ray imaging result																						
+VZ:CongenitalAbnormality	CXR proposed diagnostic-CongenitalAbnormality		X-ray imaging result																						
+VZ:CardiacDisorder	CXR proposed diagnostic-CardiacDisorder		X-ray imaging result|circulatory system																						
+VZ:VascularDisorder	CXR proposed diagnostic-VascularDisorder		X-ray imaging result|circulatory system																						
+VZ:DegenerativeDisorder	CXR proposed diagnostic-DegenerativeDisorder		X-ray imaging result																						
+VZ:LeftLung	CXR pattern Left lung field & pleura		X-ray imaging result																						
+VZ:RightLung	CXR pattern Right lung field & pleura		X-ray imaging result																						
+VZ:TBDiagnosticOther	TB Diagnostic Other		diagnosis of tuberculosis																						
+VZ:MOTBDiagnosticOther	Medical Officer Diagnostic TB Diagnostic Other		diagnosis of tuberculosis																						
+VZ:RadLeftLungNormal	Radiologist Left Lung Normal		X-ray imaging result																						
+VZ:RadLeftLungConsolid	Radiologist Left Lung Consolidation		X-ray imaging result																						
+VZ:RadLeftLungCavitation	Radiologist Left Lung Cavitation		X-ray imaging result																						
+VZ:RadLeftLungNodules	Radiologist Left Lung Nodules		X-ray imaging result																						
+VZ:RadLeftLungMass	Radiologist Left Lung Mass		X-ray imaging result																						
+VZ:RadLeftLungReticular	Radiologist Left Lung ReticularOpacities		X-ray imaging result																						
+VZ:RadLeftLungFibrosis	Radiologist Left Lung Fibrosis		X-ray imaging result																						
+VZ:RadLeftLungCalcification	Radiologist Left Lung Calcification		X-ray imaging result																						
+VZ:RadLeftLungPleuralThick	Radiologist Left Lung Pleural Thickening		X-ray imaging result																						
+VZ:RadLeftLungPleuralEffusion	Radiologist Left Lung PleuralEffusion		X-ray imaging result																						
+VZ:RadLeftLungNodeEnlarge	Radiologist Left Lung Node Enlargement		X-ray imaging result																						
+VZ:RadLeftLungOther	Radiologist Left Lung Other		X-ray imaging result																						
+VZ:RadRightLungNormal	Radiologist Right Lung Normal		X-ray imaging result																						
+VZ:RadRightLungConsolid	Radiologist Right Lung Consolidation		X-ray imaging result																						
+VZ:RadRightLungCavitation	Radiologist Right Lung Cavitation		X-ray imaging result																						
+VZ:RadRightLungNodules	Radiologist Right Lung Nodules		X-ray imaging result																						
+VZ:RadRightLungMass	Radiologist Right Lung Mass		X-ray imaging result																						
+VZ:RadRightLungReticular	Radiologist Right Lung ReticularOpacities		X-ray imaging result																						
+VZ:RadRightLungFibrosis	Radiologist Right Lung Fibrosis		X-ray imaging result																						
+VZ:RadRightLungCalcification	Radiologist Right Lung Calcification		X-ray imaging result																						
+VZ:RadRightLungPleuralThick	Radiologist Right Lung Pleural Thickening		X-ray imaging result																						
+VZ:RadRightLungPleuralEffusion	Radiologist Right Lung Pleural Effusion		X-ray imaging result																						
+VZ:RadRightLungNodeEnlarge	Radiologist Right Lung Node Enlargement		X-ray imaging result																						
+VZ:RadRightLungOther	Radiologist Right Lung Other		X-ray imaging result																						
+VZ:WillingSurveyedAttempt1	Willing Surveyed Attempt 1		Vukuzazi																						
+VZ:RadActiveTB	Radiologist Diagnostic ActiveTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:RadOldTB	Radiologist Diagnostic OldTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:RadProbableTB	Radiologist Diagnostic ProbableTB		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:RadOtherInfection	Radiologist Diagnostic Other Infection		X-ray imaging result|diagnosis of bacterial infection																						
+VZ:RadInflammatoryDisorder	Radiologist Diagnostic Inflammatory Disorder		X-ray imaging result|diagnosis of inflammatory disorder																						
+VZ:RadNeoplasm	Radiologistr Diagnostic Neoplasm		X-ray imaging result	should this be oncological?																					
+VZ:RadTrauma	Radiologist Diagnostic Trauma		X-ray imaging result																						
+VZ:RadCongenitalAbnormality	Radiologist Diagnostic CongenitalAbnormality		X-ray imaging result																						
+VZ:RadCardiacDisorder	Radiologist Diagnostic CardiacDisorder		X-ray imaging result|circulatory system																						
+VZ:RadVascularDisorder	Radiologist Diagnostic VascularDisorder		X-ray imaging result|circulatory system																						
+VZ:RadDegenerativeDisorder	Radiologist Diagnostic Degenerative Disorder		X-ray imaging result																						
+VZ:RadTBDiagnosticOther	Radiologist TB Diagnostic Other		X-ray imaging result|diagnosis of tuberculosis																						
+VZ:LabResultDate	Lab Result Date		Vukuzazi																						
+VZ:AbnormalResult	Is Result Abnormal?		Vukuzazi																						
+VZ:ClinicalReview	Needs Clinical Review?		Vukuzazi																						
+VZ:CD4LymphPercent	CD4 Lymphocytes %		blood lymphocyte count value																						
+VZ:CD4LymphAb	CD4 Lymphocytes Abs		blood lymphocyte count value																						
+VZ:CD4CD8Ratio	CD4/CD8 Ratio		blood lymphocyte count value																						
+VZ:CD8LymphPercent	CD8 Lymphocytes %		blood lymphocyte count value																						
+VZ:CD8LymphAb	CD8 Lymphocytes Abs		blood lymphocyte count value																						
+VZ:HBA1c	HBA1c		blood hemoglobin A1c level value																						
+VZ:HBA1CPercent	HBA1C%		blood hemoglobin A1c level value																						
+VZ:Glucose	Glucose Average (calculated)		blood glucose level value																						
+VZ:Rifampicin	Rifampicin Resistance		Vukuzazi																						
+VZ:GeneXpert	TB GeneXpert Test Result		Vukuzazi																						
+VZ:LiquidCulture	Liquid Culture Result(MGIT)		diagnosis of tuberculosis																						
+VZ:SolidCulture	Solid Culture Result(7H11)		diagnosis of tuberculosis																						
+VZ:SolidIncub	Solid Culture Incubation		diagnosis of tuberculosis																						
+VZ:HIVElisa	HIV Elisa Result		diagnosis of HIV	or should this be blood test?																					
+VZ:VL	HIV Viral Load Result		diagnosis of HIV	or should this be blood test?																					
+VZ:MOLeftLungNormal	Medical Officer Left Lung Normal		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungConsolid	Medical Officer Left Lung Consolidation		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungCavitation	Medical Officer Left Lung Cavitation		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungNodules	Medical Officer Left Lung Nodules		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungMass	Medical Officer Left Lung Mass		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungReticular	Medical Officer Left Lung Reticular Opacities		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungFibrosis	Medical Officer Left Lung Fibrosis		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungCalcification	Medical Officer Left Lung calcification		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungPleuralThick	Medical Officer Left Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungPleuralEffusion	Medical Officer Left Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungNodeEnlarge	Medical Officer Left Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
+VZ:MOLeftLungOther	Medical Officer Left Lung Other		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungNormal	Medical Officer Right Lung Normal		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungConsolid	Medical Officer Right Lung Consolidation		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungCavitation	Medical Officer Right Lung Cavitation		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungNodules	Medical Officer Right Lung Nodules		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungMass	Medical Officer Right Lung Mass		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungReticular	Medical Officer Right Lung ReticularOpacities		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungFibrosis	Medical Officer Right Lung Fibrosis		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungCalcification	Medical Officer Right Lung Calcification		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungPleuralThick	Medical Officer Right Lung Pleural Thickening		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungPleuralEffusion	Medical Officer Right Lung Pleural Effusion		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungNodeEnlarge	Medical Officer Right Lung Node Enlargement		Vukuzazi	are these from X-ray?																					
+VZ:MORightLungOther	Medical Officer Right Lung Other		Vukuzazi	are these from X-ray?																					
+VZ:MOActiveTB	Medical Officer Diagnostic ActiveTB		diagnosis of tuberculosis																						
+VZ:MOOldTB	Medical Officer Diagnostic OldTB		diagnosis of tuberculosis																						
+VZ:MOProbableTB	Medical Officer Diagnostic ProbableTB		diagnosis of tuberculosis																						
+VZ:MOOtherInfection	Medical Officer Diagnostic Other Infection		diagnosis of bacterial infection																						
+VZ:MOInflammatoryDisorder	Medical Officer Diagnostic Inflammatory Disorder		diagnosis of inflammatory disorder																						
+VZ:MONeoplasm	Medical Officer Diagnostic Neoplasm		oncological 	may not be cancer though																					
+VZ:MOTrauma	Medical Officer Diagnostic Trauma		Vukuzazi	where does trauma fall under?																					
+VZ:MOCongenitalAbnormality	Medical Officer Diagnostic CongenitalAbnormality		Vukuzazi	where does cong abnormality fall under? diseases?																					
+VZ:MOCardiacDisorder	Medical Officer Diagnostic CardiacDisorder		circulatory system																						
+VZ:MOVascularDisorder	Medical Officer Diagnostic VascularDisorder		circulatory system																						

--- a/src/create_xref_template.py
+++ b/src/create_xref_template.py
@@ -17,41 +17,48 @@ def main():
     xref_template = args.xref_template
 
     # make a map of index label to ID
-    reader = csv.reader(mapping_index, delimiter='\t')
-    next(reader)
-    next(reader)
     label_to_id = {}
+    reader = csv.reader(mapping_index, delimiter='\t')
+    # Skip header and template rows
+    next(reader)
+    next(reader)
     for row in reader:
         if not row:
+            # Row is empty
             continue
+        # Get the GECKO CURIE
         gecko_id = row[0].strip()
         if gecko_id == '':
+            # No curie, skip row
             continue
-        alt_label = row[1].strip()
+        # Get the label
         gecko_label = row[2].strip()
         if gecko_label == '':
+            # No label, skip row
             continue
         if gecko_label in label_to_id:
-            print('WARNING: label "{0}" already exists with as {1}'.format(
+            print('ERROR: label "{0}" already exists with as {1}'.format(
                 gecko_label, label_to_id[gecko_label]))
             continue
-        if alt_label != '' and alt_label not in label_to_id:
-            label_to_id[alt_label] = gecko_id
+        # Add to map
         label_to_id[gecko_label] = gecko_id
     mapping_index.close()
 
+    # Create the Xref template headers
     writer = csv.writer(xref_template, delimiter='\t')
-    writer.writerow(['Label', 'Xref'])
-    writer.writerow(['LABEL', 'AI database_cross_reference SPLIT=|'])
+    writer.writerow(['ID', 'Xref', 'Xref Label'])
+    writer.writerow(['ID', 'AI database_cross_reference', '>A label'])
+
+    # Read in the mapping template to get Xrefs
     reader = csv.reader(mapping_template, delimiter='\t')
     next(reader)
     next(reader)
     for row in reader:
-        label = row[0].strip()
-        gecko_labels = row[2].strip()
+        curie = row[0].strip()
+        gecko_labels = row[3].strip()
         if gecko_labels == '':
             continue
-        iris = []
+        iris_labels = {}
         for gl in gecko_labels.split('|'):
             if gl == '':
                 continue
@@ -60,8 +67,10 @@ def main():
             if gl.strip() not in label_to_id:
                 print('ERROR: "{0}" not in index!'.format(gl))
                 continue
-            iris.append(label_to_id[gl.strip()].replace('GECKO:', 'http://example.com/GECKO_'))
-        writer.writerow([label, '|'.join(iris)])
+            iri = label_to_id[gl.strip()].replace('GECKO:', 'http://example.com/GECKO_')
+            iris_labels[iri] = gl.strip()
+        for i, l in iris_labels.items():
+            writer.writerow([curie, i, l])
 
 
 if __name__ == '__main__':

--- a/src/create_xref_template.py
+++ b/src/create_xref_template.py
@@ -1,0 +1,68 @@
+import csv
+
+from argparse import ArgumentParser, FileType
+
+ignore = ['koges', 'gcs', 'vukuzazi', 'saprin', 'genomics england']
+
+
+def main():
+    p = ArgumentParser()
+    p.add_argument('mapping_template', type=FileType('r'))
+    p.add_argument('mapping_index', type=FileType('r'))
+    p.add_argument('xref_template', type=FileType('w'))
+    args = p.parse_args()
+
+    mapping_template = args.mapping_template
+    mapping_index = args.mapping_index
+    xref_template = args.xref_template
+
+    # make a map of index label to ID
+    reader = csv.reader(mapping_index, delimiter='\t')
+    next(reader)
+    next(reader)
+    label_to_id = {}
+    for row in reader:
+        if not row:
+            continue
+        gecko_id = row[0].strip()
+        if gecko_id == '':
+            continue
+        alt_label = row[1].strip()
+        gecko_label = row[2].strip()
+        if gecko_label == '':
+            continue
+        if gecko_label in label_to_id:
+            print('WARNING: label "{0}" already exists with as {1}'.format(
+                gecko_label, label_to_id[gecko_label]))
+            continue
+        if alt_label != '' and alt_label not in label_to_id:
+            label_to_id[alt_label] = gecko_id
+        label_to_id[gecko_label] = gecko_id
+    mapping_index.close()
+
+    writer = csv.writer(xref_template, delimiter='\t')
+    writer.writerow(['Label', 'Xref'])
+    writer.writerow(['LABEL', 'AI database_cross_reference SPLIT=|'])
+    reader = csv.reader(mapping_template, delimiter='\t')
+    next(reader)
+    next(reader)
+    for row in reader:
+        label = row[0].strip()
+        gecko_labels = row[2].strip()
+        if gecko_labels == '':
+            continue
+        iris = []
+        for gl in gecko_labels.split('|'):
+            if gl == '':
+                continue
+            if gl.lower() in ignore:
+                continue
+            if gl.strip() not in label_to_id:
+                print('ERROR: "{0}" not in index!'.format(gl))
+                continue
+            iris.append(label_to_id[gl.strip()].replace('GECKO:', 'http://example.com/GECKO_'))
+        writer.writerow([label, '|'.join(iris)])
+
+
+if __name__ == '__main__':
+    main()

--- a/src/create_xref_template.py
+++ b/src/create_xref_template.py
@@ -2,7 +2,7 @@ import csv
 
 from argparse import ArgumentParser, FileType
 
-ignore = ['koges', 'gcs', 'vukuzazi', 'saprin', 'genomics england']
+ignore = ['koges', 'gcs', 'vukuzazi', 'saprin', 'genomics england', 'maelstrom']
 
 
 def main():
@@ -54,11 +54,18 @@ def main():
     next(reader)
     next(reader)
     for row in reader:
+        if len(row) < 3:
+            # No GECKO mapping
+            continue
+
+        # Get the CURIE for the subject
         curie = row[0].strip()
+        # And the GECKO label (maybe more than one)
         gecko_labels = row[3].strip()
         if gecko_labels == '':
             continue
         iris_labels = {}
+        # Split on pipe and get CURIEs based on label
         for gl in gecko_labels.split('|'):
             if gl == '':
                 continue

--- a/src/create_xref_template.py
+++ b/src/create_xref_template.py
@@ -47,7 +47,7 @@ def main():
     # Create the Xref template headers
     writer = csv.writer(xref_template, delimiter='\t')
     writer.writerow(['ID', 'Xref', 'Xref Label'])
-    writer.writerow(['ID', 'AI database_cross_reference', '>A label'])
+    writer.writerow(['ID', 'A database_cross_reference', '>A label'])
 
     # Read in the mapping template to get Xrefs
     reader = csv.reader(mapping_template, delimiter='\t')
@@ -74,7 +74,7 @@ def main():
             if gl.strip() not in label_to_id:
                 print('ERROR: "{0}" not in index!'.format(gl))
                 continue
-            iri = label_to_id[gl.strip()].replace('GECKO:', 'http://example.com/GECKO_')
+            iri = label_to_id[gl.strip()]
             iris_labels[iri] = gl.strip()
         for i, l in iris_labels.items():
             writer.writerow([curie, i, l])

--- a/src/properties.tsv
+++ b/src/properties.tsv
@@ -11,3 +11,4 @@ IHCC:use-cases-requirements	owl:AnnotationProperty	use cases requirements
 IHCC:value	owl:AnnotationProperty	value
 rdfs:comment	owl:AnnotationProperty	comment
 rdfs:seeAlso	owl:AnnotationProperty	see also
+oboInOwl:hasDbXref	owl:AnnotationProperty	database_cross_reference


### PR DESCRIPTION
Resolves #52 

~Mapping files have major changes because I've removed the ID column from them. The ID column isn't needed since the ID->labels have already been defined.~

All subclass & equivalent mappings in `%-mapping.owl` files are now included as IRI annotations on the target terms using `oboInOwl:hasDbXref`.