### PR TITLE
Workflow fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ clean:
 all: $(TREES) $(TABLES)
 all: build/index.html
 all: data/cohort-data.json
-all: data/member_cohorts.csv
+all: build/member_cohorts.csv
 all: owl
 all: $(ZOOMA_DATASET)
 all: $(OLS_CONFIG)

--- a/src/create_index.py
+++ b/src/create_index.py
@@ -16,9 +16,8 @@ def main():
 
     items = []
     for cohort, item in data.items():
-        short_name = item['id'].lower()
+        short_name = cohort.lower()
         item['id'] = short_name
-        item['name'] = cohort
         item['owl'] = '{0}.owl'.format(short_name)
         item['terms'] = '{0}.html'.format(short_name)
         item['tree'] = '{0}-tree.html'.format(short_name)

--- a/src/index.html.jinja2
+++ b/src/index.html.jinja2
@@ -14,7 +14,7 @@
         <tbody>
         {% for item in items %}
         <tr>
-            <td>{{ item.name }}</td>
+            <td>{{ item.cohort_name }}</td>
             <td><a href="{{ item.tree }}">Browse {{ item.id }}.owl</a></td>
             <td><a href="{{ item.terms }}">View terms from {{ item.id }}</a></td>
             <td><a href="{{ item.owl }}">Download {{ item.id }}.owl</a></td>


### PR DESCRIPTION
Two fixes to workflow:
* `data/member_cohorts.csv` was replaced by `build/member_cohorts.csv`
* For rendering the index Jinja template, the `name` is already stored as `cohort_name` in the JSON and the cohort ID is the key