### PR TITLE
Regenerate cohort data with data from IHCC Global

### DIFF
--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -19,9 +19,9 @@
       "South Africa"
     ],
     "current_enrollment": 130000,
-    "enrollment_period": "2000:ongoing",
+    "enrollment_period": "2000:Ongoing",
     "laboratory_measures": [],
-    "pi_lead": "Deenan Pillay",
+    "pi_lead": "Willem Hankom",
     "questionnaire_survey_data": {
       "diseases": [
         "circulatory_system",
@@ -270,7 +270,7 @@
       ]
     },
     "target_enrollment": null,
-    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264"
+    "website": "http://www.cdc.go.kr/contents.es?mid=a50401010100#1"
   },
   {
     "available_data_types": {

--- a/data/member_cohorts.csv
+++ b/data/member_cohorts.csv
@@ -1,68 +1,70 @@
-﻿Cohort Name,PI - Lead,Participating countries,Current Enrollment,Target Enrollment,Enrollment Period,Genomic Data,Environmental Data,Biospecimens,Phenotypic /Clinical Data,Data Sharing Potential,Study website,Member Data Verified
-23andMe,Joyce Tung,USA,"6,800,000",,2007:Ongoing,Yes,Yes,Yes,Yes,Yes,https://research.23andme.com/,Verified
-45 and Up Study,Martin McNamara,Australia,"267,153",,2006:2009,Yes,Yes,Yes,Yes,Yes,https://www.saxinstitute.org.au/our-work/45-up-study/,Verified
-Africa Health Research Institute (AHRI) Population Cohort,Deenan Pillay,South Africa,"130,000",130000,2000:ongoing,Yes,,Yes,Yes,Yes,https://www.ahri.org,Verified
-Apolipoprotein MORtality RISk study (AMORIS),Goran Walldius,Sweden,"812,073",,1985:1996,Yes,Yes,Yes,Yes,Yes,http://amoriscohort.imm.ki.se,Verified
-Biobank Japan,Yoshinori Murakami,Japan,"270,000","270,000",2003:2018,Yes,Yes,Yes,Yes,,https://biobankjp.org/english/index.html,Verified
-BioVU Vanderbilt,Dan Roden,USA,"244,000",,2007:ongoing,Yes,No,Yes,Yes,Yes,https://victr.vanderbilt.edu/pub/biovu/,Verified
-Canadian Partnership for Tomorrow Project (CPTP),Philip Awadalla,Canada,315000,,2008:ongoing,Yes,Yes,Yes,Yes,Yes,http://www.partnershipfortomorrow.ca,Verified
-Cancer Prevention Study II (CPS-II),Susan Gapstur,USA,"1,185,106",,1982:1983,Yes,Yes,,Yes,Yes,http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index,Verified
-Cancer Prevention Study II Nutrition Cohort,Susan Gapstur,USA,"184,194",,1992:1993,Yes,Yes,Yes,Yes,,http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study,Verified
-Children's Hospital of Philadelphia (CHOP) Biorepository,Hakon Hakonarson,"USA, Europe, South America, Canada, Saudi Arabia, Australia","500,000","1,000,000",2006:ongoing,Yes,Yes,Yes,Yes,Yes,https://caglab.org/index.php/for-researchers/biorepository.html,Verified
-China Kadoorie Biobank,Zhengming Chen and Liming Li,China,"512,891",,2004:2008,Yes,Yes,Yes,Yes,Yes,http://www.ckbiobank.org/site/,Verified
-China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project,Linxin Jiang,China,"2,000,000","4,000,000",2014:ongoing,No,Yes,Yes,Yes,Yes,,Verified
-Constances Project,Marie Zins,France,"210,000",,2012:2019,Yes,Yes,Yes,Yes,Yes,http://www.constances.fr/index_EN.php,Verified
-Danish National Birth Cohort,Mads Melbye,Denmark,"198,028",,1998:2002,Yes,Yes,Yes,Yes,,dnbc.dk,Verified
-East London Genes and Health,David van Heel,UK,"41,500","100,000",2015 - ongoing (planned end date 2023),Yes,Yes,Yes,Yes,Yes,http://www.genesandhealth.org/,Verified
-ELSA-Brasil,Paulo A. Lotufo,Brazil: six cities,"15,105",,2008:2010,Yes,Yes,Yes,Yes,Yes,www.elsa.org.br,Verified
-Environmental influences on Child Health Outcomes (ECHO) Cohort,Matt Gillman,USA,,"100,000",1980:ongoing,Yes,Yes,Yes,Yes,Yes,https://www.nih.gov/echo,Verified
-"EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)","Elio Riboli, Paul Brennan, and Marc Gunter","UK, Italy, France, Germany, Norway, Netherlands, Denmark, Spain, Greece, Sweden","521,000",,1992:1999,Yes,Yes,Yes,Yes,Yes,http://epic.iarc.fr/,Verified
-EpiHealth,Lars Lind and S√∂lve Elmst√•lh,Sweden,"25,000","25,000",2011:2018,Yes,No,Yes,Yes,Yes,https://www.epihealth.se/vad-ar-epihealth/,Verified
-Estonian Genome Project,Andres Metspalu,Estonia,"200,000","200,000",2002:2018,Yes,Yes,Yes,Yes,Yes,www.biobank.ee,Verified
-Finnish Maternity Cohort Serum Bank,Helj√§-Marja Surcel,Finland,"950,000",,1983:2016,Yes,No,Yes,No,Yes,www.esis.fi,Verified
-Generations Study (GS),Anthony Swerdlow,"England, Scotland, Wales, Northern Ireland, Isle of Man, Channel Islands","113,000","100,000",2003:2015,Yes,No,Yes,Yes,Yes,http://www.breakthroughgenerations.org.uk/home,Verified
-"Genomics England / 100,000 Genomes Project",Mark Caulfield,England,"100,000","500,000",2013:2018,Yes,No,Yes,Yes,Yes,https://www.genomicsengland.co.uk/,Verified
-Golestan Cohort Study,"Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",Iran,"50,000",,2004:2008,No,Yes,Yes,Yes,Yes,https://dceg2.cancer.gov/gemshare/,Verified
-Healthy Nevada,Joe Grzymski,US,"35,000","250,000",2016:ongoing,Yes,Yes,,Yes,Yes,Healthynv.org,Verified
-Israel Genome Project,Gad Rennert,Israel,"140,000",,:ongoing,Yes,No,Yes,Yes,,,Verified
-Japan Public Health Center-based Prospective Study (JPHC),Shoichiro Tsugane,Japan,"130,000",,1990:1994,Yes,Yes,Yes,Yes,Yes,http://epi.ncc.go.jp/en/jphc/,Verified
-Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT),Shoichiro Tsugane,Japan,"115,000",,2011:2016,No,,Yes,Yes,Yes,https://epi.ncc.go.jp/jphcnext/en/index.html,Verified
-"Kaiser Permanente Research Program on Genes, Environment, and Health",Catherine Schaefer,USA; Northern California,"210,000","500,000",2008: ongoing,Yes,Yes,Yes,Yes,Yes,http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx,Verified
-Korea Biobank Project,Jae-Pil Jeon and Changhoon Kim,Republic of Korea,"830,000",,:ongoing,Yes,No,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346,Verified
-Korean Cancer Prevention Study (KCPS-II Biobank),Sun Ha Jee,Korea,"156,701",,2004:2013,Yes,Yes,Yes,Yes,Yes,,Verified
-Korean Genome and Epidemiology Study (KoGES),Hyun Young Park,South Korea,"235,000",,2001:2013,Yes,Yes,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264,Verified
-"LifeGene (and sister cohort, EpiHealth)",Nancy Pedersen,Sweden,"51,300","300,000",2009:2016,Yes,Yes,Yes,Yes,Yes,https://www.lifegene.se/For-scientists/About-LifeGene/,Verified
-LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging),Terrence Simmons,"Europe (7), Australia, USA","235,000",,Varies by cohort,Yes,Yes,Yes,Yes,Yes,http://www.lifepathproject.eu/,Verified
-Malaysian Cohort,Rahman Jamal,Malaysia,"106,527",,2007:2013,Yes,Yes,Yes,Yes,Yes,http://mycohort.gov.my/site/,Verified
-Maule Cohort (MAUCO Study),Catterina Ferreccio,Chile,"9,200","10,000",2015:2018,Yes,Yes,Yes,Yes,Yes,http://www.accdis.cl/eng/en/,Verified
-Mexico City Prospective Study,"Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",Mexico,"159,755",,1998:2004,"No
-",No,Yes,Yes,Yes,https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico,Verified
-Million Veteran Program,Mike Gaziano,USA,"785,000","1,000,000",2011:ongoing,Yes,Yes,Yes,Yes,,http://www.research.va.gov/mvp/,Verified
-Million Women Study,Valerie Beral,"England, Scotland","1,320,000",,1996:2001,,No,Yes,Yes,Yes,http://www.millionwomenstudy.org/introduction/,Verified
-"Multiethnic Cohort Study (MEC, NCI)",Loic Le Marchand,USA (Hawaii; California),"215,251",,1993:1997,Yes,Yes,Yes,Yes,Yes,https://www.uhcancercenter.org/mec,Verified
-MyCode Community Health Initiative,David H Ledbetter,USA,"252,160","250,000",2007:ongoing,Yes,Yes,Yes,Yes,Yes,https://www.geisinger.org/mycode,Verified
-Netherlands Twin Registry,Dorret Boomsma,Netherlands,"275,000",,1987:ongoing,Yes,Yes,Yes,Yes,Yes,http://www.tweelingenregister.org/en/,Verified
-Newfoundland 100K Genome Project / Sequence Bio,Michael Phillips,Canada (Province of Newfoundland and Labrador),"520,000",,2018:ongoing,Yes,No,Yes,Yes,Yes,https://www.sequencebio.com/,Verified
-"NHS (Nurses' Health Study, NCI)","Meir Stampfer, Rulla Tamimi",USA,"121,700",,1976:1976,Yes,Yes,Yes,Yes,Yes,www.nurseshealthstudy.org,Verified
-"NHSII (Nurses' Health Study II, NCI)","Walter Willett, Heather Eliassen",USA,"116,430",,1989:1989,Yes,Yes,Yes,Yes,Yes,www.nurseshealthstudy.org,Verified
-NICCC,Rennert Gad,,"40,000",,:ongoing,Yes,Yes,Yes,Yes,Yes,,Verified
-Northern Sweden Health and Disease Study,Beatrice Melin,Sweden,"135,000",,1985 : ongoing,Yes,No,Yes,Yes,,http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/,Verified
-Norwegian Family Based Life Course Study,√òyvind N√¶ss,Norway,"5,266,270",,1960:2011,Yes,Yes,Yes,Yes,Yes,,Verified
-Norwegian Mother and Child Cohort Study (MoBa),Per Magnus,Norway,"284,000",,1999:2008,Yes,Yes,Yes,Yes,Yes,https://www.fhi.no/en/studies/moba/,Verified
-Pakistan Genomic Resource (PGR),Danish Salaheen,Pakistan,"150,000","1,000,000",,Yes,,,,,https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR),Verified
-PERSIAN Cohort Study,"Reza Malekzadeh,  Hossein Poustchi,  Farin Kamangar,  Arash Etemadi",Iran,"180,000",,2014:ongoing,No,Yes,Yes,Yes,Yes,http://persiancohort.com,Verified
-"PLCO (Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial, NCI)",Paul Pinsky and Neal Freedman,USA,"154,907",,1993:2001,Yes,Yes,Yes,Yes,Yes,http://prevention.cancer.gov/major-programs/prostate-lung-colorectal,Verified
-Qatar Genome Project,Hamdi Mbarek,Qatar,"15,000","300,000",2015: ongoing,,,Yes,Yes,,https://qatargenome.org.qa/,Verified
-SAPRIN (South African Population Research Infrastructure Network),Kobus Herbst,South Africa,"350,000",700000,1993:ongoing,No,No,Yes,Yes,Yes,http://saprin.mrc.ac.za/,Verified
-Saudi Human Genome Program,Sultan AlSudiri and Malak Abedalthagafi,Saudi Arabia,"100,000",,,No,No,Yes,,Yes,http://shgp.kacst.edu.sa/site/,Verified
-Saudi National Biobank,Ada Al-Qunaibet,Saudi Arabia,"2,000",,:ongoing,No,No,Yes,Yes,Yes,http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx,Verified
-Shanghai Men and Women's Health Study (2 cohorts),Wei Zheng,"Shanghai, China","136,000",,1996:2000,,No,Yes,Yes,,http://www.mc.vanderbilt.edu/swhs-smhs/,Verified
-Singapore National Precision Medicine Program,Patrick Tan and E Shyong Tai,Singapore,"10,000","1,000,000",10 year program,Yes,No,Yes,Yes,Yes,,Verified
-South(east) Asian Cohorts - NETWORK,Rajiv Chowdhury,"Bangladesh, Malaysia, Sri Lanka","75,000","150,000",2010:ongoing,Yes,Yes,Yes,Yes,Yes,http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/,Verified
-Taiwan Biobank,Te-Chang Lee and Chung-ke Chang,Taiwan,"118,548","200,000",2012:ongoing,Yes,No,Yes,Yes,Yes,https://www.twbiobank.org.tw/new_web/,Verified
-U.S. Precision Medicine Initiative / All of Us,Stephanie Devaney,USA,"191,105","1,000,000",2018:ongoing,Yes,Yes,Yes,Yes,Yes,https://allofus.nih.gov/,Verified
-UK Biobank,Rory Collins,"England, Scotland, Wales","502,713","500,000",2006:2010,Yes,Yes,Yes,Yes,Yes,http://www.ukbiobank.ac.uk/,Verified
-UK Blood Donor Cohorts,Emanuele Di Angelantonio and John Danesh,UK,"100,000","350,000",2012:ongoing,Yes,Yes,Yes,Yes,yes,http://www.intervalstudy.org.uk/,Verified
-UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women‚Äôs Cohort UKLWC,Usha Menon,"England, Wales, Northern Ireland","202,638",,2001:2005,No,No,Yes,Yes,Yes,http://www.isrctn.com/ISRCTN22488978,Verified
-Vorarlberg Health Monitoring and Promotion Programme (VHM&PP),"Hans Concin, Gabriele Nagel, Hanno Ulmer",Austria,"180,000",,1985:2014,No,Yes,Yes,Yes,Yes,http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs,Verified
-WHI (Women's Health Initiative),Garnet Anderson,USA,"161,808",,1993:1998,Yes,Yes,Yes,Yes,Yes,https://deino.whiops.org/go/www.whi.org~ssl/SitePages/WHI%20Home.aspx,Verified
+Cohort Name,PI/Lead,Regions,Enroll Start,Enroll End,Enrolled,Target Enrollment,Genomic Data ,Env. Data,Bio specimens,Phenotypic Data,Data Sharing,Study website,Date Verified
+23andMe,Joyce Tung,USA,2007,Ongoing,"6,800,000.00",,Yes,Yes,Yes,Yes,Yes,https://research.23andme.com/,Oct-19
+45 and Up Study,Martin McNamara,Australia,2006,2009,"267,153.00",,Yes,Yes,Yes,Yes,Yes,https://www.saxinstitute.org.au/our-work/45-up-study/,Oct-19
+Africa Health Research Institute (AHRI) Population Cohort,Willem Hankom,South Africa,2000,Ongoing,"130,000.00","130,000.00",Yes,,Yes,Yes,Yes,https://www.ahri.org,Oct-19
+Apolipoprotein MORtality RISk study (AMORIS),Goran Walldius,Sweden,1985,1996,"812,073.00",,Yes,Yes,Yes,Yes,Yes,http://amoriscohort.imm.ki.se,Oct-19
+Biobank Japan,Yoshinori Murakami,Japan,2003,2018,"270,000.00","270,000.00",Yes,Yes,Yes,Yes,,https://biobankjp.org/english/index.html,Oct-19
+BioVU Vanderbilt,Dan Roden,USA,2007,Ongoing,"244,000.00",,Yes,No,Yes,Yes,Yes,https://victr.vanderbilt.edu/pub/biovu/,Oct-19
+California Teachers Study (CTS),"Jim Lacey, Elena Martinez",USA,1995,1996,"133,477.00",,Yes,Yes,Yes,Yes,Yes,https://www.calteachersstudy.org/,
+Canadian Partnership for Tomorrow's Health (CanPath),Philip Awadalla,Canada,2008,ongoing,330000,,Yes,Yes,Yes,Yes,Yes,https://canpath.ca/,Oct-19
+Cancer Prevention Study II (CPS-II),Eric Jacobs,USA,1982,1983,,,Yes,Yes,,Yes,Yes,http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index,Oct-19
+Cancer Prevention Study II Nutrition Cohort,Alpa Patel,USA,1992,1993,,,Yes,Yes,Yes,Yes,,http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study,Oct-19
+Children's Hospital of Philadelphia (CHOP) Biorepository,Hakon Hakonarson,"USA, Europe, South America, Canada, Saudi Arabia, Australia",2006,ongoing,"500,000.00","1,000,000.00",Yes,Yes,Yes,Yes,Yes,https://www.research.chop.edu/biorepository-core,Oct-19
+China Kadoorie Biobank,"Zhengming Chen,Liming Li",China,2004,2008,"512,891.00",,Yes,Yes,Yes,Yes,Yes,http://www.ckbiobank.org/site/,Oct-19
+China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project,Linxin Jiang,China,2014,ongoing,"2,000,000.00","4,000,000.00",No,Yes,Yes,Yes,Yes,https://pubmed.ncbi.nlm.nih.gov/26729395/,Oct-19
+Constances Project,Marie Zins,France,2012,2019,"210,000.00",,Yes,Yes,Yes,Yes,Yes,http://www.constances.fr/index_EN.php,Oct-19
+Danish National Birth Cohort,Mads Melbye,Denmark,1998,2002,"198,028.00",,Yes,Yes,Yes,Yes,,dnbc.dk,Oct-19
+East London Genes and Health,David van Heel,UK,2015,ongoing,"41,500.00","100,000.00",Yes,Yes,Yes,Yes,Yes,http://www.genesandhealth.org/,Oct-19
+ELSA-Brasil,Paulo A. Lotufo,Brazil,2008,2010,"15,105.00",,Yes,Yes,Yes,Yes,Yes,www.elsa.org.br,Oct-19
+Environmental influences on Child Health Outcomes (ECHO) Cohort,Matt Gillman,USA,1980,ongoing,,"100,000.00",Yes,Yes,Yes,Yes,Yes,https://www.nih.gov/echo,Oct-19
+"EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)","Elio Riboli, Paul Brennan, Marc Gunter","UK, Italy, France, Germany, Norway, Netherlands, Denmark, Spain, Greece, Sweden",1992,2023,"521,000.00",,Yes,Yes,Yes,Yes,Yes,http://epic.iarc.fr/,Oct-19
+EpiHealth,"Lars Lind, S�lve Elmst�lh",Sweden,2011,2018,"25,000.00","25,000.00",Yes,No,Yes,Yes,Yes,https://www.epihealth.se/vad-ar-epihealth/,Oct-19
+Estonian Genome Project,Andres Metspalu,Estonia,2002,2018,"200,000.00","200,000.00",Yes,Yes,Yes,Yes,Yes,www.biobank.ee,Oct-19
+Finnish Maternity Cohort Serum Bank,Helj�-Marja Surcel,Finland,1983,2016,"950,000.00",,Yes,No,Yes,No,Yes,www.esis.fi,Oct-19
+Geisinger Cohort - MyCode Community Health Initiative,"Natasha Strande, David H Ledbetter",USA,2007,ongoing,"252,160.00","250,000.00",Yes,Yes,Yes,Yes,Yes,https://www.geisinger.org/precision-health/mycode,Oct-19
+Generations Study (GS),Anthony Swerdlow,"UK, England, Scotland, Wales, Northern Ireland, Isle of Man, Channel Islands",2003,2015,"113,000.00","100,000.00",Yes,No,Yes,Yes,Yes,http://www.breakthroughgenerations.org.uk/home,Oct-19
+"Genomics England / 100,000 Genomes Project",Mark Caulfield,England,2013,2018,"100,000.00","500,000.00",Yes,No,Yes,Yes,Yes,https://www.genomicsengland.co.uk/,Oct-19
+German National Cohort (NAKO),Annette Peters,Germany,2014,2019,"205,217.00",,No,Yes,Yes,Yes,,https://nako.de/,Oct-19
+Golestan Cohort Study,"Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",Iran,2004,2008,"50,000.00",,No,Yes,Yes,Yes,Yes,https://dceg2.cancer.gov/gemshare/,Oct-19
+Healthy Nevada,Joe Grzymski,USA,2016,ongoing,"35,000.00","250,000.00",Yes,Yes,,Yes,Yes,Healthynv.org,Oct-19
+Israel Genome Project,Gad Rennert,Israel,,ongoing,"140,000.00",,Yes,No,Yes,Yes,,https://www.academy.ac.il/Index3/Entry.aspx?nodeId=842&entryId=18745,Oct-19
+Japan Public Health Center-based Prospective Study (JPHC),Shoichiro Tsugane,Japan,1990,1994,"130,000.00",,Yes,Yes,Yes,Yes,Yes,http://epi.ncc.go.jp/en/jphc/,Oct-19
+Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT),Shoichiro Tsugane,Japan,2011,2016,"115,000.00",,No,,Yes,Yes,Yes,https://epi.ncc.go.jp/jphcnext/en/index.html,Oct-19
+"Kaiser Permanente Research Program on Genes, Environment, and Health",Catherine Schaefer,"USA, California",2008,ongoing,"210,000.00","500,000.00",Yes,Yes,Yes,Yes,Yes,http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx,Oct-19
+Korea Biobank Project,"Jae-Pil Jeon,Changhoon Kim",Republic of Korea,,ongoing,"830,000.00",,Yes,No,Yes,Yes,Yes,http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346,Oct-19
+Korean Cancer Prevention Study (KCPS-II Biobank),Sun Ha Jee,Korea,2004,2013,"156,701.00",,Yes,Yes,Yes,Yes,Yes,https://pubmed.ncbi.nlm.nih.gov/29186422/,Oct-19
+Korean Genome and Epidemiology Study (KoGES),Hyun Young Park,South Korea,2001,2013,"235,000.00",,Yes,Yes,Yes,Yes,Yes,http://www.cdc.go.kr/contents.es?mid=a50401010100#1,Oct-19
+"LifeGene (and sister cohort, EpiHealth)",Nancy Pedersen,Sweden,2009,2016,"51,300.00","300,000.00",Yes,Yes,Yes,Yes,Yes,https://www.lifegene.se/For-scientists/About-LifeGene/,Oct-19
+LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging),Terrence Simmons,"Europe, Australian, USA",,,"235,000.00",,Yes,Yes,Yes,Yes,Yes,http://www.lifepathproject.eu/,Oct-19
+Malaysian Cohort,Rahman Jamal,Malaysia,2007,2013,"106,527.00",,Yes,Yes,Yes,Yes,Yes,http://mycohort.gov.my/site/,Oct-19
+Maule Cohort (MAUCO Study),Catterina Ferreccio,Chile,2015,2018,"9,200.00","10,000.00",Yes,Yes,Yes,Yes,Yes,http://www.accdis.cl/eng/en/,Oct-19
+Mexico City Prospective Study,"Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, Roberto Tapia-Conyer",Mexico,2998,2004,"159,755.00",,No,No,Yes,Yes,Yes,https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico,Oct-19
+Million Veteran Program,Mike Gaziano,USA,2011,ongoing,"785,000.00","1,000,000.00",Yes,Yes,Yes,Yes,,http://www.research.va.gov/mvp/,Oct-19
+Million Women Study,Valerie Beral,"England, Scotland",1996,2001,"1,320,000.00",,,No,Yes,Yes,Yes,http://www.millionwomenstudy.org/introduction/,Oct-19
+"Multiethnic Cohort Study (MEC, NCI)",Loic Le Marchand,"USA, Hawaii, California",1993,1997,"215,251.00",,Yes,Yes,Yes,Yes,Yes,https://www.uhcancercenter.org/mec,Oct-19
+Netherlands Twin Registry,Dorret Boomsma,Netherlands,1987,ongoing,"275,000.00",,Yes,Yes,Yes,Yes,Yes,http://www.tweelingenregister.org/en/,Oct-19
+Newfoundland 100K Genome Project / Sequence Bio,Michael Phillips,"Canada, Province of Newfoundland and Labrador",2018,ongoing,"520,000.00",,Yes,No,Yes,Yes,Yes,https://www.sequencebio.com/,Oct-19
+"NHS (Nurses' Health Study, NCI)","Meir Stampfer, Rulla Tamimi",USA,1976,1976,"121,700.00",,Yes,Yes,Yes,Yes,Yes,https://www.nurseshealthstudy.org/,Oct-19
+"NHSII (Nurses' Health Study II, NCI)","Walter Willett, Heather Eliassen",USA,1989,1989,"116,430.00",,Yes,Yes,Yes,Yes,Yes,https://www.nurseshealthstudy.org/,Oct-19
+NICCC,Rennert Gad,,,ongoing,"40,000.00",,Yes,Yes,Yes,Yes,Yes,https://www.natureindex.com/institution-outputs/israel/clalit-national-israeli-cancer-control-center-niccc/5c34466670f236567a67603c,Oct-19
+Northern Sweden Health and Disease Study,Beatrice Melin,Sweden,1985,ongoing,"135,000.00",,Yes,No,Yes,Yes,,http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/,Oct-19
+Norwegian Family Based Life Course Study,�yvind N�ss,Norway,1960,2011,"5,266,270.00",,Yes,Yes,Yes,Yes,Yes,https://pubmed.ncbi.nlm.nih.gov/22735991/,Oct-19
+Norwegian Mother and Child Cohort Study (MoBa),Per Magnus,Norway,1999,2008,"284,000.00",,Yes,Yes,Yes,Yes,Yes,https://www.fhi.no/en/studies/moba/,Oct-19
+Pakistan Genomic Resource (PGR),Danish Salaheen,Pakistan,,,"150,000.00","1,000,000.00",Yes,,,,,https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR),Oct-19
+PERSIAN Cohort Study,"Reza Malekzadeh, Hossein Poustchi, Farin Kamangar, Arash Etemadi",Iran,2014,ongoing,"180,000.00",,No,Yes,Yes,Yes,Yes,http://persiancohort.com,Oct-19
+"PLCO (Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial, NCI)","Paul Pinsky, Neal Freedman",USA,1993,2001,"154,907.00",,Yes,Yes,Yes,Yes,Yes,http://prevention.cancer.gov/major-programs/prostate-lung-colorectal,Oct-19
+Qatar Genome Project,Hamdi Mbarek,Qatar,2015,ongoing,"15,000.00","300,000.00",,,Yes,Yes,,https://qatargenome.org.qa/,Oct-19
+SAPRIN (South African Population Research Infrastructure Network),Kobus Herbst,South Africa,1993,ongoing,"350,000.00","700,000.00",No,No,Yes,Yes,Yes,http://saprin.mrc.ac.za/,Oct-19
+Saudi Human Genome Program,"Sultan AlSudiri, Malak Abedalthagafi",Saudi Arabia,,,"100,000.00",,No,No,Yes,,Yes,http://shgp.kacst.edu.sa/site/,Oct-19
+Saudi National Biobank,Jahad Alghamdi,Saudi Arabia,,ongoing,"2,000.00",,No,No,Yes,Yes,Yes,http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx,Oct-19
+Shanghai Men and Women's Health Study (2 cohorts),Wei Zheng,"Shanghai, China",1996,2000,"136,000.00",,,No,Yes,Yes,,,Oct-19
+Singapore National Precision Medicine Program,"Patrick Tan, E Shyong Tai",Singapore,,,"10,000.00","1,000,000.00",Yes,No,Yes,Yes,Yes,,Oct-19
+South(east) Asian Cohorts - NETWORK,Rajiv Chowdhury,"Bangladesh, Malaysia, Sri Lanka",2010,ongoing,"75,000.00","150,000.00",Yes,Yes,Yes,Yes,Yes,,Oct-19
+Taiwan Biobank,"Te-Chang Lee, Chung-ke Chang",Taiwan,2012,ongoing,"118,548.00","200,000.00",Yes,No,Yes,Yes,Yes,https://www.twbiobank.org.tw/new_web/,Oct-19
+Tr�ndelag Health Study (HUNT),Steinar Krokstad,Norway,1984,2019,248000,,Yes,Yes,Yes,Yes,Yes,http://www.ntnu.edu/hunt,May-19
+U.S. Precision Medicine Initiative / All of Us,Stephanie Devaney,USA,2018,ongoing,"191,105.00","1,000,000.00",Yes,Yes,Yes,Yes,Yes,https://allofus.nih.gov/,Oct-19
+UK Biobank,Rory Collins,"England, Scotland, Wales",2006,2010,"502,713.00","500,000.00",Yes,Yes,Yes,Yes,Yes,http://www.ukbiobank.ac.uk/,Oct-19
+UK Blood Donor Cohorts,"Emanuele Di Angelantonio, John Danesh",UK,2012,ongoing,,,Yes,Yes,Yes,Yes,Yes,http://www.intervalstudy.org.uk/,Oct-19
+UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women’s Cohort UKLWC,Usha Menon,"England, Wales, Northern Ireland",2001,2005,"202,638.00",,No,No,Yes,Yes,Yes,http://www.isrctn.com/ISRCTN22488978,Oct-19
+Vorarlberg Health Monitoring and Promotion Programme (VHM&PP),"Hans Concin, Gabriele Nagel, Hanno Ulmer",Austria,1985,2014,"180,000.00",,No,Yes,Yes,Yes,Yes,http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs,Oct-19
+WHI (Women's Health Initiative),Garnet Anderson,USA,1993,1998,"161,808.00",,Yes,Yes,Yes,Yes,Yes,https://www.whi.org/SitePages/WHI%20Home.aspx,Oct-19

--- a/src/generate_cohort_json.py
+++ b/src/generate_cohort_json.py
@@ -11,7 +11,7 @@ bottom_level = []
 def main():
     parser = ArgumentParser(description="Create JSON for IHCC cohort browser")
     parser.add_argument(
-        "cohorts_csv", type=FileType("r"), help="IHCC member cohort details"
+        "cohorts_csv", type=FileType("r", encoding='ISO-8859-1'), help="IHCC member cohort details"
     )
     parser.add_argument(
         "cohorts_metadata",
@@ -38,10 +38,10 @@ def main():
         countries = [x.strip() for x in row[2].split(",")]
 
         # Get available datatypes
-        genomic = row[6]
-        environment = row[7]
-        biospecimen = row[8]
-        clinical = row[9]
+        genomic = row[7]
+        environment = row[8]
+        biospecimen = row[9]
+        clinical = row[10]
         datatypes = {
             "genomic_data": False,
             "environmental_data": False,
@@ -57,27 +57,37 @@ def main():
         if clinical == "Yes":
             datatypes["phenotypic_clinical_data"] = True
 
-        cur_enroll = row[3].replace(",", "").strip()
-        target_enroll = row[4].replace(",", "").strip()
+        cur_enroll = row[5].replace(",", "").strip()
+        target_enroll = row[6].replace(",", "").strip()
 
         if cur_enroll == "":
             cur_enroll = None
         else:
-            cur_enroll = int(cur_enroll)
+            cur_enroll = int(float(cur_enroll))
 
         if target_enroll == "":
             target_enroll = None
         else:
-            target_enroll = int(target_enroll)
+            target_enroll = int(float(target_enroll))
+
+        enroll_start = row[3]
+        enroll_end = row[4]
+        if not enroll_start and not enroll_end:
+            enroll_period = None
+        elif enroll_end and not enroll_start:
+            enroll_period = enroll_end
+        else:
+            enroll_period = f"{enroll_start}:{enroll_end}"
+
 
         cohort_data[row[0]] = {
             "cohort_name": row[0],
             "countries": countries,
             "pi_lead": row[1],
-            "website": row[11],
+            "website": row[12],
             "current_enrollment": cur_enroll,
             "target_enrollment": target_enroll,
-            "enrollment_period": row[5],
+            "enrollment_period": enroll_period,
             "available_data_types": datatypes,
         }
 

--- a/src/generate_cohort_json.py
+++ b/src/generate_cohort_json.py
@@ -31,17 +31,16 @@ def main():
     gecko_hierarchy = build_hierarchy(gecko)
 
     cohort_data = {}
-    reader = csv.reader(cohorts_file)
-    next(reader)
+    reader = csv.DictReader(cohorts_file)
     for row in reader:
         # Parse countries
-        countries = [x.strip() for x in row[2].split(",")]
+        countries = [x.strip() for x in row["Regions"].split(",")]
 
         # Get available datatypes
-        genomic = row[7]
-        environment = row[8]
-        biospecimen = row[9]
-        clinical = row[10]
+        genomic = row["Genomic Data "]
+        environment = row["Env. Data"]
+        biospecimen = row["Bio specimens"]
+        clinical = row["Phenotypic Data"]
         datatypes = {
             "genomic_data": False,
             "environmental_data": False,
@@ -57,8 +56,8 @@ def main():
         if clinical == "Yes":
             datatypes["phenotypic_clinical_data"] = True
 
-        cur_enroll = row[5].replace(",", "").strip()
-        target_enroll = row[6].replace(",", "").strip()
+        cur_enroll = row["Enrolled"].replace(",", "").strip()
+        target_enroll = row["Target Enrollment"].replace(",", "").strip()
 
         if cur_enroll == "":
             cur_enroll = None
@@ -70,8 +69,8 @@ def main():
         else:
             target_enroll = int(float(target_enroll))
 
-        enroll_start = row[3]
-        enroll_end = row[4]
+        enroll_start = row["Enroll Start"]
+        enroll_end = row["Enroll End"]
         if not enroll_start and not enroll_end:
             enroll_period = None
         elif enroll_end and not enroll_start:
@@ -80,11 +79,11 @@ def main():
             enroll_period = f"{enroll_start}:{enroll_end}"
 
 
-        cohort_data[row[0]] = {
-            "cohort_name": row[0],
+        cohort_data[row["Cohort Name"]] = {
+            "cohort_name": row["Cohort Name"],
             "countries": countries,
-            "pi_lead": row[1],
-            "website": row[12],
+            "pi_lead": row["PI/Lead"],
+            "website": row["Study website"],
             "current_enrollment": cur_enroll,
             "target_enrollment": target_enroll,
             "enrollment_period": enroll_period,
@@ -100,11 +99,9 @@ def main():
             continue
         gecko_cats = []
         with open(file_name, "r") as f:
-            reader = csv.reader(f, delimiter="\t")
-            # Skip header
-            next(reader)
+            reader = csv.DictReader(f, delimiter="\t")
             for row in reader:
-                gecko_cat = row[4]
+                gecko_cat = row["GECKO Category"]
                 if gecko_cat.strip() == "":
                     continue
                 gecko_cats.extend(gecko_cat.split("|"))


### PR DESCRIPTION
I downloaded a new version of the member cohort data from https://ihccglobal.org/membercohorts/ and regenerated `data/cohort-data.json` from this. The only changes are the PI update for AHRI and a website change for KoGES (retrieved from [here](https://ihccglobal.org/cohort/korean-genome-and-epidemiologyl-study-koges/))

A few changes to note, which I updated my script to handle:
* There are some fixed special characters that changed the encoding of the file (e.g., "Øyvind Næss" was previously "�yvind N�ss" with unknown characters)
* The websites are no longer included, I had to manually copy these over and then update a few new ones (note that the websites can be found by clicking on the cohort on the IHCC Global site, so the data is stored somewhere...)
* "Enrollment Period" was split into two columns: start and end


