### PR TITLE
Add metadata to cohort OWL files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ build/index.html: src/create_index.py src/index.html.jinja2 data/metadata.json |
 owl: $(ONTS) | data_dictionaries
 	cp $^ data_dictionaries/
 
-build/%.owl: build/intermediate/properties.owl templates/%.tsv build/intermediate/%-xrefs.tsv | build/robot.jar
+build/%.owl: build/intermediate/properties.owl templates/%.tsv build/intermediate/%-xrefs.tsv metadata/%.ttl | build/robot.jar
 	$(ROBOT) template --input $< \
 	--merge-before \
 	--template $(word 2,$^) \
@@ -97,6 +97,7 @@ build/%.owl: build/intermediate/properties.owl templates/%.tsv build/intermediat
 	--template $(word 3,$^) \
 	--merge-before \
 	annotate --ontology-iri "https://purl.ihccglobal.org/$(notdir $@)" \
+	--annotation-file $(word 4,$^) \
 	--output $@
 
 

--- a/data_dictionaries/gcs.owl
+++ b/data_dictionaries/gcs.owl
@@ -1,16 +1,23 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://purl.ihccglobal.org/gcs.owl#"
      xml:base="https://purl.ihccglobal.org/gcs.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:dc1="dc:"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
      xmlns:purl="https://purl.ihccglobal.org/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://purl.ihccglobal.org/gcs.owl"/>
+    <owl:Ontology rdf:about="https://purl.ihccglobal.org/gcs.owl">
+        <dc:description>The data dictionary of items collected by the GCS.</dc:description>
+        <terms:title>Golestan Cohort Study (GCS)</terms:title>
+        <prov:wasDerivedFrom rdf:resource="https://drive.google.com/file/d/1ZLw-D6AZFKrBjTNsc4wzlthYq4w4KmOJ/view"/>
+    </owl:Ontology>
     
 
 

--- a/data_dictionaries/genomics-england.owl
+++ b/data_dictionaries/genomics-england.owl
@@ -1,16 +1,25 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://purl.ihccglobal.org/genomics-england.owl#"
      xml:base="https://purl.ihccglobal.org/genomics-england.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:dc1="dc:"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
      xmlns:purl="https://purl.ihccglobal.org/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://purl.ihccglobal.org/genomics-england.owl"/>
+    <owl:Ontology rdf:about="https://purl.ihccglobal.org/genomics-england.owl">
+        <dc:description>The main programme data dictionary for the Genomics England Research Environment.</dc:description>
+        <terms:license>TODO: The license URL</terms:license>
+        <terms:rights>TODO: A human-readable description of rights</terms:rights>
+        <terms:title>Genomics England Main Programme Data</terms:title>
+        <prov:wasDerivedFrom rdf:resource="https://cnfl.extge.co.uk/pages/viewpage.action?pageId=113189195"/>
+    </owl:Ontology>
     
 
 

--- a/data_dictionaries/koges.owl
+++ b/data_dictionaries/koges.owl
@@ -1,16 +1,23 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://purl.ihccglobal.org/koges.owl#"
      xml:base="https://purl.ihccglobal.org/koges.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:dc1="dc:"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
      xmlns:purl="https://purl.ihccglobal.org/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://purl.ihccglobal.org/koges.owl"/>
+    <owl:Ontology rdf:about="https://purl.ihccglobal.org/koges.owl">
+        <dc:description>The core variables collected in the Korean Genome and Epidemiology Study.</dc:description>
+        <terms:title>Korean Genome and Epidemiology Study (KoGES)</terms:title>
+        <prov:wasDerivedFrom rdf:resource="https://drive.google.com/file/d/1Hh_cG9HcZWXs70FEun8iDZZbt0H_J1oq/view"/>
+    </owl:Ontology>
     
 
 

--- a/data_dictionaries/saprin.owl
+++ b/data_dictionaries/saprin.owl
@@ -1,16 +1,36 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://purl.ihccglobal.org/saprin.owl#"
      xml:base="https://purl.ihccglobal.org/saprin.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:dc1="dc:"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
      xmlns:purl="https://purl.ihccglobal.org/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://purl.ihccglobal.org/saprin.owl"/>
+    <owl:Ontology rdf:about="https://purl.ihccglobal.org/saprin.owl">
+        <dc:description>The core data elements collected by SAPRIN.</dc:description>
+        <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+        <terms:rights>You are free to:
+
+Share — copy and redistribute the material in any medium or format
+
+Adapt — remix, transform, and build upon the material
+for any purpose, even commercially.
+
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.</terms:rights>
+        <terms:title>South African Population Research Infrastructure Network (SAPRIN)</terms:title>
+        <prov:wasDerivedFrom rdf:resource="https://docs.google.com/spreadsheets/d/1KjULwQ38IkWqJxOCZZ2em8ge7NZJEngOZqI3ebC9Wkk/edit?usp=sharing"/>
+    </owl:Ontology>
     
 
 

--- a/data_dictionaries/vukuzazi.owl
+++ b/data_dictionaries/vukuzazi.owl
@@ -1,16 +1,36 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="https://purl.ihccglobal.org/vukuzazi.owl#"
      xml:base="https://purl.ihccglobal.org/vukuzazi.owl"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:dc1="dc:"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
      xmlns:purl="https://purl.ihccglobal.org/"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="https://purl.ihccglobal.org/vukuzazi.owl"/>
+    <owl:Ontology rdf:about="https://purl.ihccglobal.org/vukuzazi.owl">
+        <dc:description>The data dictionary containing variables collected by the Africa Health Research Institute&apos;s Vukuzazi programme.</dc:description>
+        <terms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+        <terms:rights>You are free to:
+
+Share — copy and redistribute the material in any medium or format
+
+Adapt — remix, transform, and build upon the material
+for any purpose, even commercially.
+
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.</terms:rights>
+        <terms:title>Vukuzazi</terms:title>
+        <prov:wasDerivedFrom rdf:resource="https://drive.google.com/file/d/1YpwjiYDos5ZkXMQR6wG4Qug7sMmKB5xC/view"/>
+    </owl:Ontology>
     
 
 

--- a/metadata/gcs.ttl
+++ b/metadata/gcs.ttl
@@ -2,10 +2,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "Golestan Cohort Study (GCS)" ;
+  dc:description "The data dictionary of items collected by the GCS." ;
   prov:wasDerivedFrom <https://drive.google.com/file/d/1ZLw-D6AZFKrBjTNsc4wzlthYq4w4KmOJ/view> .

--- a/metadata/genomics-england.ttl
+++ b/metadata/genomics-england.ttl
@@ -2,12 +2,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "Genomics England Main Programme Data" ;
+  dc:description "The main programme data dictionary for the Genomics England Research Environment." ;
   dcterms:license "TODO: The license URL" ;
   dcterms:rights "TODO: A human-readable description of rights" ;
   prov:wasDerivedFrom <https://cnfl.extge.co.uk/pages/viewpage.action?pageId=113189195> .

--- a/metadata/koges.ttl
+++ b/metadata/koges.ttl
@@ -2,11 +2,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "Korean Genome and Epidemiology Study (KoGES)" ;
-  dcterms:description "TODO" ;
+  dc:description "The core variables collected in the Korean Genome and Epidemiology Study." ;
   prov:wasDerivedFrom <https://drive.google.com/file/d/1Hh_cG9HcZWXs70FEun8iDZZbt0H_J1oq/view> .

--- a/metadata/maelstrom.ttl
+++ b/metadata/maelstrom.ttl
@@ -2,15 +2,16 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "Maelstrom Area Of Information"@en ;
   dcterms:title "Maelstrom Aires d'information"@fr ;
-  dcterms:description "Information classification developed by Maelstrom Research"@en ;
-  dcterms:description "Classification des informations développée par Maelstrom Research"@fr ;
+  dc:description "Information classification developed by Maelstrom Research"@en ;
+  dc:description "Classification des informations développée par Maelstrom Research"@fr ;
   dcterms:license <https://creativecommons.org/licenses/by-nc-nd/4.0/> ;
   dcterms:rights "You are free to:
 

--- a/metadata/saprin.ttl
+++ b/metadata/saprin.ttl
@@ -2,13 +2,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "South African Population Research Infrastructure Network (SAPRIN)" ;
-  dcterms:description "TODO" ;
+  dc:description "The core data elements collected by SAPRIN." ;
   dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
   dcterms:rights "You are free to:
 

--- a/metadata/vukuzazi.ttl
+++ b/metadata/vukuzazi.ttl
@@ -2,13 +2,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/>.
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
 <>
   rdf:type owl:Ontology ;
   dcterms:title "Vukuzazi" ;
-  dcterms:description "TODO" ;
+  dc:description "The data dictionary containing variables collected by the Africa Health Research Institute's Vukuzazi programme." ;
   dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
   dcterms:rights "You are free to:
 
@@ -23,7 +24,3 @@ Attribution — You must give appropriate credit, provide a link to the license,
 
 No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits." ;
   prov:wasDerivedFrom <https://drive.google.com/file/d/1YpwjiYDos5ZkXMQR6wG4Qug7sMmKB5xC/view> .
-
-<http://example.com/value>
-  rdf:type owl:AnnotationProperty ;
-  rdfs:label "value" .


### PR DESCRIPTION
In order for details to show up in the OLS list of all ontologies (https://registry.ihccglobal.app/ontologies), we need the `dcterms:title` and `dc:description` annotations in the OWL files for all cohorts. We have metadata TTL files that were not being used, so I added a step to merge these into the final products.

Going forward, we will need to generate a metadata TTL for all new cohorts. Maybe we could have some sort of interactive process with DROID @jamesaoverton ?