### PR TITLE
Switch to gizmos in workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,8 @@ build/%.html: build/%.db
 
 # Top-level cohort data
 
-build/gecko_structure.json: build/gecko.owl | build/robot-tree.jar src/prefixes.json
-	java -jar build/robot-tree.jar \
-	--prefixes src/prefixes.json \
-	remove --input $< \
-	--term GECKO:0000019 \
-	tree \
-	--format json \
-	--tree $@
+build/gecko_structure.json: src/get_gecko_structure.py build/gecko.db
+	python3 $^ > $@
 
 data/cohort-data.json: src/generate_cohort_json.py data/metadata.json build/gecko_structure.json $(TEMPLATES)
 	python3 $(filter-out $(TEMPLATES),$^) $@
@@ -238,9 +232,6 @@ build build/intermediate build/browser build/browser/cohorts data_dictionaries:
 
 build/robot.jar: | build
 	curl -Lk -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/master/lastSuccessfulBuild/artifact/bin/robot.jar
-
-build/robot-tree.jar: | build
-	curl -L -o $@ https://build.obolibrary.io/job/ontodev/job/robot/job/tree-view/lastSuccessfulBuild/artifact/bin/robot.jar
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ numpy
 jsonschema
 openpyxl
 ontodev-cogs==0.3.2
-ontodev-gizmos==0.3.0
+ontodev-gizmos==0.3.1
+urlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy
 jsonschema
 openpyxl
 ontodev-cogs==0.3.2
+ontodev-gizmos==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ numpy
 jsonschema
 openpyxl
 ontodev-cogs==0.3.2
-ontodev-gizmos==0.2.0
+ontodev-gizmos==0.3.0

--- a/src/convert_prefixes.py
+++ b/src/convert_prefixes.py
@@ -1,0 +1,33 @@
+import json
+
+from argparse import ArgumentParser, FileType
+
+
+def main():
+	parser = ArgumentParser()
+	parser.add_argument("json", type=FileType("r"))
+	parser.add_argument("sql", type=FileType("w"))
+	args = parser.parse_args()
+
+	prefixes = json.loads(args.json.read())["@context"]
+
+	sql = """CREATE TABLE IF NOT EXISTS prefix (
+  prefix TEXT PRIMARY KEY,
+  base TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO prefix VALUES
+"""
+
+	lines = []
+	for prefix, namespace in prefixes.items():
+		lines.append(f'("{prefix}", "{namespace}")')
+
+	sql += ",\n".join(lines)
+	sql += ";"
+
+	args.sql.write(sql)
+
+
+if __name__ == '__main__':
+	main()

--- a/src/create_index.py
+++ b/src/create_index.py
@@ -20,7 +20,7 @@ def main():
         item['id'] = short_name
         item['owl'] = '{0}.owl'.format(short_name)
         item['terms'] = '{0}.html'.format(short_name)
-        item['tree'] = '{0}-tree.html'.format(short_name)
+        item['tree'] = '../src/tree.sh?db={0}'.format(short_name)
         items.append(item)
 
     html = t.render(items=items)

--- a/src/generate_cohort_json.py
+++ b/src/generate_cohort_json.py
@@ -23,7 +23,7 @@ def main():
     output_file = args.output
 
     metadata = json.loads(metadata_file.read())
-    gecko = json.loads(args.gecko.read())[1]
+    gecko = json.loads(args.gecko.read())
     gecko_hierarchy = build_hierarchy(gecko)
 
     all_data = []

--- a/src/get_gecko_structure.py
+++ b/src/get_gecko_structure.py
@@ -1,0 +1,59 @@
+import json
+import sqlite3
+
+from argparse import ArgumentParser
+
+
+def get_subclass_array(cur, term_id):
+    children = []
+    cur.execute(
+        "SELECT DISTINCT stanza FROM statements WHERE predicate = 'rdfs:subClassOf' AND object = ?",
+        (term_id,),
+    )
+    for res in cur.fetchall():
+        if res[0] == "GECKO:0000019":
+            # Skip "blood collected from fasting subject"
+            continue
+        next_level = parse_class(cur, res[0])
+        if not next_level:
+            continue
+        children.append(next_level)
+    return children
+
+
+def parse_class(cur, term_id):
+    cur.execute(
+        "SELECT value FROM statements WHERE predicate = 'rdfs:label' AND stanza = ?", (term_id,)
+    )
+    res = cur.fetchone()
+    if res:
+        label = res[0]
+    else:
+        label = term_id
+    children = get_subclass_array(cur, term_id)
+    if children:
+        return {"id": label, "children": get_subclass_array(cur, term_id)}
+    return {"id": label}
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("db")
+    args = parser.parse_args()
+
+    with sqlite3.connect(args.db) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """SELECT stanza FROM statements WHERE stanza NOT IN
+               (SELECT stanza FROM statements WHERE predicate = 'rdfs:subClassOf')
+               AND predicate = 'rdf:type' AND object = 'owl:Class';"""
+        )
+        classes = []
+        for res in cur.fetchall():
+            classes.append(parse_class(cur, res[0]))
+        out = {"id": "http://www.w3.org/2002/07/owl#Thing", "text": "Classes", "children": classes}
+    print(json.dumps(out, indent=4))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prefixes.json
+++ b/src/prefixes.json
@@ -38,6 +38,7 @@
         "obo": "http://purl.obolibrary.org/obo/",
         "oboInOwl": "http://www.geneontology.org/formats/oboInOwl#",
         "owl": "http://www.w3.org/2002/07/owl#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
     }
 }

--- a/src/tree.sh
+++ b/src/tree.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This simple CGI script helps create a tree browser for ONTIE
+
+cd ..
+
+URL="http://example.com?${QUERY_STRING}"
+DB=$(urlp --query --query_field=db "${URL}")
+ID=$(urlp --query --query_field=id "${URL}")
+TEXT=$(urlp --query --query_field=text "${URL}")
+PROJECT=$(urlp --query --query_field=project-name "${URL}")
+BRANCH=$(urlp --query --query_field=branch-name "${URL}")
+
+# Check that the sqlite database exists
+if ! [[ -s build/${DB}.db ]]; then
+	rm build/${DB}.db > /dev/null 2>&1
+	make build/${DB}.db > /dev/null 2>&1
+fi
+
+if [[ ${TEXT} ]]; then
+	echo "Content-Type: application/json"
+	echo ""
+	python3 -m gizmos.search build/${DB}.db "${TEXT}"
+else
+	echo "Content-Type: text/html"
+	echo ""
+
+	if [[ ${ID} ]]; then
+		python3 -m gizmos.tree build/${DB}.db ${ID} -H "?db=${DB}&id={curie}" -s
+	else
+		python3 -m gizmos.tree build/${DB}.db -H "?db=${DB}&id={curie}" -s
+	fi
+
+	echo "<a href=\"/${PROJECT}/branches/${BRANCH}\"><b>Return Home</b></a>"
+fi


### PR DESCRIPTION
Resolves #176 

Replace `robot tree` with `gizmos.tree` and `robot validate` with `gizmos.export` to generate HTML tables.

We're still using the old `robot-tree.jar` to create the GECKO structure for the real browser (`build/gecko_structure.json`). We could replace this with a custom script, but ROBOT is outputting the format that they need for `data/cohort-data.json`.

I had to add `[](./src/tree.sh)` to the DROID header in order for DROID to find the `src/tree.sh` script, otherwise it would say "resource not found" when trying to access the tree browsers from the index page ("View results"). I'm not sure if there's a better way to do this, but this at least doesn't show up on the main DROID page.