### PR TITLE
Add validation workflow using COGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,11 @@ destroy-cogs: | .cogs
 
 ### Validation
 
-build/gecko_labels.tsv: build/gecko.owl src/queries/get_labels.rq | build/robot.jar
-	$(ROBOT) query --input $< --query $(word 2,$^) $@
+build/gecko_labels.tsv: build/gecko.owl | build/robot.jar
+	$(ROBOT) export \
+	--input $< \
+	--header "LABEL" \
+	--export $@
 
 # We always get the latest changes before running validation
 .PHONY: build/$(BRANCH)-problems.tsv

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,37 @@ data/full-cohort-data.json: data/cohort-data.json data/random-data.json
 	sed '1d' $(word 2,$^) >> $@
 
 
+### COGS Set Up
+
+# The branch name should be the namespace for the new cohort
+BRANCH := $(shell git branch --show-current)
+
+templates/$(BRANCH).tsv:
+	echo -e "Term ID\tLabel\tParent Term\tDefinition\tGECKO Category\tSuggested Categories\tComment\nID\tLABEL\tC % SPLIT=|\tA definition\n\tis-required;" > $@
+
+# required env var GOOGLE_CREDENTIALS
+.cogs: | templates/$(BRANCH).tsv
+	cogs init -u $(EMAIL) -t $(BRANCH)
+	cogs add $< -r 2
+	cogs push
+	cogs open
+
+
+### Validation
+
+# We always get the latest changes before running validation
+.PHONY: build/$(BRANCH)-problems.tsv
+build/$(BRANCH)-problems.tsv: src/validate.py templates/index.tsv templates/$(BRANCH).tsv
+	cogs fetch
+	cogs pull
+	rm -rf $@ && touch $@
+	python3 $< templates/index.tsv $(BRANCH) $@
+
+apply-problems: build/$(BRANCH)-problems.tsv
+	cogs apply $<
+	cogs push
+
+
 ### Pre-build Tasks
 
 build build/intermediate build/browser build/browser/cohorts data_dictionaries:

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,9 @@ templates/$(BRANCH).tsv:
 	cogs push
 	cogs open
 
+destroy-cogs: | .cogs
+	cogs delete -f
+
 
 ### Validation
 

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ data/full-cohort-data.json: data/cohort-data.json data/random-data.json
 # The branch name should be the namespace for the new cohort
 BRANCH := $(shell git branch --show-current)
 
+init-cogs: .cogs
+
 templates/$(BRANCH).tsv:
 	echo -e "Term ID\tLabel\tParent Term\tDefinition\tGECKO Category\tSuggested Categories\tComment\nID\tLABEL\tC % SPLIT=|\tA definition\n\tis-required;" > $@
 

--- a/Makefile
+++ b/Makefile
@@ -173,13 +173,16 @@ templates/$(BRANCH).tsv:
 
 ### Validation
 
+build/gecko_labels.tsv: build/gecko.owl src/queries/get_labels.rq | build/robot.jar
+	$(ROBOT) query --input $< --query $(word 2,$^) $@
+
 # We always get the latest changes before running validation
 .PHONY: build/$(BRANCH)-problems.tsv
-build/$(BRANCH)-problems.tsv: src/validate.py templates/index.tsv templates/$(BRANCH).tsv
+build/$(BRANCH)-problems.tsv: src/validate.py build/gecko_labels.tsv templates/$(BRANCH).tsv
 	cogs fetch
 	cogs pull
 	rm -rf $@ && touch $@
-	python3 $< templates/index.tsv $(BRANCH) $@
+	python3 $< $(word 2,$^) $(BRANCH) $@
 
 apply-problems: build/$(BRANCH)-problems.tsv
 	cogs apply $<

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ templates/$(BRANCH).tsv:
 # required env var GOOGLE_CREDENTIALS
 .cogs: | templates/$(BRANCH).tsv
 	cogs init -u $(EMAIL) -t $(BRANCH)
-	cogs add $< -r 2
+	cogs add templates/$(BRANCH).tsv -r 2
 	cogs push
 	cogs open
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 rdflib
 xlsx2csv
 requests
+ontodev-cogs

--- a/src/validate.py
+++ b/src/validate.py
@@ -1,0 +1,209 @@
+import collections
+import csv
+
+from argparse import ArgumentParser
+
+
+def idx_to_a1(row, col):
+    """Convert a row & column to A1 notation. Adapted from gspread.utils."""
+    div = col
+    column_label = ""
+
+    while div:
+        (div, mod) = divmod(div, 26)
+        if mod == 0:
+            mod = 26
+            div -= 1
+        column_label = chr(mod + 64) + column_label
+
+    label = f"{column_label}{row}"
+    return label
+
+
+def main():
+    p = ArgumentParser()
+    p.add_argument("index")
+    p.add_argument("namespace")
+    p.add_argument("output")
+    args = p.parse_args()
+
+    gecko_labels = []
+    with open(args.index, "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        next(reader)
+        for row in reader:
+            gecko_labels.append(row["Label"])
+
+    ns = args.namespace
+    table = f"templates/{ns}.tsv"
+
+    problems = []
+    problem_count = 0
+    # row -> ID
+    ids = {}
+    # label -> locs
+    labels = {}
+    # loc -> parent_term
+    parent_terms = {}
+
+    lines = []
+
+    with open(table, "r") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        # Skip template & validation strings
+        lines.append(next(reader))
+        lines.append(next(reader))
+
+        row_idx = 3
+        for row in reader:
+            lines.append(row)
+            row_idx += 1
+
+            # Add ID to IDs (note that this may be empty)
+            local_id = row["Term ID"].strip()
+            ids[row_idx] = local_id
+
+            # Add label to labels map
+            label = row["Label"]
+            if label in labels:
+                locs = labels[label]
+            else:
+                locs = []
+            locs.append(idx_to_a1(row_idx, 2))
+            labels[label] = locs
+
+            # Add parent to parent_terms map
+            parent_terms[idx_to_a1(row_idx, 3)] = row["Parent Term"].strip()
+
+            # Check that GECKO category is valid
+            gecko_cat = row["GECKO Category"].strip()
+            if gecko_cat != "" and gecko_cat not in gecko_labels:
+                problem_count += 1
+                problems.append(
+                    {
+                        "ID": problem_count,
+                        "table": ns,
+                        "cell": idx_to_a1(row_idx, 5),
+                        "level": "error",
+                        "rule ID": "",
+                        "rule name": "Invalid GECKO category",
+                        "value": gecko_cat,
+                        "fix": "",
+                        "instructions": "select a valid GECKO category",
+                    }
+                )
+
+    # Validate labels
+    duplicates = {k: v for k, v in labels.items() if len(v) > 1}
+    if duplicates:
+        for label, locs in duplicates.items():
+            for loc in locs:
+                problem_count += 1
+                other_locs = ", ".join([x for x in locs if x != loc])
+                problems.append(
+                    {
+                        "ID": problem_count,
+                        "table": ns,
+                        "cell": loc,
+                        "level": "error",
+                        "rule ID": "",
+                        "rule name": "Duplicate label",
+                        "value": label,
+                        "fix": "",
+                        "instructions": f"update this label & label(s) in cell(s): {other_locs}",
+                    }
+                )
+
+    # Validate parent terms
+    for loc, parent_term in parent_terms.items():
+        if parent_term == "":
+            continue
+        for pt in parent_term.split("|"):
+            if pt not in labels.keys():
+                problem_count += 1
+                problems.append(
+                    {
+                        "ID": problem_count,
+                        "table": ns,
+                        "cell": loc,
+                        "level": "error",
+                        "rule ID": "",
+                        "rule name": "Invalid parent term",
+                        "value": pt,
+                        "fix": "",
+                        "instructions": "make sure that the parent term is a label listed in the "
+                        "label column of this table",
+                    }
+                )
+
+    # Maybe assign IDs
+    id_counter = 0
+    updated_ids = {}
+
+    # First get existing max ID number if there are existing IDs
+    for local_id in ids.values():
+        if local_id == "":
+            continue
+        num_id = int(local_id.split(":")[1].lstrip("0"))
+        if num_id > id_counter:
+            id_counter = num_id
+
+    # Then assign IDs to any without
+    for row, local_id in ids.items():
+        if local_id == "":
+            id_counter += 1
+            id_str = str(id_counter).zfill(7)
+            local_id = f"{ns}:{id_str}"
+            updated_ids[row] = local_id
+
+    if updated_ids:
+        # Write new IDs if we have them
+        with open(table, "w") as f:
+            writer = csv.DictWriter(
+                f,
+                delimiter="\t",
+                lineterminator="\n",
+                fieldnames=[
+                    "Term ID",
+                    "Label",
+                    "Parent Term",
+                    "Definition",
+                    "GECKO Category",
+                    "Suggested Categories",
+                    "Comment",
+                ],
+            )
+            writer.writeheader()
+            row_idx = 1
+            for line in lines:
+                row_idx += 1
+                if row_idx in updated_ids:
+                    local_id = updated_ids[row_idx]
+                    line["Term ID"] = local_id
+                writer.writerow(line)
+
+    if problems:
+        # Write any problems if we have them
+        with open(args.output, "w") as f:
+            writer = csv.DictWriter(
+                f,
+                delimiter="\t",
+                lineterminator="\n",
+                fieldnames=[
+                    "ID",
+                    "table",
+                    "cell",
+                    "level",
+                    "rule ID",
+                    "rule name",
+                    "value",
+                    "fix",
+                    "instructions",
+                ],
+            )
+            writer.writeheader()
+            writer.writerows(problems)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/validate.py
+++ b/src/validate.py
@@ -161,31 +161,33 @@ def main():
             local_id = f"{ns}:{id_str}"
             updated_ids[row] = local_id
 
-    if updated_ids:
-        # Write new IDs if we have them
-        with open(table, "w") as f:
-            writer = csv.DictWriter(
-                f,
-                delimiter="\t",
-                lineterminator="\n",
-                fieldnames=[
-                    "Term ID",
-                    "Label",
-                    "Parent Term",
-                    "Definition",
-                    "GECKO Category",
-                    "Suggested Categories",
-                    "Comment",
-                ],
-            )
-            writer.writeheader()
-            row_idx = 1
-            for line in lines:
-                row_idx += 1
-                if row_idx in updated_ids:
-                    local_id = updated_ids[row_idx]
-                    line["Term ID"] = local_id
-                writer.writerow(line)
+    # Fix any leading or trailing whitespace
+    lines = [{k: v.strip() for k, v in x.items()} for x in lines]
+
+    # Write new IDs and trimmed whitespace
+    with open(table, "w") as f:
+        writer = csv.DictWriter(
+            f,
+            delimiter="\t",
+            lineterminator="\n",
+            fieldnames=[
+                "Term ID",
+                "Label",
+                "Parent Term",
+                "Definition",
+                "GECKO Category",
+                "Suggested Categories",
+                "Comment",
+            ],
+        )
+        writer.writeheader()
+        row_idx = 1
+        for line in lines:
+            row_idx += 1
+            if row_idx in updated_ids:
+                local_id = updated_ids[row_idx]
+                line["Term ID"] = local_id
+            writer.writerow(line)
 
     if problems:
         # Write any problems if we have them

--- a/src/validate.py
+++ b/src/validate.py
@@ -22,17 +22,18 @@ def idx_to_a1(row, col):
 
 def main():
     p = ArgumentParser()
-    p.add_argument("index")
+    p.add_argument("labels")
     p.add_argument("namespace")
     p.add_argument("output")
     args = p.parse_args()
 
     gecko_labels = []
-    with open(args.index, "r") as f:
-        reader = csv.DictReader(f, delimiter="\t")
+    with open(args.labels, "r") as f:
+        reader = csv.reader(f, delimiter="\t")
+        # Skip header
         next(reader)
         for row in reader:
-            gecko_labels.append(row["Label"])
+            gecko_labels.append(row[0])
 
     ns = args.namespace
     table = f"templates/{ns}.tsv"
@@ -144,7 +145,11 @@ def main():
     for local_id in ids.values():
         if local_id == "":
             continue
-        num_id = int(local_id.split(":")[1].lstrip("0"))
+        try:
+            num_id = int(local_id.split(":")[1].lstrip("0"))
+        except ValueError:
+            # Not a number - stick with whatever ID counter is currently at
+            num_id = id_counter
         if num_id > id_counter:
             id_counter = num_id
 


### PR DESCRIPTION
Resolves #70 

This assumes:
1. The cohort has selected a namespace
2. We are on a branch that is named with that namespace (`git checkout -b <namespace>`)
3. There is a `GOOGLE_CREDENTIALS` environment variable set

First we set up the COGS project:
```
make EMAIL=<user-email> init-cogs
```

Right now the email is just passed to `make`, but maybe we want to set that as an env var as well? I don't know what's best.

The last line of the `init-cogs` task is the link to the new Google Sheet. It will have one sheet (the branch name/namespace) with the required headers described in #62.

The user adds their terms & any mappings that they can do, then:
```
make apply-problems
```

The user then looks at the sheet again to see if any problems were found.

The `validate.py` script checks:
* All "Parent Term" values are defined as labels somewhere in the table
* All "GECKO Category" values are valid IHCC browser labels
* No duplicate labels

It also assigns numeric IDs starting after whatever the last-used numeric ID was. It will start at `ns:0000001` if there are no existing IDs, or no existing numeric IDs (some cohorts already have IDs that use text).

This will also work for updating cohorts, as long as we are on a branch with that cohort name. For example, if we want to update GCS:
```
git checkout -b gcs
make EMAIL=myemail@email.com init-cogs
```

And the sheet will contain the existing `templates/gcs.tsv` that can be updated & validated.

Once we are finished editing and validating, the cogs directory & corresponding Google Sheet should be removed:
```
make destroy-cogs
```

