### PR TITLE
2021-06-30 Workflow Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ build/%-tree.html: build/%.owl | build/robot-tree.jar
 	--input $< \
 	--tree $@
 
-build/%.html: build/%.owl build/%.tsv | src/prefixes.json build/robot.jar
-	$(ROBOT) validate \
+build/%.html: build/%.owl build/%.tsv | src/prefixes.json build/robot-validate.jar
+	java -jar build/robot-validate.jar validate \
 	--input $< \
 	--table $(word 2,$^) \
 	--skip-row 2 \
@@ -202,7 +202,7 @@ build/member_cohorts.csv: src/convert_metadata.py data/metadata.json
 ### COGS Set Up & Tasks
 
 # The branch name should be the namespace for the new cohort
-BRANCH := $(shell git branch --show-current)
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 init-cogs: .cogs
 
@@ -233,6 +233,9 @@ build/robot.jar: | build
 
 build/robot-tree.jar: | build
 	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/tree-view/lastSuccessfulBuild/artifact/bin/robot.jar
+
+build/robot-validate.jar: | build
+	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/master/106/artifact/bin/robot.jar
 
 build/intermediate/properties.owl: templates/properties.tsv | build/intermediate build/robot.jar
 	$(ROBOT) template --template $< --output $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ scikit-learn
 numpy
 jsonschema
 openpyxl
-git+https://github.com/ontodev/cogs.git@small-fixes
-
+ontodev-cogs==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ pandas
 rdflib
 xlsx2csv
 requests
-ontodev-cogs
 pyyaml
 scikit-learn
 numpy
 jsonschema
+openpyxl
+git+https://github.com/ontodev/cogs.git@small-fixes
+

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -133,7 +133,6 @@ def main():
             f"IHCC Data Harmonization: {cohort_id}",
             user=args["admin_google_id"],
             role="writer",
-            credentials="credentials.json"
         )
         cogs.add(instructions, title="Instructions")
         cogs.add(metadata, title="Metadata")

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -132,7 +132,8 @@ def main():
         cogs.init(
             f"IHCC Data Harmonization: {cohort_id}",
             user=args["admin_google_id"],
-            role="writer"
+            role="writer",
+            credentials="credentials.json"
         )
         cogs.add(instructions, title="Instructions")
         cogs.add(metadata, title="Metadata")


### PR DESCRIPTION
Some updates to the data harmonization workflow:
* Add `robot-validate.jar` from older ROBOT Jenkins build, as we have removed `validate` from ROBOT
* Replace `git branch --show-current`; Docker seems to be using an older version of git that doesn't have this, but the new command produces the exact same result
* Switch to a GitHub branch for COGS to fix an issue with hyperlinks described here: https://github.com/ontodev/cogs/issues/127