### PR TITLE
Fix biosample types in cohort data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,9 @@ build/%.html: build/%.owl templates/%.tsv | src/prefixes.json build/robot.jar
 build/gecko_structure.json: build/gecko.owl | build/robot-tree.jar src/prefixes.json
 	java -jar build/robot-tree.jar \
 	--prefixes src/prefixes.json \
-	tree --input $< \
+	remove --input $< \
+	--term GECKO:0000019 \
+	tree \
 	--format json \
 	--tree $@
 

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -29,24 +29,24 @@
     "questionnaire_survey_data": {
       "diseases": [
         "circulatory_system",
-        "respiratory_system",
         "endocrine_nutritional_metabolic_disorders",
-        "oncological"
+        "oncological",
+        "respiratory_system"
       ],
       "general_variables": [
-        "signs_and_symptoms",
-        "physician_practitioner_info"
+        "physician_practitioner_info",
+        "signs_and_symptoms"
       ],
       "lifestyle_and_behaviours": [
         "alcohol",
         "drugs",
-        "tobacco",
+        "nutrition",
         "physical_activity",
-        "nutrition"
+        "tobacco"
       ],
       "medication": [
-        "prescription",
-        "associated_diseases"
+        "associated_diseases",
+        "prescription"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
@@ -57,17 +57,17 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure",
-        "ethnicity_race",
-        "residence",
-        "gender",
         "age_birthdate",
-        "education"
+        "education",
+        "ethnicity_race",
+        "family_and_household_structure",
+        "gender",
+        "residence"
       ]
     },
     "survey_administration": [
@@ -103,9 +103,9 @@
     "pi_lead": "Sung Soo Kim",
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system",
+        "digestive_system",
         "mental_and_behaviour_disorders",
-        "digestive_system"
+        "respiratory_system"
       ],
       "general_variables": [
         "reproduction",
@@ -113,10 +113,10 @@
       ],
       "lifestyle_and_behaviours": [
         "alcohol",
-        "tobacco",
-        "physical_activity",
         "nutrition",
-        "sleep"
+        "physical_activity",
+        "sleep",
+        "tobacco"
       ],
       "medication": [],
       "non_pharmacological_interventions": [
@@ -128,13 +128,13 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure",
-        "education"
+        "education",
+        "family_and_household_structure"
       ]
     },
     "target_enrollment": null,
@@ -166,24 +166,24 @@
     "questionnaire_survey_data": {
       "diseases": [
         "circulatory_system",
-        "respiratory_system",
-        "nervous_system",
         "endocrine_nutritional_metabolic_disorders",
+        "mental_and_behaviour_disorders",
+        "nervous_system",
         "oncological",
-        "mental_and_behaviour_disorders"
+        "respiratory_system"
       ],
       "general_variables": [
-        "signs_and_symptoms",
+        "physician_practitioner_info",
         "reproduction",
-        "physician_practitioner_info"
+        "signs_and_symptoms"
       ],
       "lifestyle_and_behaviours": [
         "alcohol"
       ],
       "medication": [
-        "prescription",
         "administration",
-        "drug_responses"
+        "drug_responses",
+        "prescription"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
@@ -195,13 +195,13 @@
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure",
-        "biological_sex",
-        "ethnicity_race",
-        "residence",
-        "gender",
         "age_birthdate",
-        "education"
+        "biological_sex",
+        "education",
+        "ethnicity_race",
+        "family_and_household_structure",
+        "gender",
+        "residence"
       ]
     },
     "survey_administration": [
@@ -231,21 +231,21 @@
         "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
-        "reproduction",
-        "life_stage_time_point"
+        "life_stage_time_point",
+        "reproduction"
       ],
       "non_pharmacological_interventions": [],
       "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race",
-        "residence",
         "age_birthdate",
+        "biological_sex",
+        "ethnicity_race",
         "family_and_household_structure",
-        "biological_sex"
+        "residence"
       ]
     },
     "survey_administration": [
-      "unique_identifiers",
-      "date_and_time_related_information"
+      "date_and_time_related_information",
+      "unique_identifiers"
     ],
     "target_enrollment": 700000,
     "website": "http://saprin.mrc.ac.za/"
@@ -260,9 +260,9 @@
     "biosample": {
       "sample_type": [
         "blood",
+        "other_biosample_type",
         "saliva",
-        "urine",
-        "other_biosample_type"
+        "urine"
       ]
     },
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
@@ -276,18 +276,18 @@
     "questionnaire_survey_data": {
       "diseases": [
         "circulatory_system",
-        "respiratory_system",
         "endocrine_nutritional_metabolic_disorders",
-        "oncological"
+        "oncological",
+        "respiratory_system"
       ],
       "general_variables": [
-        "signs_and_symptoms",
-        "reproduction"
+        "reproduction",
+        "signs_and_symptoms"
       ],
       "lifestyle_and_behaviours": [
         "alcohol",
-        "tobacco",
-        "nutrition"
+        "nutrition",
+        "tobacco"
       ],
       "medication": [
         "associated_diseases"
@@ -299,8 +299,8 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       }
     },

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -13,12 +13,10 @@
       ]
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "other_biosample_type"
-        ]
-      }
+      "sample_type": [
+        "other_biosample_type",
+        "blood"
+      ]
     },
     "cohort_name": "Golestan Cohort Study",
     "countries": [
@@ -30,9 +28,9 @@
     "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
     "questionnaire_survey_data": {
       "diseases": [
+        "respiratory_system",
         "oncological",
         "circulatory_system",
-        "respiratory_system",
         "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
@@ -41,10 +39,10 @@
       ],
       "lifestyle_and_behaviours": [
         "tobacco",
-        "alcohol",
-        "physical_activity",
         "drugs",
-        "nutrition"
+        "physical_activity",
+        "nutrition",
+        "alcohol"
       ],
       "medication": [
         "prescription",
@@ -55,26 +53,26 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "education",
-        "ethnicity_race",
         "family_and_household_structure",
+        "age_birthdate",
         "residence",
         "gender",
-        "age_birthdate"
+        "education",
+        "ethnicity_race"
       ]
     },
     "survey_administration": [
-      "date_and_time_related_information",
-      "unique_identifiers"
+      "unique_identifiers",
+      "date_and_time_related_information"
     ],
     "target_enrollment": null,
     "website": "https://dceg2.cancer.gov/gemshare/"
@@ -87,12 +85,10 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "urine"
-        ]
-      }
+      "sample_type": [
+        "blood",
+        "urine"
+      ]
     },
     "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
     "countries": [
@@ -112,15 +108,15 @@
         "respiratory_system"
       ],
       "general_variables": [
-        "reproduction",
-        "signs_and_symptoms"
+        "signs_and_symptoms",
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
         "tobacco",
-        "sleep",
-        "alcohol",
         "physical_activity",
-        "nutrition"
+        "nutrition",
+        "alcohol",
+        "sleep"
       ],
       "medication": [],
       "non_pharmacological_interventions": [
@@ -128,17 +124,17 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "education",
-        "family_and_household_structure"
+        "family_and_household_structure",
+        "education"
       ]
     },
     "target_enrollment": null,
@@ -169,17 +165,17 @@
     "pi_lead": "Mark Caulfield",
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological",
-        "mental_and_behaviour_disorders",
         "nervous_system",
         "respiratory_system",
+        "oncological",
         "circulatory_system",
-        "endocrine_nutritional_metabolic_disorders"
+        "endocrine_nutritional_metabolic_disorders",
+        "mental_and_behaviour_disorders"
       ],
       "general_variables": [
-        "reproduction",
         "signs_and_symptoms",
-        "physician_practitioner_info"
+        "physician_practitioner_info",
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
         "alcohol"
@@ -194,23 +190,23 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "education",
         "family_and_household_structure",
-        "biological_sex",
+        "age_birthdate",
         "residence",
         "gender",
-        "age_birthdate",
-        "ethnicity_race"
+        "education",
+        "ethnicity_race",
+        "biological_sex"
       ]
     },
     "survey_administration": [
-      "date_and_time_related_information",
-      "unique_identifiers"
+      "unique_identifiers",
+      "date_and_time_related_information"
     ],
     "target_enrollment": 500000,
     "website": "https://www.genomicsengland.co.uk/"
@@ -240,11 +236,11 @@
       ],
       "non_pharmacological_interventions": [],
       "socio_demographic_and_economic_characteristics": [
-        "residence",
-        "biological_sex",
-        "age_birthdate",
         "family_and_household_structure",
-        "ethnicity_race"
+        "ethnicity_race",
+        "age_birthdate",
+        "biological_sex",
+        "residence"
       ]
     },
     "survey_administration": [
@@ -262,14 +258,12 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "other_biosample_type",
-          "saliva",
-          "urine"
-        ]
-      }
+      "sample_type": [
+        "other_biosample_type",
+        "saliva",
+        "blood",
+        "urine"
+      ]
     },
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
     "countries": [
@@ -281,19 +275,19 @@
     "pi_lead": "Deenan Pillay",
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological",
         "respiratory_system",
+        "oncological",
         "circulatory_system",
         "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
-        "reproduction",
-        "signs_and_symptoms"
+        "signs_and_symptoms",
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
         "tobacco",
-        "alcohol",
-        "nutrition"
+        "nutrition",
+        "alcohol"
       ],
       "medication": [
         "associated_diseases"
@@ -301,18 +295,18 @@
       "non_pharmacological_interventions": [],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
-          "heart_rate_HR",
-          "blood_pressure"
+          "blood_pressure",
+          "heart_rate_HR"
         ]
       }
     },
     "survey_administration": [
-      "date_and_time_related_information",
-      "unique_identifiers"
+      "unique_identifiers",
+      "date_and_time_related_information"
     ],
     "target_enrollment": 130000,
     "website": "https://www.ahri.org"

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -14,8 +14,8 @@
     },
     "biosample": {
       "sample_type": [
-        "other_biosample_type",
-        "blood"
+        "blood",
+        "other_biosample_type"
       ]
     },
     "cohort_name": "Golestan Cohort Study",
@@ -28,21 +28,21 @@
     "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system",
-        "oncological",
         "circulatory_system",
-        "endocrine_nutritional_metabolic_disorders"
+        "respiratory_system",
+        "endocrine_nutritional_metabolic_disorders",
+        "oncological"
       ],
       "general_variables": [
         "signs_and_symptoms",
         "physician_practitioner_info"
       ],
       "lifestyle_and_behaviours": [
-        "tobacco",
+        "alcohol",
         "drugs",
+        "tobacco",
         "physical_activity",
-        "nutrition",
-        "alcohol"
+        "nutrition"
       ],
       "medication": [
         "prescription",
@@ -57,22 +57,22 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "blood_pressure",
-          "heart_rate_HR"
+          "heart_rate_HR",
+          "blood_pressure"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
         "family_and_household_structure",
-        "age_birthdate",
+        "ethnicity_race",
         "residence",
         "gender",
-        "education",
-        "ethnicity_race"
+        "age_birthdate",
+        "education"
       ]
     },
     "survey_administration": [
-      "unique_identifiers",
-      "date_and_time_related_information"
+      "date_and_time_related_information",
+      "unique_identifiers"
     ],
     "target_enrollment": null,
     "website": "https://dceg2.cancer.gov/gemshare/"
@@ -103,19 +103,19 @@
     "pi_lead": "Sung Soo Kim",
     "questionnaire_survey_data": {
       "diseases": [
+        "respiratory_system",
         "mental_and_behaviour_disorders",
-        "digestive_system",
-        "respiratory_system"
+        "digestive_system"
       ],
       "general_variables": [
-        "signs_and_symptoms",
-        "reproduction"
+        "reproduction",
+        "signs_and_symptoms"
       ],
       "lifestyle_and_behaviours": [
+        "alcohol",
         "tobacco",
         "physical_activity",
         "nutrition",
-        "alcohol",
         "sleep"
       ],
       "medication": [],
@@ -128,8 +128,8 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "blood_pressure",
-          "heart_rate_HR"
+          "heart_rate_HR",
+          "blood_pressure"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
@@ -165,25 +165,25 @@
     "pi_lead": "Mark Caulfield",
     "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system",
-        "respiratory_system",
-        "oncological",
         "circulatory_system",
+        "respiratory_system",
+        "nervous_system",
         "endocrine_nutritional_metabolic_disorders",
+        "oncological",
         "mental_and_behaviour_disorders"
       ],
       "general_variables": [
         "signs_and_symptoms",
-        "physician_practitioner_info",
-        "reproduction"
+        "reproduction",
+        "physician_practitioner_info"
       ],
       "lifestyle_and_behaviours": [
         "alcohol"
       ],
       "medication": [
         "prescription",
-        "drug_responses",
-        "administration"
+        "administration",
+        "drug_responses"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
@@ -196,17 +196,17 @@
       },
       "socio_demographic_and_economic_characteristics": [
         "family_and_household_structure",
-        "age_birthdate",
+        "biological_sex",
+        "ethnicity_race",
         "residence",
         "gender",
-        "education",
-        "ethnicity_race",
-        "biological_sex"
+        "age_birthdate",
+        "education"
       ]
     },
     "survey_administration": [
-      "unique_identifiers",
-      "date_and_time_related_information"
+      "date_and_time_related_information",
+      "unique_identifiers"
     ],
     "target_enrollment": 500000,
     "website": "https://www.genomicsengland.co.uk/"
@@ -231,21 +231,21 @@
         "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
-        "life_stage_time_point",
-        "reproduction"
+        "reproduction",
+        "life_stage_time_point"
       ],
       "non_pharmacological_interventions": [],
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure",
         "ethnicity_race",
+        "residence",
         "age_birthdate",
-        "biological_sex",
-        "residence"
+        "family_and_household_structure",
+        "biological_sex"
       ]
     },
     "survey_administration": [
-      "date_and_time_related_information",
-      "unique_identifiers"
+      "unique_identifiers",
+      "date_and_time_related_information"
     ],
     "target_enrollment": 700000,
     "website": "http://saprin.mrc.ac.za/"
@@ -259,10 +259,10 @@
     },
     "biosample": {
       "sample_type": [
-        "other_biosample_type",
-        "saliva",
         "blood",
-        "urine"
+        "saliva",
+        "urine",
+        "other_biosample_type"
       ]
     },
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
@@ -275,19 +275,19 @@
     "pi_lead": "Deenan Pillay",
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system",
-        "oncological",
         "circulatory_system",
-        "endocrine_nutritional_metabolic_disorders"
+        "respiratory_system",
+        "endocrine_nutritional_metabolic_disorders",
+        "oncological"
       ],
       "general_variables": [
         "signs_and_symptoms",
         "reproduction"
       ],
       "lifestyle_and_behaviours": [
+        "alcohol",
         "tobacco",
-        "nutrition",
-        "alcohol"
+        "nutrition"
       ],
       "medication": [
         "associated_diseases"
@@ -299,14 +299,14 @@
           "weight"
         ],
         "circulation_and_respiration": [
-          "blood_pressure",
-          "heart_rate_HR"
+          "heart_rate_HR",
+          "blood_pressure"
         ]
       }
     },
     "survey_administration": [
-      "unique_identifiers",
-      "date_and_time_related_information"
+      "date_and_time_related_information",
+      "unique_identifiers"
     ],
     "target_enrollment": 130000,
     "website": "https://www.ahri.org"

--- a/data/full-cohort-data.json
+++ b/data/full-cohort-data.json
@@ -13,12 +13,10 @@
       ]
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "other_biosample_type"
-        ]
-      }
+      "sample_type": [
+        "other_biosample_type",
+        "blood"
+      ]
     },
     "cohort_name": "Golestan Cohort Study",
     "countries": [
@@ -30,21 +28,21 @@
     "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
     "questionnaire_survey_data": {
       "diseases": [
-        "endocrine_nutritional_metabolic_disorders",
-        "oncological",
         "respiratory_system",
-        "circulatory_system"
+        "oncological",
+        "circulatory_system",
+        "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
-        "physician_practitioner_info",
-        "signs_and_symptoms"
+        "signs_and_symptoms",
+        "physician_practitioner_info"
       ],
       "lifestyle_and_behaviours": [
+        "tobacco",
         "drugs",
-        "alcohol",
-        "nutrition",
         "physical_activity",
-        "tobacco"
+        "nutrition",
+        "alcohol"
       ],
       "medication": [
         "prescription",
@@ -55,8 +53,8 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
           "blood_pressure",
@@ -65,11 +63,11 @@
       },
       "socio_demographic_and_economic_characteristics": [
         "family_and_household_structure",
-        "residence",
-        "education",
         "age_birthdate",
-        "ethnicity_race",
-        "gender"
+        "residence",
+        "gender",
+        "education",
+        "ethnicity_race"
       ]
     },
     "survey_administration": [
@@ -87,12 +85,10 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "urine"
-        ]
-      }
+      "sample_type": [
+        "blood",
+        "urine"
+      ]
     },
     "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
     "countries": [
@@ -112,15 +108,15 @@
         "respiratory_system"
       ],
       "general_variables": [
-        "reproduction",
-        "signs_and_symptoms"
+        "signs_and_symptoms",
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
-        "alcohol",
-        "nutrition",
+        "tobacco",
         "physical_activity",
-        "sleep",
-        "tobacco"
+        "nutrition",
+        "alcohol",
+        "sleep"
       ],
       "medication": [],
       "non_pharmacological_interventions": [
@@ -128,8 +124,8 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
           "blood_pressure",
@@ -169,24 +165,24 @@
     "pi_lead": "Mark Caulfield",
     "questionnaire_survey_data": {
       "diseases": [
-        "mental_and_behaviour_disorders",
-        "endocrine_nutritional_metabolic_disorders",
         "nervous_system",
-        "oncological",
         "respiratory_system",
-        "circulatory_system"
+        "oncological",
+        "circulatory_system",
+        "endocrine_nutritional_metabolic_disorders",
+        "mental_and_behaviour_disorders"
       ],
       "general_variables": [
+        "signs_and_symptoms",
         "physician_practitioner_info",
-        "reproduction",
-        "signs_and_symptoms"
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
         "alcohol"
       ],
       "medication": [
-        "drug_responses",
         "prescription",
+        "drug_responses",
         "administration"
       ],
       "non_pharmacological_interventions": [
@@ -194,17 +190,17 @@
       ],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
         "family_and_household_structure",
-        "residence",
-        "education",
         "age_birthdate",
-        "ethnicity_race",
+        "residence",
         "gender",
+        "education",
+        "ethnicity_race",
         "biological_sex"
       ]
     },
@@ -241,15 +237,15 @@
       "non_pharmacological_interventions": [],
       "socio_demographic_and_economic_characteristics": [
         "family_and_household_structure",
-        "residence",
-        "age_birthdate",
         "ethnicity_race",
-        "biological_sex"
+        "age_birthdate",
+        "biological_sex",
+        "residence"
       ]
     },
     "survey_administration": [
-      "unique_identifiers",
-      "date_and_time_related_information"
+      "date_and_time_related_information",
+      "unique_identifiers"
     ],
     "target_enrollment": 700000,
     "website": "http://saprin.mrc.ac.za/"
@@ -262,14 +258,12 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample_type": {
-        "blood": [],
-        "general_variables": [
-          "urine",
-          "other_biosample_type",
-          "saliva"
-        ]
-      }
+      "sample_type": [
+        "other_biosample_type",
+        "saliva",
+        "blood",
+        "urine"
+      ]
     },
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
     "countries": [
@@ -281,19 +275,19 @@
     "pi_lead": "Deenan Pillay",
     "questionnaire_survey_data": {
       "diseases": [
-        "endocrine_nutritional_metabolic_disorders",
-        "oncological",
         "respiratory_system",
-        "circulatory_system"
+        "oncological",
+        "circulatory_system",
+        "endocrine_nutritional_metabolic_disorders"
       ],
       "general_variables": [
-        "reproduction",
-        "signs_and_symptoms"
+        "signs_and_symptoms",
+        "reproduction"
       ],
       "lifestyle_and_behaviours": [
-        "alcohol",
+        "tobacco",
         "nutrition",
-        "tobacco"
+        "alcohol"
       ],
       "medication": [
         "associated_diseases"
@@ -301,8 +295,8 @@
       "non_pharmacological_interventions": [],
       "physiological_measurements": {
         "anthropometry": [
-          "weight",
-          "height"
+          "height",
+          "weight"
         ],
         "circulation_and_respiration": [
           "blood_pressure",

--- a/src/generate_cohort_json.py
+++ b/src/generate_cohort_json.py
@@ -184,6 +184,7 @@ def clean_dict(d):
             v = clean_dict(v)
         if isinstance(v, list):
             v = [clean_string(x) for x in v]
+            v = sorted(v)
         new[clean_string(k)] = v
     return new
 


### PR DESCRIPTION
"blood" has a child "fasting or non-fasting" which was previously excluded from the browser. When I reworked the script to generate the cohort data, I did not exclude this, which lead to the "sample_type" structure looking something like this:
```
"sample_type": {
  "blood": [],
  "general_variables": [
    "other_biosample_type"
  ]
}
```

When blood shouldn't have any children, and it should look like this:
```
"sample_type": [
  "other_biosample_type",
  "blood"
]
```

This caused the browser to not display any biosample types for the real cohorts:
![image](https://user-images.githubusercontent.com/16750150/93100942-f2461e00-f666-11ea-9799-e4f89e5c0006.png)

Since we never included "fasting or non-fasting" in the browser, should we consider removing it from GECKO?