### PR TITLE
Fix PI lead and countries for KoGES

### DIFF
--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -228,15 +228,11 @@
     },
     "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
     "countries": [
-      "South Korea",
-      "Vietnam",
-      "Cambodia",
-      "Japan",
-      "China"
+      "South Korea"
     ],
     "current_enrollment": 235000,
     "enrollment_period": "2001:2013",
-    "pi_lead": "Sung Soo Kim",
+    "pi_lead": "Hyun Young Park",
     "questionnaire_survey_data": {
       "diseases": [
         "digestive_system",

--- a/data/member_cohorts.csv
+++ b/data/member_cohorts.csv
@@ -30,7 +30,7 @@ Japan Public Health Center-based Prospective Study for the Next Generation (JPHC
 "Kaiser Permanente Research Program on Genes, Environment, and Health",Catherine Schaefer,USA; Northern California,"210,000","500,000",2008: ongoing,Yes,Yes,Yes,Yes,Yes,http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx,Verified
 Korea Biobank Project,Jae-Pil Jeon and Changhoon Kim,Republic of Korea,"830,000",,:ongoing,Yes,No,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346,Verified
 Korean Cancer Prevention Study (KCPS-II Biobank),Sun Ha Jee,Korea,"156,701",,2004:2013,Yes,Yes,Yes,Yes,Yes,,Verified
-Korean Genome and Epidemiology Study (KoGES),Sung Soo Kim,"South Korea, Vietnam, Cambodia, Japan, China","235,000",,2001:2013,Yes,Yes,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264,Verified
+Korean Genome and Epidemiology Study (KoGES),Hyun Young Park,South Korea,"235,000",,2001:2013,Yes,Yes,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264,Verified
 "LifeGene (and sister cohort, EpiHealth)",Nancy Pedersen,Sweden,"51,300","300,000",2009:2016,Yes,Yes,Yes,Yes,Yes,https://www.lifegene.se/For-scientists/About-LifeGene/,Verified
 LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging),Terrence Simmons,"Europe (7), Australia, USA","235,000",,Varies by cohort,Yes,Yes,Yes,Yes,Yes,http://www.lifepathproject.eu/,Verified
 Malaysian Cohort,Rahman Jamal,Malaysia,"106,527",,2007:2013,Yes,Yes,Yes,Yes,Yes,http://mycohort.gov.my/site/,Verified


### PR DESCRIPTION
Change the PI lead and countries for KoGES to 'Hyun Young Park' and 'South Korea', respectively, as requested by the cohort.