### PR TITLE
Fix category sorting and add auto-assign feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,8 +347,8 @@ build/suggestions_%.tsv: templates/%.tsv \
 					build/intermediate/%_mapping_suggestions_nlp.tsv
 	python3 $(MAP_SCRIPT_DIR)/merge-mapping-suggestions.py -t $< $(patsubst %, -s %, $(filter-out $<,$^)) -o $@
 
-build/cogs-data-validation.tsv: $(MAP_SCRIPT_DIR)/create-data-validation.py build/terminology.tsv build/gecko_labels.tsv
-	python3 $^ $@
+build/cogs-data-validation.tsv build/cogs-info-table.tsv: $(MAP_SCRIPT_DIR)/create-data-validation.py build/terminology.tsv build/gecko_labels.tsv
+	python3 $^ build/cogs-data-validation.tsv build/cogs-info-table.tsv
 
 # Pipeline to build a the zooma dataset that stores the existing mappings
 
@@ -377,4 +377,5 @@ automated_mapping:
 	cp build/suggestions_cogs.tsv build/terminology.tsv
 	rm -f templates/cogs.tsv
 	make cogs-apply-data-validation
+	make cogs-apply-info-table
 	cogs push

--- a/src/mapping-suggest/create-data-validation.py
+++ b/src/mapping-suggest/create-data-validation.py
@@ -39,12 +39,14 @@ def main():
             # Parse suggested categories into a list
             cat_names = []
             for sc in suggested_cats.split(" | "):
+                auto_assigned = False
                 match = re.search(r"([^ ]+) [A-Z]+:[0-9]+ (.+)", sc)
                 if match:
                     gecko_cat = match.group(2)
                     cat_names.append(gecko_cat)
                     score = float(match.group(1))
-                    if score > 0.97:
+                    if score > 0.97 and not auto_assigned:
+                        auto_assigned = True
                         rewrite_table = True
                         row["GECKO Category"] = gecko_cat
                         problem_rows.append(

--- a/src/mapping-suggest/create-data-validation.py
+++ b/src/mapping-suggest/create-data-validation.py
@@ -61,7 +61,7 @@ def main():
                 cat_names.extend(gecko_copy)
             else:
                 # No suggested categories, add all the labels in alphabetical order
-                cat_names = sorted(gecko_copy, key=str.casefold)
+                cat_names = gecko_copy
             dv_rows.append(
                 {
                     "table": "terminology",

--- a/src/mapping-suggest/create-data-validation.py
+++ b/src/mapping-suggest/create-data-validation.py
@@ -47,7 +47,17 @@ def main():
                     if score > 0.97:
                         rewrite_table = True
                         row["GECKO Category"] = gecko_cat
-                        problem_rows.append({"ID": row_num, "table": "terminology", "cell": f"E{row_num}", "level": "INFO", "rule ID": "automatically_assigned_category", "rule name": f"this is an automatically assigned category based on a score of {score}", "value": gecko_cat})
+                        problem_rows.append(
+                            {
+                                "ID": row_num,
+                                "table": "terminology",
+                                "cell": f"E{row_num}",
+                                "level": "INFO",
+                                "rule ID": "automatically_assigned_category",
+                                "rule name": f"this is an automatically assigned category based on a score of {score}",
+                                "value": gecko_cat,
+                            }
+                        )
             updated_rows.append(row)
 
             # Then add them to the sheet
@@ -92,18 +102,36 @@ def main():
             )
             writer.writeheader()
             writer.writerows(updated_rows)
-    
+
     # Create a "problems table" to apply (not really a problem)
     # These are just the INFO messages for the auto-assigned categories
     with open(args.problem_table, "w") as f:
-        writer = csv.DictWriter(f, fieldnames=["ID", "table", "cell", "level", "rule ID", "rule name", "value", "fix", "instructions"], delimiter="\t", lineterminator="\n")
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "ID",
+                "table",
+                "cell",
+                "level",
+                "rule ID",
+                "rule name",
+                "value",
+                "fix",
+                "instructions",
+            ],
+            delimiter="\t",
+            lineterminator="\n",
+        )
         writer.writeheader()
         writer.writerows(problem_rows)
 
     # Write a data-validation sheet for `cogs apply`
     with open(args.data_validation, "w") as f:
         writer = csv.DictWriter(
-            f, fieldnames=["table", "range", "condition", "value"], delimiter="\t", lineterminator="\n"
+            f,
+            fieldnames=["table", "range", "condition", "value"],
+            delimiter="\t",
+            lineterminator="\n",
         )
         writer.writeheader()
         writer.writerows(dv_rows)


### PR DESCRIPTION
Resolves #114 
Resolves #112 

Updates the script that adds data validation to also pre-populate the GECKO category for scores > 0.97. Only the top (first found) value will be auto-assigned. The auto-assign includes an INFO message that the category was auto-assigned.

The INFO messages are missing blue backgrounds due to a bug in COGS: https://github.com/ontodev/cogs/pull/74