### PR TITLE
Add script to generate ONE_OF_LIST values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,8 @@ all_mapping_suggest: src/mapping-suggest/mapping-suggest-qc.py $(MAP_SUGGEST)
 id_generation_%: $(MAP_SCRIPT_DIR)/id-generator-templates.py templates/%.tsv
 	python3 $< -t $(word 2,$^)
 	
-id_generation_cogs: $(MAP_SCRIPT_DIR)/id-generator-templates.py templates/cogs.tsv .cogs/metadata.tsv
-	python3 $< -t $(word 2,$^) -m .cogs/metadata.tsv
+id_generation_cogs: $(MAP_SCRIPT_DIR)/id-generator-templates.py templates/cogs.tsv .cogs/tracked/metadata.tsv
+	python3 $< -t $(word 2,$^) -m .cogs/tracked/metadata.tsv
 
 build/intermediate/%_mapping_suggestions_nlp.tsv: $(MAP_SCRIPT_DIR)/mapping-suggest-nlp.py \
 													templates/%.tsv $(GECKO_LEXICAL) \

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,12 @@ mapping_suggest_%: templates/%.tsv \
 					build/intermediate/%_mapping_suggestions_nlp.tsv
 	python3 $(MAP_SCRIPT_DIR)/merge-mapping-suggestions.py -t $< $(patsubst %, -s %, $(filter-out $<,$^))
 
+build/data-validation.tsv: $(MAP_SCRIPT_DIR)/create-data-validation.py build/terminology.tsv
+	python3 $^ $@
+
+cogs_apply: build/data-validation.tsv
+	cogs apply build/data-validation.tsv
+
 # Pipeline to build a the zooma dataset that stores the existing mappings
 
 .PHONY: .FORCE
@@ -345,6 +351,7 @@ automated_mapping:
 	make cogs_pull
 	make mapping_suggest_cogs
 	mv templates/cogs.tsv build/terminology.tsv
+	make cogs_apply
 	cogs push
 
 python_requirements: requirements.txt

--- a/src/mapping-suggest/create-data-validation.py
+++ b/src/mapping-suggest/create-data-validation.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import csv
+import re
+
+from argparse import ArgumentParser
+
+
+def main():
+	p = ArgumentParser()
+	p.add_argument("table")
+	p.add_argument("output")
+	args = p.parse_args()
+
+	dv_rows = []
+	with open(args.table, "r") as f:
+		reader = csv.DictReader(f, delimiter="\t")
+		row_num = 2
+		for row in reader:
+			suggested_cats = row["Suggested Categories"]
+			cat_names = []
+			for sc in suggested_cats.split(" | "):
+				match = re.search(r"[^ ]+ [A-Z]+:[0-9]+ (.+)", sc)
+				if match:
+					cat_names.append(match.group(1))
+			if cat_names:
+				dv_rows.append({"table": "terminology", "range": f"E{row_num}", "condition": "ONE_OF_LIST", "value": ", ".join(cat_names)})
+			row_num += 1
+
+	with open(args.output, "w") as f:
+		writer = csv.DictWriter(f, delimiter="\t", fieldnames=["table", "range", "condition", "value"])
+		writer.writeheader()
+		writer.writerows(dv_rows)
+
+
+if __name__ == '__main__':
+	main()

--- a/src/mapping-suggest/id-generator-templates.py
+++ b/src/mapping-suggest/id-generator-templates.py
@@ -55,7 +55,8 @@ if COL_TERM_ID in df.columns:
     df_nn = df[df[COL_TERM_ID].notnull()]
     ids = df_nn[df_nn[COL_TERM_ID].str.startswith(PREFIX)][COL_TERM_ID].tolist()
     ids = [int(i.replace(PREFIX, "")) for i in ids]
-    highest_current_id = max(ids)
+    if ids:
+        highest_current_id = max(ids)
 else:
     df[COL_TERM_ID] = ""
 


### PR DESCRIPTION
* Change `.cogs` tracked files to `.cogs/tracked` in `Makefile` (this is updated in the latest release of COGS)
* Fix an error in `id-generator-template.py` if there were no IDs
* Add `create-data-validation.py` and `cogs_apply` step to the `automated_mapping`

Unfortunately, `gspread-formatting` does not add the dropdown menu to the cell. If you hit ENTER or double click on a cell with the `ONE_OF_LIST`, it will show the list (in the correct order). To get the dropdown arrow, you need to select the range and go to Data -> Data Validation and select "Show dropdown list in cell".

This is potentially something we could add support for in COGS, but we will need to write our own version of the `gspread_formatting.set_data_validation_for_cell_range` function. This might be something to discuss in COGS, though. It will probably be a pain to implement, but it seems important...